### PR TITLE
Add LLM capacity manager

### DIFF
--- a/docs/CAPACITY.md
+++ b/docs/CAPACITY.md
@@ -1,0 +1,109 @@
+# Capacity management
+
+freellmpool can pool several legitimate LLM providers behind one local endpoint. The capacity tools help you see what is usable right now, what is close to quota, and what needs manual setup.
+
+This feature is intentionally read-only. It does not create accounts, does not manage email inboxes, and does not try to bypass provider limits.
+
+## Main commands
+
+```bash
+freellmpool capacity status --target 5
+freellmpool keys status --target 5
+freellmpool keys checklist --target 5
+freellmpool providers health
+```
+
+## Provider capacity
+
+`capacity status` summarizes the local catalog, configured environment variables, daily quota counters and optional key inventory.
+
+Statuses:
+
+- `healthy`: configured and usable according to local state.
+- `low_quota`: usage is above 80 percent of the daily request hint.
+- `exhausted`: usage reached the daily request hint.
+- `invalid_key`: local inventory says the key has expired.
+- `missing`: the provider exists in the catalog but is not configured.
+
+Example:
+
+```text
+LLM capacity: 3/5 healthy providers
+Action recommended: add 2 provider(s).
+```
+
+## Key inventory
+
+The key inventory is optional. It tracks metadata about keys you created manually. By default it is read from:
+
+```text
+~/.config/freellmpool/keys.toml
+```
+
+You can override it with:
+
+```bash
+export FREELLMPOOL_KEYS_PATH=/path/to/keys.toml
+```
+
+Example:
+
+```toml
+[[keys]]
+provider = "groq"
+env_var = "GROQ_API_KEY"
+label = "personal-main"
+created_at = "2026-06-05"
+expires_at = "2026-12-31"
+commercial_allowed = true
+notes = "created manually"
+```
+
+The inventory should not contain raw API key values. Keep real secrets in environment variables, `config.toml`, your shell profile, or a secret manager.
+
+## Manual checklist
+
+`keys checklist --target 5` tells you which providers to configure manually to reach the desired number of healthy providers.
+
+Example:
+
+```text
+Manual key checklist to reach 5 healthy providers:
+  - cerebras: create a key manually, then set CEREBRAS_API_KEY
+  - cloudflare: create a key manually, then set CLOUDFLARE_API_TOKEN
+```
+
+## Provider health
+
+`providers health` sends one tiny request to each configured provider and reports latency or failure.
+
+```bash
+freellmpool providers health
+freellmpool providers health --timeout 10
+freellmpool providers health -p groq,cerebras
+freellmpool providers health -m llama-3.3-70b-versatile
+```
+
+This is different from `capacity status`: health checks touch the network, while capacity status only reads local state.
+
+## Dashboard
+
+When the proxy is running, open:
+
+```text
+http://127.0.0.1:8080/dashboard
+```
+
+The dashboard shows request counters, cache hits, estimated savings, provider usage, capacity status, and measured latency if the process has already made calls or health checks.
+
+## Recommended workflow
+
+1. Run `freellmpool capacity status --target 5`.
+2. Run `freellmpool keys checklist --target 5`.
+3. Add provider keys manually.
+4. Run `freellmpool providers health`.
+5. Start the proxy and watch `/dashboard`.
+
+## Limits
+
+The daily quota hints are local estimates. Providers can change limits or return 429 earlier. The router still reacts to real provider failures at request time.

--- a/docs/CAPACITY.md
+++ b/docs/CAPACITY.md
@@ -73,6 +73,28 @@ Manual key checklist to reach 5 healthy providers:
   - cloudflare: create a key manually, then set CLOUDFLARE_API_TOKEN
 ```
 
+## Adding a provider key
+
+`keys add` first looks for an existing local provider. If the provider is not local, it checks the synced external catalog. Typos and model names are matched with a small Levenshtein search, then the CLI asks before importing the suggested provider.
+
+```bash
+freellmpool keys add Hyperbolic
+freellmpool keys add Hyperbolc
+freellmpool keys add Llama-3.3-70B-Instruct
+```
+
+If no external match is good enough, the CLI can create a minimal OpenAI-compatible provider in the user `providers.toml`. It asks for the API base URL and a default model id. Leave the model blank to autodiscover models from the OpenAI-compatible `GET /models` endpoint; if a key is needed, the CLI uses the key passed with `--value` or asks for one.
+
+Non-interactive example:
+
+```bash
+freellmpool keys add Hyperbolic \
+  --base-url https://api.hyperbolic.xyz/v1 \
+  --model meta-llama/Llama-3.3-70B-Instruct \
+  --value "$HYPERBOLIC_API_KEY" \
+  --yes
+```
+
 ## Provider health
 
 `providers health` sends one tiny request to each configured provider and reports latency or failure.

--- a/docs/CAPACITY.md
+++ b/docs/CAPACITY.md
@@ -106,7 +106,7 @@ freellmpool providers health -p groq,cerebras
 freellmpool providers health -m llama-3.3-70b-versatile
 ```
 
-This is different from `capacity status`: health checks touch the network, while capacity status only reads local state.
+This is different from `capacity status`. `providers health` sends real test requests to each configured provider's API. `capacity status` never calls a provider, but by default it does refresh the advisory external catalog over the network (a read-only metadata fetch); pass `--no-catalog-sync` to keep it fully local.
 
 ## Dashboard
 

--- a/src/freellmpool/benchmark.py
+++ b/src/freellmpool/benchmark.py
@@ -83,7 +83,7 @@ def benchmark(
             return BenchRow(key, False, None, None, str(exc))
         except Exception as exc:  # noqa: BLE001 — report it, don't abort the sweep
             pool.metrics.record_failure(key, f"{type(exc).__name__}: {exc}")
-            return BenchRow(key, False, None, None, f"{type(exc).__name__}")
+            return BenchRow(key, False, None, None, f"{type(exc).__name__}: {exc}")
         elapsed = (time.monotonic() - started) * 1000.0
         if reply.text:
             pool.metrics.record_success(key, elapsed)

--- a/src/freellmpool/capacity.py
+++ b/src/freellmpool/capacity.py
@@ -1,0 +1,163 @@
+"""Capacity reporting for configured free-tier providers.
+
+This module is deliberately read-only: it summarizes catalog/env/quota state so
+users can keep several legitimate providers available without automating signup
+or account creation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+
+from .config import configured_providers, effective_env, load_catalog
+from .key_inventory import KeyRecord, records_by_provider
+from .models import Provider
+from .quota import QuotaStore
+
+
+@dataclass(frozen=True)
+class ProviderCapacity:
+    provider_id: str
+    label: str
+    status: str
+    reason: str
+    key_env: str | None
+    configured: bool
+    keyless: bool
+    enabled_models: int
+    total_models: int
+    used_today: int
+    quota_hint: int
+    inventory_count: int = 0
+    expires_at: str | None = None
+
+    @property
+    def healthy(self) -> bool:
+        return self.status == "healthy"
+
+
+@dataclass(frozen=True)
+class CapacityReport:
+    providers: list[ProviderCapacity]
+    target: int = 5
+
+    @property
+    def healthy_count(self) -> int:
+        return sum(1 for p in self.providers if p.healthy)
+
+    @property
+    def low_quota_count(self) -> int:
+        return sum(1 for p in self.providers if p.status == "low_quota")
+
+    @property
+    def needs_action(self) -> bool:
+        return self.healthy_count < self.target
+
+    def checklist(self) -> list[ProviderCapacity]:
+        missing = [p for p in self.providers if p.status == "missing" and p.key_env]
+        missing.sort(key=lambda p: (p.inventory_count, p.provider_id))
+        return missing[: max(0, self.target - self.healthy_count)]
+
+
+def build_capacity_report(
+    *,
+    target: int = 5,
+    env: dict[str, str] | None = None,
+    quota: QuotaStore | None = None,
+    catalog: list[Provider] | None = None,
+    inventory: list[KeyRecord] | None = None,
+) -> CapacityReport:
+    env = effective_env(env)
+    catalog = catalog or load_catalog()
+    quota = quota or QuotaStore()
+    inventory = inventory or []
+    inv = records_by_provider(inventory)
+    configured_ids = {p.id for p in configured_providers(catalog, env)}
+    snap = quota.snapshot()
+    rows = [
+        _provider_capacity(provider, configured_ids, snap, inv.get(provider.id, []))
+        for provider in catalog
+    ]
+    rows.sort(key=_capacity_sort_key)
+    return CapacityReport(providers=rows, target=target)
+
+
+def _provider_capacity(
+    provider: Provider,
+    configured_ids: set[str],
+    snap: dict[str, int],
+    inventory: list[KeyRecord],
+) -> ProviderCapacity:
+    configured = provider.id in configured_ids
+    enabled_models = sum(1 for m in provider.models if m.enabled)
+    used_today = sum(int(v) for k, v in snap.items() if k.startswith(f"{provider.id}::"))
+    quota_hint = sum(m.rpd for m in provider.models if m.enabled and m.rpd > 0)
+    expires_at = _soonest_expiry(inventory)
+
+    if not configured:
+        status = "missing"
+        if provider.key_env:
+            reason = f"set {provider.key_env}"
+        elif provider.extra_env:
+            reason = "missing extra environment values"
+        else:
+            reason = "not configured"
+    elif quota_hint > 0 and used_today >= quota_hint:
+        status = "exhausted"
+        reason = "daily quota hint reached"
+    elif quota_hint > 0 and used_today >= quota_hint * 0.8:
+        status = "low_quota"
+        reason = "usage is above 80% of daily quota hint"
+    elif expires_at and _is_expired_or_today(expires_at):
+        status = "invalid_key"
+        reason = "inventory expiry date has passed or is today"
+    else:
+        status = "healthy"
+        reason = "configured and usable"
+
+    return ProviderCapacity(
+        provider_id=provider.id,
+        label=provider.label,
+        status=status,
+        reason=reason,
+        key_env=provider.key_env,
+        configured=configured,
+        keyless=provider.keyless,
+        enabled_models=enabled_models,
+        total_models=len(provider.models),
+        used_today=used_today,
+        quota_hint=quota_hint,
+        inventory_count=len(inventory),
+        expires_at=expires_at,
+    )
+
+
+def _capacity_sort_key(row: ProviderCapacity) -> tuple[int, int, int, str]:
+    # Higher local quota hints and more enabled models indicate more useful capacity.
+    generosity = row.quota_hint if row.quota_hint > 0 else 0
+    return (_status_rank(row.status), -generosity, -row.enabled_models, row.provider_id)
+
+
+def _status_rank(status: str) -> int:
+    order = {
+        "healthy": 0,
+        "low_quota": 1,
+        "exhausted": 2,
+        "invalid_key": 3,
+        "missing": 4,
+        "disabled": 5,
+    }
+    return order.get(status, 9)
+
+
+def _soonest_expiry(records: list[KeyRecord]) -> str | None:
+    values = sorted(r.expires_at for r in records if r.expires_at)
+    return values[0] if values else None
+
+
+def _is_expired_or_today(value: str) -> bool:
+    try:
+        return date.fromisoformat(value) <= date.today()
+    except ValueError:
+        return False

--- a/src/freellmpool/catalog.py
+++ b/src/freellmpool/catalog.py
@@ -1,0 +1,274 @@
+"""Advisory external provider catalog sync.
+
+This imports metadata from mnfst/awesome-free-llm-apis into a local cache. It is
+advisory only: the executable provider configuration remains providers.toml.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_SOURCE_URL = "https://raw.githubusercontent.com/mnfst/awesome-free-llm-apis/main/data.json"
+
+
+def default_external_catalog_path() -> Path:
+    override = os.environ.get("FREELLMPOOL_EXTERNAL_CATALOG_PATH")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".config" / "freellmpool" / "provider_catalog.json"
+
+
+@dataclass(frozen=True)
+class ExternalProvider:
+    name: str
+    slug: str
+    category: str | None
+    url: str | None
+    base_url: str | None
+    description: str
+    model_count: int
+    best_rpd: int
+    best_rpm: int
+    best_tpd: int
+    generous_score: int
+
+
+def sync_external_catalog(
+    *,
+    source_url: str = DEFAULT_SOURCE_URL,
+    path: Path | None = None,
+    timeout: float = 20.0,
+) -> tuple[Path, list[ExternalProvider]]:
+    path = path or default_external_catalog_path()
+    with urllib.request.urlopen(source_url, timeout=timeout) as response:
+        raw = response.read().decode("utf-8")
+    data = json.loads(raw)
+    providers = parse_external_catalog(data)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    return path, providers
+
+
+def load_external_catalog(path: Path | None = None) -> list[ExternalProvider]:
+    path = path or default_external_catalog_path()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return []
+    return parse_external_catalog(data)
+
+
+def parse_external_catalog(data: Any) -> list[ExternalProvider]:
+    rows = data.get("providers", []) if isinstance(data, dict) else []
+    providers = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("name") or "").strip()
+        if not name:
+            continue
+        models = row.get("models") if isinstance(row.get("models"), list) else []
+        best_rpd = 0
+        best_rpm = 0
+        best_tpd = 0
+        for model in models:
+            if not isinstance(model, dict):
+                continue
+            limit = str(model.get("rateLimit") or "")
+            best_rpd = max(best_rpd, _extract_limit(limit, "RPD"))
+            best_rpm = max(best_rpm, _extract_limit(limit, "RPM"))
+            best_tpd = max(best_tpd, _extract_limit(limit, "TPD"))
+        score = best_tpd or best_rpd or best_rpm or 0
+        providers.append(
+            ExternalProvider(
+                name=name,
+                slug=_slug(name),
+                category=_optional(row.get("category")),
+                url=_optional(row.get("url")),
+                base_url=_optional(row.get("baseUrl")),
+                description=str(row.get("description") or ""),
+                model_count=len(models),
+                best_rpd=best_rpd,
+                best_rpm=best_rpm,
+                best_tpd=best_tpd,
+                generous_score=score,
+            )
+        )
+    providers.sort(key=lambda p: (-p.generous_score, p.slug))
+    return providers
+
+
+def _optional(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def _extract_model_rpd(text: str) -> int:
+    pattern = re.compile(r"([0-9][0-9,.]*\s*[kKmMbB]?)\s*RPD")
+    values = [_parse_number(match.group(1)) for match in pattern.finditer(text)]
+    values = [value for value in values if value > 0]
+    if not values:
+        return 0
+    return min(values)
+
+
+def _extract_limit(text: str, unit: str) -> int:
+    pattern = re.compile(r"([0-9][0-9,.]*\s*[kKmMbB]?)\s*" + re.escape(unit))
+    values = [_parse_number(match.group(1)) for match in pattern.finditer(text)]
+    return max(values) if values else 0
+
+
+def _parse_number(value: str) -> int:
+    text = value.strip().replace(",", "")
+    multiplier = 1
+    if text[-1:].lower() == "k":
+        multiplier = 1_000
+        text = text[:-1]
+    elif text[-1:].lower() == "m":
+        multiplier = 1_000_000
+        text = text[:-1]
+    elif text[-1:].lower() == "b":
+        multiplier = 1_000_000_000
+        text = text[:-1]
+    try:
+        return int(float(text.strip()) * multiplier)
+    except ValueError:
+        return 0
+
+
+def match_local_provider(external: ExternalProvider, local_providers) -> str | None:
+    """Return the local provider id matching an external catalog row, if any."""
+    external_base = (external.base_url or "").rstrip("/").lower()
+    for provider in local_providers:
+        if provider.base_url.rstrip("/").lower() == external_base and external_base:
+            return provider.id
+    external_slug = external.slug
+    for provider in local_providers:
+        if _slug(provider.id) == external_slug or _slug(provider.label) == external_slug:
+            return provider.id
+    aliases = {
+        "google-gemini": "gemini",
+        "github-models": "github",
+        "z-ai-zhipu-glm": "zhipu",
+        "llm7-io": "llm7",
+        "openrouter": "openrouter",
+        "nvidia-nim": "nvidia",
+        "groq": "groq",
+        "cerebras": "cerebras",
+        "cohere": "cohere",
+        "mistral-ai": "mistral",
+        "sambanova": "sambanova",
+        "cloudflare-workers-ai": "cloudflare",
+        "ollama-cloud": "ollama",
+    }
+    wanted = aliases.get(external_slug)
+    if wanted and any(provider.id == wanted for provider in local_providers):
+        return wanted
+    return None
+
+
+def import_external_provider_to_user_catalog(query: str) -> str:
+    """Create a user providers.toml stub from an external-only catalog provider.
+
+    Returns the local provider id that was written. This is intentionally a
+    user-catalog append, not a change to the packaged providers.toml.
+    """
+    data_path = default_external_catalog_path()
+    try:
+        raw = json.loads(data_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        raise ValueError("external catalog cache is missing; run capacity status first") from None
+    needle = _external_lookup_slug(query)
+    rows = raw.get("providers", []) if isinstance(raw, dict) else []
+    match = None
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("name") or "")
+        if _external_lookup_slug(name) == needle:
+            match = row
+            break
+    if match is None:
+        available = ", ".join(str(row.get("name")) for row in rows[:8] if isinstance(row, dict))
+        raise ValueError(f"provider not found in external catalog: {query}. Try one of: {available}")
+    base_url = str(match.get("baseUrl") or "").strip()
+    if not base_url:
+        raise ValueError(f"external provider has no baseUrl: {query}")
+    provider_id = _slug(str(match.get("name") or query)).replace("-", "_")
+    key_env = provider_id.upper() + "_API_KEY"
+    models = []
+    for model in match.get("models", []):
+        if not isinstance(model, dict):
+            continue
+        model_id = model.get("id") or model.get("name")
+        if not model_id:
+            continue
+        model_id = str(model_id).strip()
+        if not model_id or model_id.startswith("+"):
+            continue
+        modality = str(model.get("modality") or "").lower()
+        if "image" in modality and "text" not in modality:
+            continue
+        limit = str(model.get("rateLimit") or "")
+        rpd = _extract_model_rpd(limit)
+        models.append((model_id, rpd))
+    if not models:
+        raise ValueError(f"external provider has no usable text models: {query}")
+    path = _user_provider_catalog_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    if f'id = "{provider_id}"' not in existing:
+        with path.open("a", encoding="utf-8") as fh:
+            if existing and not existing.endswith("\n"):
+                fh.write("\n")
+            fh.write("\n[[provider]]\n")
+            fh.write(f'id = "{provider_id}"\n')
+            fh.write(f'label = "{_toml_escape(str(match.get("name") or query))}"\n')
+            fh.write('adapter = "openai"\n')
+            fh.write(f'base_url = "{_toml_escape(base_url)}"\n')
+            fh.write(f'key_env = "{key_env}"\n')
+            fh.write("models = [\n")
+            for model_id, rpd in models:
+                fh.write(f'    {{ name = "{_toml_escape(model_id)}", rpd = {rpd} }},\n')
+            fh.write("]\n")
+    return provider_id
+
+
+def _external_lookup_slug(value: str) -> str:
+    slug = _slug(value)
+    aliases = {
+        "ai21": "ai21-labs",
+        "ai21labs": "ai21-labs",
+        "model-scope": "modelscope",
+        "modelscope": "modelscope",
+        "silicon-flow": "siliconflow",
+        "google": "google-gemini",
+        "gemini": "google-gemini",
+        "github": "github-models",
+        "hf": "hugging-face",
+        "huggingface": "hugging-face",
+    }
+    return aliases.get(slug, slug)
+
+
+def _user_provider_catalog_path() -> Path:
+    override = os.environ.get("FREELLMPOOL_CONFIG")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".config" / "freellmpool" / "providers.toml"
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')

--- a/src/freellmpool/catalog.py
+++ b/src/freellmpool/catalog.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .toml_utils import toml_escape
+
 DEFAULT_SOURCE_URL = "https://raw.githubusercontent.com/mnfst/awesome-free-llm-apis/main/data.json"
 
 
@@ -152,7 +154,8 @@ def match_local_provider(external: ExternalProvider, local_providers) -> str | N
     """Return the local provider id matching an external catalog row, if any."""
     external_base = (external.base_url or "").rstrip("/").lower()
     for provider in local_providers:
-        if provider.base_url.rstrip("/").lower() == external_base and external_base:
+        local_base = (provider.base_url or "").rstrip("/").lower()
+        if local_base == external_base and external_base:
             return provider.id
     external_slug = external.slug
     for provider in local_providers:
@@ -189,7 +192,10 @@ def import_external_provider_to_user_catalog(query: str) -> str:
     try:
         raw = json.loads(data_path.read_text(encoding="utf-8"))
     except (FileNotFoundError, OSError, json.JSONDecodeError):
-        raise ValueError("external catalog cache is missing; run capacity status first") from None
+        raise ValueError(
+            "external catalog cache is missing; run freellmpool catalog sync or "
+            "freellmpool capacity status first"
+        ) from None
     needle = _external_lookup_slug(query)
     rows = raw.get("providers", []) if isinstance(raw, dict) else []
     match = None
@@ -235,13 +241,13 @@ def import_external_provider_to_user_catalog(query: str) -> str:
                 fh.write("\n")
             fh.write("\n[[provider]]\n")
             fh.write(f'id = "{provider_id}"\n')
-            fh.write(f'label = "{_toml_escape(str(match.get("name") or query))}"\n')
+            fh.write(f'label = "{toml_escape(str(match.get("name") or query))}"\n')
             fh.write('adapter = "openai"\n')
-            fh.write(f'base_url = "{_toml_escape(base_url)}"\n')
+            fh.write(f'base_url = "{toml_escape(base_url)}"\n')
             fh.write(f'key_env = "{key_env}"\n')
             fh.write("models = [\n")
             for model_id, rpd in models:
-                fh.write(f'    {{ name = "{_toml_escape(model_id)}", rpd = {rpd} }},\n')
+                fh.write(f'    {{ name = "{toml_escape(model_id)}", rpd = {rpd} }},\n')
             fh.write("]\n")
     return provider_id
 
@@ -264,11 +270,8 @@ def _external_lookup_slug(value: str) -> str:
 
 
 def _user_provider_catalog_path() -> Path:
+    """Return the providers.toml path used for user provider definitions."""
     override = os.environ.get("FREELLMPOOL_CONFIG")
     if override:
         return Path(override).expanduser()
     return Path.home() / ".config" / "freellmpool" / "providers.toml"
-
-
-def _toml_escape(value: str) -> str:
-    return value.replace("\\", "\\\\").replace('"', '\\"')

--- a/src/freellmpool/catalog.py
+++ b/src/freellmpool/catalog.py
@@ -18,6 +18,32 @@ from .toml_utils import toml_escape
 
 DEFAULT_SOURCE_URL = "https://raw.githubusercontent.com/mnfst/awesome-free-llm-apis/main/data.json"
 
+# Cap network reads so a huge/hostile body can't exhaust memory.
+_MAX_CATALOG_BYTES = 8 * 1024 * 1024
+_MAX_DISCOVER_BYTES = 4 * 1024 * 1024
+
+
+def _validated_base_url(raw: str, *, https_only: bool, what: str, strip: bool = False) -> str:
+    """Validate a base URL before it becomes (or is queried as) a routing target.
+
+    Rejects empty values, embedded whitespace/control characters, and disallowed
+    schemes. ``strip=True`` trims surrounding whitespace first (friendly for
+    user-typed input); ``strip=False`` validates the raw value (untrusted catalog
+    data, so leading/trailing junk is rejected rather than silently normalized).
+    """
+    url = (raw or "").strip() if strip else (raw or "")
+    if not url.strip():
+        raise ValueError(f"{what} requires a base URL")
+    schemes = ("https://",) if https_only else ("http://", "https://")
+    if not url.lower().startswith(schemes) or any(
+        c.isspace() or ord(c) < 0x20 or ord(c) == 0x7F for c in url
+    ):
+        need = "https" if https_only else "http(s)"
+        raise ValueError(
+            f"{what} has an unsupported base URL (need {need}, no whitespace/control chars)"
+        )
+    return url
+
 
 def default_external_catalog_path() -> Path:
     override = os.environ.get("FREELLMPOOL_EXTERNAL_CATALOG_PATH")
@@ -57,9 +83,12 @@ def sync_external_catalog(
     timeout: float = 20.0,
 ) -> tuple[Path, list[ExternalProvider]]:
     path = path or default_external_catalog_path()
+    # source_url is the fixed https default (or a caller-provided override).
     with urllib.request.urlopen(source_url, timeout=timeout) as response:
-        raw = response.read().decode("utf-8")
-    data = json.loads(raw)
+        raw_bytes = response.read(_MAX_CATALOG_BYTES + 1)
+    if len(raw_bytes) > _MAX_CATALOG_BYTES:
+        raise ValueError(f"external catalog exceeds {_MAX_CATALOG_BYTES} bytes; refusing to load")
+    data = json.loads(raw_bytes.decode("utf-8"))
     providers = parse_external_catalog(data)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
@@ -196,7 +225,9 @@ def match_local_provider(external: ExternalProvider, local_providers) -> str | N
     return None
 
 
-def suggest_external_provider(query: str, providers: list[ExternalProvider]) -> ExternalProviderMatch | None:
+def suggest_external_provider(
+    query: str, providers: list[ExternalProvider]
+) -> ExternalProviderMatch | None:
     """Return the best external provider match from provider names or model ids."""
     needle = _external_lookup_slug(query)
     if not needle:
@@ -219,7 +250,9 @@ def suggest_external_provider(query: str, providers: list[ExternalProvider]) -> 
         if exact:
             distance = 0
         if best is None or distance < best.distance:
-            best = ExternalProviderMatch(provider=provider, matched=value, distance=distance, exact=exact)
+            best = ExternalProviderMatch(
+                provider=provider, matched=value, distance=distance, exact=exact
+            )
 
     if best is None:
         return None
@@ -245,10 +278,14 @@ def import_external_provider_to_user_catalog(query: str) -> str:
     if match is None:
         rows = raw.get("providers", []) if isinstance(raw, dict) else []
         available = ", ".join(str(row.get("name")) for row in rows[:8] if isinstance(row, dict))
-        raise ValueError(f"provider not found in external catalog: {query}. Try one of: {available}")
-    base_url = str(match.get("baseUrl") or "").strip()
-    if not base_url:
-        raise ValueError(f"external provider has no baseUrl: {query}")
+        raise ValueError(
+            f"provider not found in external catalog: {query}. Try one of: {available}"
+        )
+    # Third-party catalog data; the imported provider becomes an executable
+    # routing target once its key is set, so validate the RAW value strictly.
+    base_url = _validated_base_url(
+        str(match.get("baseUrl") or ""), https_only=True, what=f"external provider {query}"
+    )
     provider_id = _slug(str(match.get("name") or query)).replace("-", "_")
     key_env = provider_id.upper() + "_API_KEY"
     models = []
@@ -300,9 +337,9 @@ def create_user_provider_stub(
     provider_id = _slug(name).replace("-", "_")
     if not provider_id:
         raise ValueError("provider name is required")
-    base_url = base_url.strip().rstrip("/")
-    if not base_url:
-        raise ValueError("base_url is required")
+    base_url = _validated_base_url(base_url, https_only=False, what="provider", strip=True).rstrip(
+        "/"
+    )
     model = model.strip()
     if not model:
         raise ValueError("model is required")
@@ -334,15 +371,23 @@ def discover_openai_models(
     timeout: float = 10.0,
 ) -> list[str]:
     """Discover model ids from an OpenAI-compatible /models endpoint."""
-    url = base_url.strip().rstrip("/") + "/models"
+    # base_url is user-supplied; only fetch http(s) (never file://, etc.).
+    url = (
+        _validated_base_url(base_url, https_only=False, what="model discovery", strip=True).rstrip(
+            "/"
+        )
+        + "/models"
+    )
     headers = {"Accept": "application/json"}
     if api_key:
         headers["Authorization"] = f"Bearer {api_key}"
     request = urllib.request.Request(url, headers=headers)
     try:
         with urllib.request.urlopen(request, timeout=timeout) as response:
-            raw = response.read().decode("utf-8")
-        data = json.loads(raw)
+            raw_bytes = response.read(_MAX_DISCOVER_BYTES + 1)
+        if len(raw_bytes) > _MAX_DISCOVER_BYTES:
+            raise ValueError(f"model discovery response exceeds {_MAX_DISCOVER_BYTES} bytes")
+        data = json.loads(raw_bytes.decode("utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise ValueError(f"model discovery failed: {exc}") from None
     rows = data.get("data", []) if isinstance(data, dict) else []

--- a/src/freellmpool/catalog.py
+++ b/src/freellmpool/catalog.py
@@ -39,6 +39,15 @@ class ExternalProvider:
     best_rpm: int
     best_tpd: int
     generous_score: int
+    search_terms: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ExternalProviderMatch:
+    provider: ExternalProvider
+    matched: str
+    distance: int
+    exact: bool
 
 
 def sync_external_catalog(
@@ -100,6 +109,11 @@ def parse_external_catalog(data: Any) -> list[ExternalProvider]:
                 best_rpm=best_rpm,
                 best_tpd=best_tpd,
                 generous_score=score,
+                search_terms=tuple(
+                    str(model.get("id") or model.get("name") or "").strip()
+                    for model in models
+                    if isinstance(model, dict) and (model.get("id") or model.get("name"))
+                ),
             )
         )
     providers.sort(key=lambda p: (-p.generous_score, p.slug))
@@ -182,6 +196,37 @@ def match_local_provider(external: ExternalProvider, local_providers) -> str | N
     return None
 
 
+def suggest_external_provider(query: str, providers: list[ExternalProvider]) -> ExternalProviderMatch | None:
+    """Return the best external provider match from provider names or model ids."""
+    needle = _external_lookup_slug(query)
+    if not needle:
+        return None
+
+    candidates: list[tuple[ExternalProvider, str]] = []
+    for provider in providers:
+        candidates.append((provider, provider.name))
+        candidates.append((provider, provider.slug))
+        for model in provider.search_terms:
+            candidates.append((provider, model))
+
+    best: ExternalProviderMatch | None = None
+    for provider, value in candidates:
+        candidate = _external_lookup_slug(value)
+        if not candidate:
+            continue
+        distance = _levenshtein(needle, candidate)
+        exact = distance == 0 or needle in candidate or candidate in needle
+        if exact:
+            distance = 0
+        if best is None or distance < best.distance:
+            best = ExternalProviderMatch(provider=provider, matched=value, distance=distance, exact=exact)
+
+    if best is None:
+        return None
+    max_distance = max(2, len(needle) // 4)
+    return best if best.exact or best.distance <= max_distance else None
+
+
 def import_external_provider_to_user_catalog(query: str) -> str:
     """Create a user providers.toml stub from an external-only catalog provider.
 
@@ -196,17 +241,9 @@ def import_external_provider_to_user_catalog(query: str) -> str:
             "external catalog cache is missing; run freellmpool catalog sync or "
             "freellmpool capacity status first"
         ) from None
-    needle = _external_lookup_slug(query)
-    rows = raw.get("providers", []) if isinstance(raw, dict) else []
-    match = None
-    for row in rows:
-        if not isinstance(row, dict):
-            continue
-        name = str(row.get("name") or "")
-        if _external_lookup_slug(name) == needle:
-            match = row
-            break
+    match = _find_external_provider_row(raw, query)
     if match is None:
+        rows = raw.get("providers", []) if isinstance(raw, dict) else []
         available = ", ".join(str(row.get("name")) for row in rows[:8] if isinstance(row, dict))
         raise ValueError(f"provider not found in external catalog: {query}. Try one of: {available}")
     base_url = str(match.get("baseUrl") or "").strip()
@@ -252,6 +289,71 @@ def import_external_provider_to_user_catalog(query: str) -> str:
     return provider_id
 
 
+def create_user_provider_stub(
+    *,
+    name: str,
+    base_url: str,
+    model: str,
+    key_env: str | None = None,
+) -> str:
+    """Append a minimal OpenAI-compatible provider to the user providers.toml."""
+    provider_id = _slug(name).replace("-", "_")
+    if not provider_id:
+        raise ValueError("provider name is required")
+    base_url = base_url.strip().rstrip("/")
+    if not base_url:
+        raise ValueError("base_url is required")
+    model = model.strip()
+    if not model:
+        raise ValueError("model is required")
+    key_env = key_env or provider_id.upper() + "_API_KEY"
+
+    path = _user_provider_catalog_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    if f'id = "{provider_id}"' not in existing:
+        with path.open("a", encoding="utf-8") as fh:
+            if existing and not existing.endswith("\n"):
+                fh.write("\n")
+            fh.write("\n[[provider]]\n")
+            fh.write(f'id = "{provider_id}"\n')
+            fh.write(f'label = "{toml_escape(name)}"\n')
+            fh.write('adapter = "openai"\n')
+            fh.write(f'base_url = "{toml_escape(base_url)}"\n')
+            fh.write(f'key_env = "{toml_escape(key_env)}"\n')
+            fh.write("models = [\n")
+            fh.write(f'    {{ name = "{toml_escape(model)}" }},\n')
+            fh.write("]\n")
+    return provider_id
+
+
+def discover_openai_models(
+    base_url: str,
+    *,
+    api_key: str | None = None,
+    timeout: float = 10.0,
+) -> list[str]:
+    """Discover model ids from an OpenAI-compatible /models endpoint."""
+    url = base_url.strip().rstrip("/") + "/models"
+    headers = {"Accept": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    request = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+        data = json.loads(raw)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"model discovery failed: {exc}") from None
+    rows = data.get("data", []) if isinstance(data, dict) else []
+    models = []
+    for row in rows:
+        model_id = row.get("id") if isinstance(row, dict) else None
+        if model_id:
+            models.append(str(model_id))
+    return models
+
+
 def _external_lookup_slug(value: str) -> str:
     slug = _slug(value)
     aliases = {
@@ -267,6 +369,41 @@ def _external_lookup_slug(value: str) -> str:
         "huggingface": "hugging-face",
     }
     return aliases.get(slug, slug)
+
+
+def _find_external_provider_row(data: Any, query: str) -> dict | None:
+    needle = _external_lookup_slug(query)
+    rows = data.get("providers", []) if isinstance(data, dict) else []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("name") or "")
+        if _external_lookup_slug(name) == needle:
+            return row
+    return None
+
+
+def _levenshtein(left: str, right: str) -> int:
+    if left == right:
+        return 0
+    if not left:
+        return len(right)
+    if not right:
+        return len(left)
+    previous = list(range(len(right) + 1))
+    for i, char_left in enumerate(left, start=1):
+        current = [i]
+        for j, char_right in enumerate(right, start=1):
+            cost = 0 if char_left == char_right else 1
+            current.append(
+                min(
+                    current[j - 1] + 1,
+                    previous[j] + 1,
+                    previous[j - 1] + cost,
+                )
+            )
+        previous = current
+    return previous[-1]
 
 
 def _user_provider_catalog_path() -> Path:

--- a/src/freellmpool/cli.py
+++ b/src/freellmpool/cli.py
@@ -110,6 +110,21 @@ def cmd_providers(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_providers_health(args: argparse.Namespace) -> int:
+    from .healthcheck import render_health_table, run_healthcheck
+
+    pool = Pool.from_default_config()
+    provider_filter = args.providers.split(",") if args.providers else None
+    rows = run_healthcheck(
+        pool,
+        model=args.model,
+        providers=provider_filter,
+        timeout=args.timeout,
+    )
+    print(render_health_table(rows))
+    return 0
+
+
 def cmd_models(args: argparse.Namespace) -> int:
     catalog = load_catalog()
     configured = {p.id for p in configured_providers(catalog)}
@@ -176,6 +191,220 @@ def cmd_quota(args: argparse.Namespace) -> int:
     print("Today's usage (UTC):")
     for key, count in sorted(snap.items(), key=lambda kv: -kv[1]):
         print(f"  {count:>6}  {key}")
+    return 0
+
+
+def _format_capacity_row(row) -> str:
+    quota = "?" if row.quota_hint <= 0 else str(row.quota_hint)
+    key = "keyless" if row.keyless else (row.key_env or "-")
+    expiry = f" expires={row.expires_at}" if row.expires_at else ""
+    return (
+        f"  {row.status:<11} {row.provider_id:<13} {row.label:<28} "
+        f"used={row.used_today}/{quota:<5} models={row.enabled_models:<3} "
+        f"key={key}{expiry}  {row.reason}"
+    )
+
+
+def cmd_keys_status(args: argparse.Namespace) -> int:
+    from .capacity import build_capacity_report
+    from .key_inventory import default_inventory_path, load_inventory
+
+    inventory_path = default_inventory_path()
+    inventory = load_inventory(inventory_path)
+    report = build_capacity_report(target=args.target, inventory=inventory)
+    print(f"Key inventory: {inventory_path}")
+    print(f"Records: {len(inventory)}")
+    print(f"Healthy providers: {report.healthy_count}/{args.target}\n")
+    for row in report.providers:
+        if args.all or row.status != "missing":
+            print(_format_capacity_row(row))
+    return 0
+
+
+def cmd_keys_checklist(args: argparse.Namespace) -> int:
+    from .capacity import build_capacity_report
+    from .key_inventory import load_inventory
+
+    report = build_capacity_report(target=args.target, inventory=load_inventory())
+    todo = report.checklist()
+    if not todo:
+        print(f"Enough healthy providers: {report.healthy_count}/{args.target}.")
+        return 0
+    print(f"Manual key checklist to reach {args.target} healthy providers:")
+    for row in todo:
+        print(f"  - {row.provider_id}: create a key manually, then set {row.key_env}")
+    return 0
+
+
+def _choose_provider(catalog, provider_id: str | None):
+    providers = [p for p in catalog if p.key_env]
+    if provider_id:
+        needle = provider_id.lower()
+        matches = [p for p in providers if p.id.lower() == needle or p.label.lower() == needle]
+        if not matches:
+            raise SystemExit(f"provider is not configured in local providers.toml, or is keyless/external-only: {provider_id}")
+        return matches[0]
+
+    print("Choose a provider to configure:")
+    for i, provider in enumerate(providers, start=1):
+        print(f"  {i}. {provider.id} ({provider.key_env})")
+
+    while True:
+        raw = input("Provider number or id: ").strip()
+        if raw.isdigit():
+            idx = int(raw)
+            if 1 <= idx <= len(providers):
+                return providers[idx - 1]
+
+        for provider in providers:
+            if provider.id == raw:
+                return provider
+
+        print("Invalid provider, try again.")
+
+
+def cmd_keys_add(args: argparse.Namespace) -> int:
+    import getpass
+    from datetime import date
+
+    from .config import load_catalog
+    from .key_inventory import (
+        KeyRecord,
+        append_inventory_record,
+        default_config_path,
+        upsert_config_key,
+    )
+
+    if getattr(args, "provider_arg", None) and not args.provider:
+        args.provider = args.provider_arg
+    try:
+        catalog = load_catalog()
+    except FileNotFoundError:
+        catalog = []
+    try:
+        provider = _choose_provider(catalog, args.provider)
+    except SystemExit:
+        if not args.provider:
+            raise
+        from .catalog import import_external_provider_to_user_catalog
+
+        try:
+            local_id = import_external_provider_to_user_catalog(args.provider)
+        except ValueError as exc:
+            print(f"Could not import provider: {exc}", file=sys.stderr)
+            return 3
+        print(f"Imported external provider '{args.provider}' as local provider '{local_id}'.")
+        provider = _choose_provider(load_catalog(), local_id)
+
+    value = getattr(args, "value", None)
+    if not value:
+        value = getpass.getpass(f"Paste {provider.key_env}: ").strip()
+
+    if not value:
+        print("No value provided.", file=sys.stderr)
+        return 3
+
+    if not args.yes:
+        answer = input(f"Write {provider.key_env} to {default_config_path()}? [y/N] ")
+        if answer.strip().lower() not in {"y", "yes"}:
+            print("Cancelled.")
+            return 1
+
+    config_path = upsert_config_key(provider.key_env, value)
+
+    inventory_path = append_inventory_record(
+        KeyRecord(
+            provider=provider.id,
+            env_var=provider.key_env,
+            label=args.label or "manual",
+            created_at=date.today().isoformat(),
+            commercial_allowed=args.commercial_allowed,
+            notes=args.notes or "added with freellmpool keys add",
+        )
+    )
+
+    print(f"Added {provider.id} key metadata.")
+    print(f"Config: {config_path}")
+    print(f"Inventory: {inventory_path}")
+    print("Next command:")
+    print("  python3 -m freellmpool providers health -p " + provider.id)
+    return 0
+
+
+def cmd_capacity_status(args: argparse.Namespace) -> int:
+    from .capacity import build_capacity_report
+    from .catalog import load_external_catalog, match_local_provider, sync_external_catalog
+    from .key_inventory import load_inventory
+
+    external = []
+    cache_note = None
+    if not args.no_catalog_sync:
+        try:
+            path, external = sync_external_catalog(timeout=args.catalog_timeout)
+            cache_note = f"External catalog synced: {len(external)} providers ({path})"
+        except Exception as exc:  # noqa: BLE001 - capacity must still work offline
+            external = load_external_catalog()
+            cache_note = f"External catalog sync failed ({type(exc).__name__}); using cache with {len(external)} providers"
+    else:
+        external = load_external_catalog()
+        cache_note = f"External catalog cache: {len(external)} providers"
+
+    local_catalog = load_catalog()
+    linked = {match_local_provider(item, local_catalog) for item in external}
+    linked.discard(None)
+    external_only = [item for item in external if match_local_provider(item, local_catalog) is None]
+
+    report = build_capacity_report(target=args.target, inventory=load_inventory(), catalog=local_catalog)
+    print(f"LLM capacity: {report.healthy_count}/{args.target} healthy providers")
+    print(cache_note)
+    if external:
+        print(f"Catalog links: {len(linked)} linked locally, {len(external_only)} external-only")
+    if report.low_quota_count:
+        print(f"Warning: {report.low_quota_count} provider(s) are near quota.")
+    if report.needs_action:
+        print(f"Action recommended: add {args.target - report.healthy_count} provider(s).")
+    print()
+    for row in report.providers:
+        if args.all or row.status in {"healthy", "low_quota", "exhausted", "invalid_key"}:
+            print(_format_capacity_row(row))
+    if args.all and external_only:
+        print()
+        print("External-only catalog candidates, not in local providers.toml:")
+        for item in external_only[: args.external_limit]:
+            score = item.best_tpd or item.best_rpd or item.best_rpm
+            print(f"  external    {item.name:<24} score={score:<8} models={item.model_count:<3} link={item.url or '-'}")
+    return 0
+
+
+def cmd_catalog_sync(args: argparse.Namespace) -> int:
+    from .catalog import sync_external_catalog
+
+    path, providers = sync_external_catalog(timeout=args.timeout)
+    print(f"Synced {len(providers)} external providers.")
+    print(f"Cache: {path}")
+    top = providers[:5]
+    if top:
+        print("Most generous external entries:")
+        for provider in top:
+            score = provider.best_tpd or provider.best_rpd or provider.best_rpm
+            print(f"  {provider.name}: score={score} models={provider.model_count}")
+    return 0
+
+
+def cmd_catalog_status(args: argparse.Namespace) -> int:
+    from .catalog import default_external_catalog_path, load_external_catalog
+
+    path = default_external_catalog_path()
+    providers = load_external_catalog(path)
+    if not providers:
+        print(f"No external catalog cache found at {path}.")
+        print("Run: freellmpool catalog sync")
+        return 1
+    print(f"External catalog: {len(providers)} providers")
+    print(f"Cache: {path}")
+    for provider in providers[: args.limit]:
+        score = provider.best_tpd or provider.best_rpd or provider.best_rpm
+        print(f"  {provider.name:<28} score={score:<8} models={provider.model_count:<3} base={provider.base_url or '-'}")
     return 0
 
 
@@ -287,6 +516,12 @@ def build_parser() -> argparse.ArgumentParser:
     p_ask.set_defaults(func=cmd_ask)
 
     p_prov = sub.add_parser("providers", help="list providers and configuration status")
+    prov_sub = p_prov.add_subparsers(dest="providers_command")
+    p_prov_health = prov_sub.add_parser("health", help="test configured providers with a tiny request")
+    p_prov_health.add_argument("-m", "--model", help="pin one model name to test on every provider")
+    p_prov_health.add_argument("-p", "--providers", help="comma-separated provider ids to test")
+    p_prov_health.add_argument("--timeout", type=float, default=20.0, help="per-call timeout seconds")
+    p_prov_health.set_defaults(func=cmd_providers_health)
     p_prov.set_defaults(func=cmd_providers)
 
     p_models = sub.add_parser("models", help="list every available provider/model id")
@@ -301,6 +536,44 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_quota = sub.add_parser("quota", help="show today's per-provider usage")
     p_quota.set_defaults(func=cmd_quota)
+
+    p_keys = sub.add_parser("keys", help="inspect manually configured provider keys")
+    keys_sub = p_keys.add_subparsers(dest="keys_command", required=True)
+    p_keys_status = keys_sub.add_parser("status", help="show key inventory and provider readiness")
+    p_keys_status.add_argument("--target", type=int, default=5, help="desired healthy provider count")
+    p_keys_status.add_argument("--all", action="store_true", help="include missing providers")
+    p_keys_status.set_defaults(func=cmd_keys_status)
+    p_keys_checklist = keys_sub.add_parser("checklist", help="manual actions to reach target capacity")
+    p_keys_checklist.add_argument("--target", type=int, default=5, help="desired healthy provider count")
+    p_keys_checklist.set_defaults(func=cmd_keys_checklist)
+    p_keys_add = keys_sub.add_parser("add")
+    p_keys_add.add_argument("provider_arg", nargs="?", help="provider id or external provider name")
+    p_keys_add.add_argument("-p", "--provider")
+    p_keys_add.add_argument("--value")
+    p_keys_add.add_argument("--label")
+    p_keys_add.add_argument("--notes")
+    p_keys_add.add_argument("--commercial-allowed", action="store_true")
+    p_keys_add.add_argument("-y", "--yes", action="store_true")
+    p_keys_add.set_defaults(func=cmd_keys_add)
+
+    p_catalog = sub.add_parser("catalog", help="sync and inspect advisory external provider metadata")
+    catalog_sub = p_catalog.add_subparsers(dest="catalog_command", required=True)
+    p_catalog_sync = catalog_sub.add_parser("sync", help="sync mnfst/awesome-free-llm-apis metadata into a local cache")
+    p_catalog_sync.add_argument("--timeout", type=float, default=20.0, help="download timeout seconds")
+    p_catalog_sync.set_defaults(func=cmd_catalog_sync)
+    p_catalog_status = catalog_sub.add_parser("status", help="show cached external provider metadata")
+    p_catalog_status.add_argument("--limit", type=int, default=10, help="number of providers to show")
+    p_catalog_status.set_defaults(func=cmd_catalog_status)
+
+    p_capacity = sub.add_parser("capacity", help="summarize legitimate LLM capacity")
+    capacity_sub = p_capacity.add_subparsers(dest="capacity_command", required=True)
+    p_capacity_status = capacity_sub.add_parser("status", help="show provider capacity and quota hints")
+    p_capacity_status.add_argument("--target", type=int, default=5, help="desired healthy provider count")
+    p_capacity_status.add_argument("--all", action="store_true", help="include missing providers")
+    p_capacity_status.add_argument("--no-catalog-sync", action="store_true", help="use external catalog cache without refreshing")
+    p_capacity_status.add_argument("--catalog-timeout", type=float, default=8.0, help="external catalog sync timeout seconds")
+    p_capacity_status.add_argument("--external-limit", type=int, default=8, help="external-only candidates to show with --all")
+    p_capacity_status.set_defaults(func=cmd_capacity_status)
 
     p_bench = sub.add_parser(
         "benchmark", help="time each configured provider and report latency / success"

--- a/src/freellmpool/cli.py
+++ b/src/freellmpool/cli.py
@@ -263,6 +263,103 @@ def _choose_provider(catalog, provider_id: str | None):
         print("Invalid provider, try again.")
 
 
+def _yes(raw: str) -> bool:
+    return raw.strip().lower() in {"y", "yes"}
+
+
+def _load_or_sync_external_catalog():
+    from .catalog import load_external_catalog, sync_external_catalog
+
+    external = load_external_catalog()
+    if external:
+        return external
+    try:
+        _, external = sync_external_catalog()
+    except Exception:  # noqa: BLE001 - keys add can continue with manual creation
+        return []
+    return external
+
+
+def _import_or_create_provider(provider_name: str, args: argparse.Namespace) -> str | None:
+    from .catalog import (
+        create_user_provider_stub,
+        discover_openai_models,
+        import_external_provider_to_user_catalog,
+        suggest_external_provider,
+    )
+
+    external = _load_or_sync_external_catalog()
+    suggestion = suggest_external_provider(provider_name, external)
+    if suggestion:
+        provider_slug = suggestion.provider.slug.replace("-", "_")
+        query_slug = provider_name.lower().replace("_", "-")
+        is_exact_provider = suggestion.exact and query_slug in {suggestion.provider.slug, provider_slug}
+        if is_exact_provider or (
+            not args.yes
+            and _yes(
+                input(
+                    f"Provider not found. Use external match "
+                    f"{suggestion.provider.name} (matched {suggestion.matched})? [y/N] "
+                )
+            )
+        ):
+            local_id = import_external_provider_to_user_catalog(suggestion.provider.name)
+            print(f"Imported external provider '{suggestion.provider.name}' as local provider '{local_id}'.")
+            return local_id
+
+    if args.yes and not args.base_url:
+        print("Provider not found. Pass --base-url to create it non-interactively.", file=sys.stderr)
+        return None
+
+    if not args.yes and not _yes(input(f"Provider '{provider_name}' not found. Create it manually? [y/N] ")):
+        return None
+
+    base_url = args.base_url or input("OpenAI-compatible API base URL: ").strip()
+    model = args.model or ("" if args.yes else input("Default model id (blank to autodiscover): ").strip())
+    if not model:
+        api_key = getattr(args, "value", None)
+        if not api_key and not args.yes:
+            import getpass
+
+            api_key = getpass.getpass("API key for model discovery (blank if not needed): ").strip()
+            if api_key:
+                args.value = api_key
+        try:
+            models = discover_openai_models(base_url, api_key=api_key or None)
+        except ValueError as exc:
+            print(f"Could not autodiscover models: {exc}", file=sys.stderr)
+            models = []
+        model = _choose_discovered_model(models, args)
+        if not model and not args.yes:
+            model = input("Default model id: ").strip()
+    try:
+        local_id = create_user_provider_stub(name=provider_name, base_url=base_url, model=model)
+    except ValueError as exc:
+        print(f"Could not create provider: {exc}", file=sys.stderr)
+        return None
+    print(f"Created local provider '{local_id}' in user providers.toml.")
+    return local_id
+
+
+def _choose_discovered_model(models: list[str], args: argparse.Namespace) -> str | None:
+    if not models:
+        return None
+    if len(models) == 1 or args.yes:
+        print(f"Discovered model: {models[0]}")
+        return models[0]
+    print("Discovered models:")
+    for i, model in enumerate(models[:10], start=1):
+        print(f"  {i}. {model}")
+    raw = input("Model number or id: ").strip()
+    if raw.isdigit():
+        idx = int(raw)
+        if 1 <= idx <= min(len(models), 10):
+            return models[idx - 1]
+    if raw in models:
+        return raw
+    return None
+
+
 def cmd_keys_add(args: argparse.Namespace) -> int:
     import getpass
     from datetime import date
@@ -286,14 +383,9 @@ def cmd_keys_add(args: argparse.Namespace) -> int:
     except SystemExit:
         if not args.provider:
             raise
-        from .catalog import import_external_provider_to_user_catalog
-
-        try:
-            local_id = import_external_provider_to_user_catalog(args.provider)
-        except ValueError as exc:
-            print(f"Could not import provider: {exc}", file=sys.stderr)
+        local_id = _import_or_create_provider(args.provider, args)
+        if not local_id:
             return 3
-        print(f"Imported external provider '{args.provider}' as local provider '{local_id}'.")
         provider = _choose_provider(load_catalog(), local_id)
 
     value = getattr(args, "value", None)
@@ -550,6 +642,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_keys_add.add_argument("provider_arg", nargs="?", help="provider id or external provider name")
     p_keys_add.add_argument("-p", "--provider")
     p_keys_add.add_argument("--value")
+    p_keys_add.add_argument("--base-url", help="OpenAI-compatible base URL for a new provider")
+    p_keys_add.add_argument("--model", help="default model id for a new provider")
     p_keys_add.add_argument("--label")
     p_keys_add.add_argument("--notes")
     p_keys_add.add_argument("--commercial-allowed", action="store_true")

--- a/src/freellmpool/healthcheck.py
+++ b/src/freellmpool/healthcheck.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .benchmark import benchmark
+from .router import Pool
+
+
+@dataclass(frozen=True)
+class HealthRow:
+    target: str
+    status: str
+    latency_ms: float | None
+    note: str
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "ok"
+
+
+def run_healthcheck(pool: Pool, *, model: str | None = None, providers=None, timeout: float = 20.0) -> list[HealthRow]:
+    rows = benchmark(pool, model=model, providers=providers, timeout=timeout, max_tokens=8)
+    out: list[HealthRow] = []
+    for row in rows:
+        if row.ok:
+            note = f"{row.tokens} tok" if row.tokens else "responded"
+            out.append(HealthRow(row.target, "ok", row.latency_ms, note))
+        else:
+            note = (row.error or "failed").splitlines()[0]
+            status = "rate_limited" if "429" in note else "fail"
+            out.append(HealthRow(row.target, status, None, note[:80]))
+    return out
+
+
+def render_health_table(rows: list[HealthRow]) -> str:
+    if not rows:
+        return "No configured providers to check."
+    width = max(len(row.target) for row in rows)
+    lines = [f"  {'provider/model':<{width}}  {'status':<12}  {'latency':>9}  note"]
+    for row in rows:
+        latency = f"{row.latency_ms:,.0f} ms" if row.latency_ms is not None else "-"
+        lines.append(f"  {row.target:<{width}}  {row.status:<12}  {latency:>9}  {row.note}")
+    ok = sum(1 for row in rows if row.ok)
+    lines.append(f"\n  {ok}/{len(rows)} providers ok")
+    return "\n".join(lines)

--- a/src/freellmpool/healthcheck.py
+++ b/src/freellmpool/healthcheck.py
@@ -26,9 +26,9 @@ def run_healthcheck(pool: Pool, *, model: str | None = None, providers=None, tim
             note = f"{row.tokens} tok" if row.tokens else "responded"
             out.append(HealthRow(row.target, "ok", row.latency_ms, note))
         else:
-            note = (row.error or "failed").splitlines()[0]
+            note = _short_note(row.error or "failed")
             status = "rate_limited" if "429" in note else "fail"
-            out.append(HealthRow(row.target, status, None, note[:80]))
+            out.append(HealthRow(row.target, status, None, note))
     return out
 
 
@@ -39,7 +39,11 @@ def render_health_table(rows: list[HealthRow]) -> str:
     lines = [f"  {'provider/model':<{width}}  {'status':<12}  {'latency':>9}  note"]
     for row in rows:
         latency = f"{row.latency_ms:,.0f} ms" if row.latency_ms is not None else "-"
-        lines.append(f"  {row.target:<{width}}  {row.status:<12}  {latency:>9}  {row.note}")
+        lines.append(f"  {row.target:<{width}}  {row.status:<12}  {latency:>9}  {_short_note(row.note)}")
     ok = sum(1 for row in rows if row.ok)
     lines.append(f"\n  {ok}/{len(rows)} providers ok")
     return "\n".join(lines)
+
+
+def _short_note(value: str) -> str:
+    return value.splitlines()[0][:80]

--- a/src/freellmpool/key_inventory.py
+++ b/src/freellmpool/key_inventory.py
@@ -1,0 +1,201 @@
+"""Safe local inventory of manually-created provider keys.
+
+The inventory is metadata only by default: it tracks which provider keys exist,
+where they live (env var name), optional dates and notes. Secret values should
+stay in env vars, config.toml, a shell profile, or a real secret manager.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tomllib
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+_SECRET_PATTERNS = [
+    re.compile(r"\bsk-[A-Za-z0-9_\-]{8,}\b"),
+    re.compile(r"\bsk-or-[A-Za-z0-9_\-]{8,}\b"),
+    re.compile(r"\bgsk_[A-Za-z0-9_\-]{8,}\b"),
+    re.compile(r"\bcsk-[A-Za-z0-9_\-]{8,}\b"),
+    re.compile(r"\bnvapi-[A-Za-z0-9_\-]{8,}\b"),
+    re.compile(r"\bghp_[A-Za-z0-9_]{8,}\b"),
+    re.compile(r"\bAIza[A-Za-z0-9_\-]{8,}\b"),
+]
+
+
+def redact_secrets(text: str) -> str:
+    """Return text with common API-key shapes redacted."""
+    redacted = text
+    for pattern in _SECRET_PATTERNS:
+        redacted = pattern.sub("[redacted]", redacted)
+    return redacted
+
+
+def default_inventory_path() -> Path:
+    override = os.environ.get("FREELLMPOOL_KEYS_PATH")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".config" / "freellmpool" / "keys.toml"
+
+
+@dataclass(frozen=True)
+class KeyRecord:
+    provider: str
+    env_var: str | None = None
+    label: str | None = None
+    created_at: str | None = None
+    expires_at: str | None = None
+    commercial_allowed: bool | None = None
+    notes: str | None = None
+
+    @classmethod
+    def from_row(cls, row: dict[str, Any]) -> KeyRecord:
+        return cls(
+            provider=str(row.get("provider", "")).strip(),
+            env_var=_optional_str(row.get("env_var")),
+            label=_optional_str(row.get("label")),
+            created_at=_optional_date(row.get("created_at")),
+            expires_at=_optional_date(row.get("expires_at")),
+            commercial_allowed=_optional_bool(row.get("commercial_allowed")),
+            notes=_optional_str(row.get("notes")),
+        )
+
+    @property
+    def display_label(self) -> str:
+        return self.label or self.env_var or self.provider
+
+    def safe_notes(self) -> str | None:
+        if self.notes is None:
+            return None
+        return redact_secrets(self.notes)
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    return bool(value)
+
+
+def _optional_date(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, date):
+        return value.isoformat()
+    text = str(value).strip()
+    return text or None
+
+
+def load_inventory(path: Path | None = None) -> list[KeyRecord]:
+    """Load [[keys]] records from TOML. Missing or invalid files return []."""
+    path = path or default_inventory_path()
+    try:
+        with path.open("rb") as fh:
+            data = tomllib.load(fh)
+    except (FileNotFoundError, OSError, tomllib.TOMLDecodeError):
+        return []
+    records = []
+    for row in data.get("keys", []):
+        if not isinstance(row, dict):
+            continue
+        record = KeyRecord.from_row(row)
+        if record.provider:
+            records.append(record)
+    return records
+
+
+def records_by_provider(records: list[KeyRecord]) -> dict[str, list[KeyRecord]]:
+    grouped: dict[str, list[KeyRecord]] = {}
+    for record in records:
+        grouped.setdefault(record.provider, []).append(record)
+    return grouped
+
+
+def default_config_path() -> Path:
+    override = os.environ.get("FREELLMPOOL_CONFIG_FILE")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".config" / "freellmpool" / "config.toml"
+
+
+def upsert_config_key(env_var: str, value: str, path: Path | None = None) -> Path:
+    """Write one [keys] value to config.toml and return the path.
+
+    This small writer preserves existing top-level tables that we understand,
+    but does not preserve comments. It is used by the interactive CLI helper.
+    """
+    path = path or default_config_path()
+    data: dict[str, dict] = {}
+    try:
+        with path.open("rb") as fh:
+            raw = tomllib.load(fh)
+        data = {str(k): dict(v) for k, v in raw.items() if isinstance(v, dict)}
+    except (FileNotFoundError, OSError, tomllib.TOMLDecodeError):
+        data = {}
+    keys = dict(data.get("keys", {}))
+    keys[env_var] = value
+    data["keys"] = keys
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_dump_simple_toml(data), encoding="utf-8")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return path
+
+
+def append_inventory_record(record: KeyRecord, path: Path | None = None) -> Path:
+    """Append a metadata record to keys.toml unless the same provider/env exists."""
+    path = path or default_inventory_path()
+    records = load_inventory(path)
+    exists = any(r.provider == record.provider and r.env_var == record.env_var for r in records)
+    if not exists:
+        records.append(record)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_dump_inventory(records), encoding="utf-8")
+    return path
+
+
+def _dump_inventory(records: list[KeyRecord]) -> str:
+    chunks = []
+    for record in records:
+        lines = ["[[keys]]", f'provider = "{_toml_escape(record.provider)}"']
+        for name in ("env_var", "label", "created_at", "expires_at", "notes"):
+            value = getattr(record, name)
+            if value:
+                lines.append(f'{name} = "{_toml_escape(value)}"')
+        if record.commercial_allowed is not None:
+            lines.append(f"commercial_allowed = {str(record.commercial_allowed).lower()}")
+        chunks.append("\n".join(lines))
+    return "\n\n".join(chunks) + ("\n" if chunks else "")
+
+
+def _dump_simple_toml(data: dict[str, dict]) -> str:
+    chunks = []
+    for table, values in data.items():
+        lines = [f"[{table}]"]
+        for key, value in values.items():
+            lines.append(f'{key} = {_toml_value(value)}')
+        chunks.append("\n".join(lines))
+    return "\n\n".join(chunks) + ("\n" if chunks else "")
+
+
+def _toml_value(value) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, int | float):
+        return str(value)
+    return f'"{_toml_escape(str(value))}"'
+
+
+def _toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')

--- a/src/freellmpool/key_inventory.py
+++ b/src/freellmpool/key_inventory.py
@@ -15,6 +15,8 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
+from .toml_utils import dump_simple_toml, toml_escape
+
 _SECRET_PATTERNS = [
     re.compile(r"\bsk-[A-Za-z0-9_\-]{8,}\b"),
     re.compile(r"\bsk-or-[A-Za-z0-9_\-]{8,}\b"),
@@ -121,6 +123,11 @@ def records_by_provider(records: list[KeyRecord]) -> dict[str, list[KeyRecord]]:
 
 
 def default_config_path() -> Path:
+    """Return the config.toml path used for [keys] values.
+
+    FREELLMPOOL_CONFIG_FILE points to config.toml. FREELLMPOOL_CONFIG is reserved
+    for the user provider catalog, matching freellmpool.config.
+    """
     override = os.environ.get("FREELLMPOOL_CONFIG_FILE")
     if override:
         return Path(override).expanduser()
@@ -145,7 +152,7 @@ def upsert_config_key(env_var: str, value: str, path: Path | None = None) -> Pat
     keys[env_var] = value
     data["keys"] = keys
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(_dump_simple_toml(data), encoding="utf-8")
+    path.write_text(dump_simple_toml(data), encoding="utf-8")
     try:
         path.chmod(0o600)
     except OSError:
@@ -168,34 +175,12 @@ def append_inventory_record(record: KeyRecord, path: Path | None = None) -> Path
 def _dump_inventory(records: list[KeyRecord]) -> str:
     chunks = []
     for record in records:
-        lines = ["[[keys]]", f'provider = "{_toml_escape(record.provider)}"']
+        lines = ["[[keys]]", f'provider = "{toml_escape(record.provider)}"']
         for name in ("env_var", "label", "created_at", "expires_at", "notes"):
             value = getattr(record, name)
             if value:
-                lines.append(f'{name} = "{_toml_escape(value)}"')
+                lines.append(f'{name} = "{toml_escape(value)}"')
         if record.commercial_allowed is not None:
             lines.append(f"commercial_allowed = {str(record.commercial_allowed).lower()}")
         chunks.append("\n".join(lines))
     return "\n\n".join(chunks) + ("\n" if chunks else "")
-
-
-def _dump_simple_toml(data: dict[str, dict]) -> str:
-    chunks = []
-    for table, values in data.items():
-        lines = [f"[{table}]"]
-        for key, value in values.items():
-            lines.append(f'{key} = {_toml_value(value)}')
-        chunks.append("\n".join(lines))
-    return "\n\n".join(chunks) + ("\n" if chunks else "")
-
-
-def _toml_value(value) -> str:
-    if isinstance(value, bool):
-        return str(value).lower()
-    if isinstance(value, int | float):
-        return str(value)
-    return f'"{_toml_escape(str(value))}"'
-
-
-def _toml_escape(value: str) -> str:
-    return value.replace("\\", "\\\\").replace('"', '\\"')

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -492,6 +492,8 @@ def _dashboard_html(pool) -> str:
     import html as _html
 
     from . import __version__
+    from .capacity import build_capacity_report
+    from .key_inventory import load_inventory
     from .savings import usd_saved
 
     s = pool.stats
@@ -518,6 +520,25 @@ def _dashboard_html(pool) -> str:
         )
     provider_rows = "\n".join(rows) or "<tr><td colspan=3>no providers configured</td></tr>"
 
+    capacity = build_capacity_report(env=pool.env, quota=pool.quota, inventory=load_inventory())
+    capacity_rows = []
+    for item in capacity.providers:
+        if item.status == "missing":
+            continue
+        quota = "?" if item.quota_hint <= 0 else str(item.quota_hint)
+        capacity_rows.append(
+            f"<tr><td>{_html.escape(item.provider_id)}</td>"
+            f"<td>{_html.escape(item.status)}</td>"
+            f"<td class=num>{item.used_today}/{quota}</td>"
+            f"<td>{_html.escape(item.reason)}</td></tr>"
+        )
+    capacity_table_rows = "\n".join(capacity_rows) or "<tr><td colspan=4>no capacity data</td></tr>"
+    capacity_table = (
+        "<h2>capacity</h2>"
+        "<table><tr><th>provider</th><th>status</th><th class=num>usage</th><th>reason</th></tr>"
+        f"{capacity_table_rows}</table>"
+    )
+
     # Measured latency / success, if any calls have been timed this run.
     metrics_snap = pool.metrics.snapshot() if getattr(pool, "metrics", None) else {}
     measured = sorted(
@@ -543,7 +564,7 @@ def _dashboard_html(pool) -> str:
     cards = [
         ("requests served", str(s.get("requests", 0))),
         ("cache hits", str(s.get("cache_hits", 0))),
-        ("tokens out", f"{s.get('completion_tokens', 0):,}"),
+        ("healthy providers", f"{capacity.healthy_count}/{capacity.target}"),
         ("not paid to OpenAI", f"${saved:,.2f}"),
     ]
     card_html = "\n".join(
@@ -554,7 +575,8 @@ def _dashboard_html(pool) -> str:
 <style>
  body{{font-family:ui-sans-serif,system-ui,sans-serif;margin:0;background:#0b0e14;color:#e6e6e6}}
  .wrap{{max-width:760px;margin:0 auto;padding:32px 20px}}
- h1{{font-size:22px;margin:0 0 2px}} .sub{{color:#8a93a2;font-size:13px;margin-bottom:24px}}
+ h1{{font-size:22px;margin:0 0 2px}} h2{{font-size:14px;color:#8a93a2;margin:24px 0 8px}}
+ .sub{{color:#8a93a2;font-size:13px;margin-bottom:24px}}
  .cards{{display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:28px}}
  .card{{background:#141925;border:1px solid #232a39;border-radius:10px;padding:16px;text-align:center}}
  .big{{font-size:26px;font-weight:700}} .lbl{{color:#8a93a2;font-size:11px;margin-top:4px}}
@@ -568,6 +590,7 @@ def _dashboard_html(pool) -> str:
 <div class=cards>{card_html}</div>
 <table><tr><th>provider</th><th>models</th><th class=num>requests today</th></tr>
 {provider_rows}</table>
+{capacity_table}
 {metrics_table}
 <p class=sub style="margin-top:20px">OpenAI endpoint: <code>/v1</code> · <a href="https://github.com/0xzr/freellmpool">github.com/0xzr/freellmpool</a></p>
 </div></body></html>"""

--- a/src/freellmpool/toml_utils.py
+++ b/src/freellmpool/toml_utils.py
@@ -1,0 +1,25 @@
+"""Small TOML writing helpers for simple generated config files."""
+
+from __future__ import annotations
+
+
+def toml_escape(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def toml_value(value) -> str:
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (int, float)):
+        return str(value)
+    return f'"{toml_escape(str(value))}"'
+
+
+def dump_simple_toml(data: dict[str, dict]) -> str:
+    chunks = []
+    for table, values in data.items():
+        lines = [f"[{table}]"]
+        for key, value in values.items():
+            lines.append(f"{key} = {toml_value(value)}")
+        chunks.append("\n".join(lines))
+    return "\n\n".join(chunks) + ("\n" if chunks else "")

--- a/src/freellmpool/toml_utils.py
+++ b/src/freellmpool/toml_utils.py
@@ -2,9 +2,31 @@
 
 from __future__ import annotations
 
+# TOML basic strings must escape backslash, double-quote, and control characters
+# (newline, CR, etc.). Tab is allowed literally. Anything generated from
+# untrusted input (e.g. the external provider catalog) is run through this so a
+# stray control character can't corrupt the file it's written into.
+_TOML_BASIC_ESCAPES = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\b": "\\b",
+    "\f": "\\f",
+    "\n": "\\n",
+    "\r": "\\r",
+}
+
 
 def toml_escape(value: str) -> str:
-    return value.replace("\\", "\\\\").replace('"', '\\"')
+    out = []
+    for ch in value:
+        mapped = _TOML_BASIC_ESCAPES.get(ch)
+        if mapped is not None:
+            out.append(mapped)
+        elif ch != "\t" and (ch < "\x20" or ch == "\x7f"):
+            out.append(f"\\u{ord(ch):04x}")
+        else:
+            out.append(ch)
+    return "".join(out)
 
 
 def toml_value(value) -> str:

--- a/tests/test_capacity.py
+++ b/tests/test_capacity.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from freellmpool.capacity import build_capacity_report
+from freellmpool.key_inventory import KeyRecord
+from freellmpool.models import Model, Provider
+
+
+class FakeQuota:
+    def __init__(self, snap):
+        self._snap = snap
+
+    def snapshot(self):
+        return dict(self._snap)
+
+
+def _catalog():
+    return [
+        Provider(
+            id="keyless",
+            label="Keyless",
+            adapter="openai",
+            base_url="https://example.test/v1",
+            auth="none",
+            models=(Model("a", rpd=10),),
+        ),
+        Provider(
+            id="needskey",
+            label="Needs Key",
+            adapter="openai",
+            base_url="https://example.test/v1",
+            key_env="NEEDS_KEY",
+            models=(Model("b", rpd=10),),
+        ),
+        Provider(
+            id="low",
+            label="Low",
+            adapter="openai",
+            base_url="https://example.test/v1",
+            key_env="LOW_KEY",
+            models=(Model("c", rpd=10),),
+        ),
+    ]
+
+
+def test_capacity_marks_configured_missing_and_low_quota():
+    report = build_capacity_report(
+        target=3,
+        env={"LOW_KEY": "value"},
+        quota=FakeQuota({"low::c": 8}),
+        catalog=_catalog(),
+    )
+    statuses = {p.provider_id: p.status for p in report.providers}
+    assert statuses["keyless"] == "healthy"
+    assert statuses["needskey"] == "missing"
+    assert statuses["low"] == "low_quota"
+    assert report.healthy_count == 1
+    assert report.low_quota_count == 1
+
+
+def test_capacity_checklist_returns_missing_key_provider():
+    report = build_capacity_report(
+        target=3,
+        env={"NEEDS_KEY": "value"},
+        quota=FakeQuota({}),
+        catalog=_catalog(),
+    )
+    checklist = report.checklist()
+    assert [p.provider_id for p in checklist] == ["low"]
+    assert checklist[0].key_env == "LOW_KEY"
+
+
+def test_inventory_expiry_marks_invalid_key():
+    report = build_capacity_report(
+        target=1,
+        env={"NEEDS_KEY": "value"},
+        quota=FakeQuota({}),
+        catalog=[_catalog()[1]],
+        inventory=[KeyRecord(provider="needskey", env_var="NEEDS_KEY", expires_at="2000-01-01")],
+    )
+    assert report.providers[0].status == "invalid_key"
+
+
+def test_capacity_sorts_by_generosity_within_status():
+    catalog = [
+        Provider(
+            id="small",
+            label="Small",
+            adapter="openai",
+            base_url="https://example.test/v1",
+            auth="none",
+            models=(Model("a", rpd=10),),
+        ),
+        Provider(
+            id="large",
+            label="Large",
+            adapter="openai",
+            base_url="https://example.test/v1",
+            auth="none",
+            models=(Model("b", rpd=1000),),
+        ),
+    ]
+    report = build_capacity_report(target=2, env={}, quota=FakeQuota({}), catalog=catalog)
+    assert [p.provider_id for p in report.providers] == ["large", "small"]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from freellmpool.catalog import parse_external_catalog
+
+
+def test_parse_external_catalog_rate_limits():
+    data = {
+        "providers": [
+            {
+                "name": "Small",
+                "category": "provider_api",
+                "url": "https://example.test/small",
+                "baseUrl": "https://api.example.test/v1",
+                "description": "small plan",
+                "models": [{"id": "a", "rateLimit": "10 RPM, 100 RPD"}],
+            },
+            {
+                "name": "Large",
+                "category": "provider_api",
+                "url": "https://example.test/large",
+                "baseUrl": "https://api2.example.test/v1",
+                "description": "large plan",
+                "models": [{"id": "b", "rateLimit": "2k RPM, 1M TPD"}],
+            },
+        ]
+    }
+    providers = parse_external_catalog(data)
+    assert [p.name for p in providers] == ["Large", "Small"]
+    assert providers[0].best_rpm == 2000
+    assert providers[0].best_tpd == 1_000_000
+    assert providers[1].best_rpd == 100
+
+
+def test_import_external_provider_to_user_catalog(tmp_path, monkeypatch):
+    from freellmpool.catalog import (
+        default_external_catalog_path,
+        import_external_provider_to_user_catalog,
+    )
+
+    cache = tmp_path / "provider_catalog.json"
+    user_catalog = tmp_path / "providers.toml"
+    cache.write_text(
+        '{"providers":[{"name":"ModelScope","baseUrl":"https://api-inference.modelscope.cn/v1",'
+        '"models":[{"id":"Qwen/Qwen3.5-27B","modality":"Text","rateLimit":"2,000 RPD total; <=500 RPD/model"},'
+        '{"id":"+ API-Inference-enabled models","modality":"LLM","rateLimit":"Dynamic quotas"}]}]}'
+    )
+    monkeypatch.setenv("FREELLMPOOL_EXTERNAL_CATALOG_PATH", str(cache))
+    monkeypatch.setenv("FREELLMPOOL_CONFIG", str(user_catalog))
+
+    assert default_external_catalog_path() == cache
+    local_id = import_external_provider_to_user_catalog("ModelScope")
+    assert local_id == "modelscope"
+    written = user_catalog.read_text()
+    assert 'id = "modelscope"' in written
+    assert 'key_env = "MODELSCOPE_API_KEY"' in written
+    assert 'Qwen/Qwen3.5-27B' in written
+    assert '+ API-Inference-enabled models' not in written
+    assert 'rpd = 500' in written

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from freellmpool.catalog import (
@@ -83,9 +85,9 @@ def test_import_external_provider_to_user_catalog(tmp_path, monkeypatch):
     written = user_catalog.read_text()
     assert 'id = "modelscope"' in written
     assert 'key_env = "MODELSCOPE_API_KEY"' in written
-    assert 'Qwen/Qwen3.5-27B' in written
-    assert '+ API-Inference-enabled models' not in written
-    assert 'rpd = 500' in written
+    assert "Qwen/Qwen3.5-27B" in written
+    assert "+ API-Inference-enabled models" not in written
+    assert "rpd = 500" in written
 
 
 def test_import_external_provider_missing_cache_points_to_catalog_sync(tmp_path, monkeypatch):
@@ -144,7 +146,7 @@ def test_discover_openai_models(monkeypatch):
         def __exit__(self, *args):
             return None
 
-        def read(self):
+        def read(self, *args):
             return b'{"data":[{"id":"model-a"},{"id":"model-b"}]}'
 
     seen = {}
@@ -165,3 +167,66 @@ def test_discover_openai_models(monkeypatch):
         "auth": "Bearer secret",
         "timeout": 3,
     }
+
+
+def _write_cache(tmp_path, monkeypatch, base_url, model_id="m"):
+    cache = tmp_path / "provider_catalog.json"
+    cache.write_text(
+        json.dumps(
+            {
+                "providers": [
+                    {
+                        "name": "P",
+                        "baseUrl": base_url,
+                        "models": [{"id": model_id, "modality": "Text", "rateLimit": "1 RPD"}],
+                    }
+                ]
+            }
+        )
+    )
+    monkeypatch.setenv("FREELLMPOOL_EXTERNAL_CATALOG_PATH", str(cache))
+    monkeypatch.setenv("FREELLMPOOL_CONFIG", str(tmp_path / "providers.toml"))
+
+
+def test_import_rejects_non_https_base_url(tmp_path, monkeypatch):
+    _write_cache(tmp_path, monkeypatch, "http://api.insecure.test/v1")
+    with pytest.raises(ValueError, match="https"):
+        import_external_provider_to_user_catalog("P")
+
+
+def test_import_rejects_surrounding_whitespace_base_url(tmp_path, monkeypatch):
+    _write_cache(tmp_path, monkeypatch, "https://api.test/v1\n")
+    with pytest.raises(ValueError, match="https"):
+        import_external_provider_to_user_catalog("P")
+
+
+def test_import_sanitizes_control_chars_in_model_id(tmp_path, monkeypatch):
+    """A malicious model id with a newline must not corrupt the user catalog."""
+    import tomllib
+
+    evil = 'good\nkey_env = "PATH"\n[[provider]]\nid = "injected"\nmodels = [{ name = "x"'
+    _write_cache(tmp_path, monkeypatch, "https://api.evil.test/v1", model_id=evil)
+    import_external_provider_to_user_catalog("P")
+    parsed = tomllib.loads((tmp_path / "providers.toml").read_text())
+    assert [p.get("id") for p in parsed.get("provider", [])] == ["p"]
+
+
+def test_create_user_provider_stub_rejects_bad_scheme(tmp_path, monkeypatch):
+    monkeypatch.setenv("FREELLMPOOL_CONFIG", str(tmp_path / "providers.toml"))
+    with pytest.raises(ValueError, match="http"):
+        create_user_provider_stub(name="X", base_url="file:///etc/passwd", model="m")
+
+
+def test_create_user_provider_stub_allows_http_localhost(tmp_path, monkeypatch):
+    # http is fine for a user's own custom/local endpoint (e.g. Ollama).
+    monkeypatch.setenv("FREELLMPOOL_CONFIG", str(tmp_path / "providers.toml"))
+    local_id = create_user_provider_stub(
+        name="Local", base_url="http://localhost:11434/v1", model="llama3"
+    )
+    assert local_id == "local"
+    assert 'base_url = "http://localhost:11434/v1"' in (tmp_path / "providers.toml").read_text()
+
+
+def test_discover_openai_models_rejects_non_http_scheme():
+    with pytest.raises(ValueError, match="http"):
+        discover_openai_models("file:///etc/passwd")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -4,9 +4,12 @@ import pytest
 
 from freellmpool.catalog import (
     ExternalProvider,
+    create_user_provider_stub,
+    discover_openai_models,
     import_external_provider_to_user_catalog,
     match_local_provider,
     parse_external_catalog,
+    suggest_external_provider,
 )
 
 
@@ -36,6 +39,29 @@ def test_parse_external_catalog_rate_limits():
     assert providers[0].best_rpm == 2000
     assert providers[0].best_tpd == 1_000_000
     assert providers[1].best_rpd == 100
+
+
+def test_suggest_external_provider_matches_typo_and_model_id():
+    data = {
+        "providers": [
+            {
+                "name": "Hyperbolic",
+                "baseUrl": "https://api.hyperbolic.xyz/v1",
+                "models": [{"id": "meta-llama/Llama-3.3-70B-Instruct", "rateLimit": "100 RPD"}],
+            }
+        ]
+    }
+    providers = parse_external_catalog(data)
+
+    typo = suggest_external_provider("Hyperbolc", providers)
+    by_model = suggest_external_provider("Llama-3.3-70B-Instruct", providers)
+
+    assert typo is not None
+    assert typo.provider.name == "Hyperbolic"
+    assert not typo.exact
+    assert by_model is not None
+    assert by_model.provider.name == "Hyperbolic"
+    assert by_model.exact
 
 
 def test_import_external_provider_to_user_catalog(tmp_path, monkeypatch):
@@ -90,3 +116,52 @@ def test_match_local_provider_handles_missing_local_base_url():
         base_url = None
 
     assert match_local_provider(external, [LocalProvider()]) is None
+
+
+def test_create_user_provider_stub(tmp_path, monkeypatch):
+    user_catalog = tmp_path / "providers.toml"
+    monkeypatch.setenv("FREELLMPOOL_CONFIG", str(user_catalog))
+
+    local_id = create_user_provider_stub(
+        name="Hyperbolic",
+        base_url="https://api.hyperbolic.xyz/v1/",
+        model="meta-llama/Llama-3.3-70B-Instruct",
+    )
+
+    text = user_catalog.read_text()
+    assert local_id == "hyperbolic"
+    assert 'id = "hyperbolic"' in text
+    assert 'base_url = "https://api.hyperbolic.xyz/v1"' in text
+    assert 'key_env = "HYPERBOLIC_API_KEY"' in text
+    assert 'name = "meta-llama/Llama-3.3-70B-Instruct"' in text
+
+
+def test_discover_openai_models(monkeypatch):
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def read(self):
+            return b'{"data":[{"id":"model-a"},{"id":"model-b"}]}'
+
+    seen = {}
+
+    def fake_urlopen(request, timeout):
+        seen["url"] = request.full_url
+        seen["auth"] = request.headers.get("Authorization")
+        seen["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    models = discover_openai_models("https://api.example.test/v1/", api_key="secret", timeout=3)
+
+    assert models == ["model-a", "model-b"]
+    assert seen == {
+        "url": "https://api.example.test/v1/models",
+        "auth": "Bearer secret",
+        "timeout": 3,
+    }

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from freellmpool.catalog import parse_external_catalog
+import pytest
+
+from freellmpool.catalog import (
+    ExternalProvider,
+    import_external_provider_to_user_catalog,
+    match_local_provider,
+    parse_external_catalog,
+)
 
 
 def test_parse_external_catalog_rate_limits():
@@ -32,10 +39,7 @@ def test_parse_external_catalog_rate_limits():
 
 
 def test_import_external_provider_to_user_catalog(tmp_path, monkeypatch):
-    from freellmpool.catalog import (
-        default_external_catalog_path,
-        import_external_provider_to_user_catalog,
-    )
+    from freellmpool.catalog import default_external_catalog_path
 
     cache = tmp_path / "provider_catalog.json"
     user_catalog = tmp_path / "providers.toml"
@@ -56,3 +60,33 @@ def test_import_external_provider_to_user_catalog(tmp_path, monkeypatch):
     assert 'Qwen/Qwen3.5-27B' in written
     assert '+ API-Inference-enabled models' not in written
     assert 'rpd = 500' in written
+
+
+def test_import_external_provider_missing_cache_points_to_catalog_sync(tmp_path, monkeypatch):
+    monkeypatch.setenv("FREELLMPOOL_EXTERNAL_CATALOG_PATH", str(tmp_path / "missing.json"))
+
+    with pytest.raises(ValueError, match="freellmpool catalog sync"):
+        import_external_provider_to_user_catalog("ModelScope")
+
+
+def test_match_local_provider_handles_missing_local_base_url():
+    external = ExternalProvider(
+        name="Demo",
+        slug="external-demo",
+        category=None,
+        url=None,
+        base_url="https://example.test/v1",
+        description="",
+        model_count=0,
+        best_rpd=0,
+        best_rpm=0,
+        best_tpd=0,
+        generous_score=0,
+    )
+
+    class LocalProvider:
+        id = "local"
+        label = "Local"
+        base_url = None
+
+    assert match_local_provider(external, [LocalProvider()]) is None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,3 +15,51 @@ def test_strip_fenced_json():
 
 def test_strip_bare_fence():
     assert _strip_fences("```\nhello\n```") == "hello"
+
+
+def test_cli_capacity_status_smoke(monkeypatch, capsys):
+    from freellmpool.cli import main
+
+    monkeypatch.setenv("FREELLMPOOL_KEYS_PATH", "/tmp/freellmpool-test-missing-keys.toml")
+    assert main(["capacity", "status", "--target", "1", "--no-catalog-sync"]) == 0
+    out = capsys.readouterr().out
+    assert "LLM capacity:" in out
+
+
+def test_cli_keys_checklist_smoke(monkeypatch, capsys):
+    from freellmpool.cli import main
+
+    monkeypatch.setenv("FREELLMPOOL_KEYS_PATH", "/tmp/freellmpool-test-missing-keys.toml")
+    assert main(["keys", "checklist", "--target", "1"]) == 0
+    out = capsys.readouterr().out
+    assert "healthy providers" in out or "Manual key checklist" in out
+
+
+def test_cli_providers_health_smoke(monkeypatch, capsys):
+    from freellmpool.cli import main
+
+    monkeypatch.setattr(
+        "freellmpool.cli.cmd_providers_health",
+        lambda args: print("health smoke") or 0,
+    )
+    assert main(["providers", "health"]) == 0
+    assert "health smoke" in capsys.readouterr().out
+
+
+def test_dashboard_contains_capacity(monkeypatch):
+    from freellmpool.models import Model, Provider
+    from freellmpool.proxy import _dashboard_html
+    from freellmpool.router import Pool
+
+    provider = Provider(
+        id="demo",
+        label="Demo",
+        adapter="openai",
+        base_url="https://example.test/v1",
+        auth="none",
+        models=(Model("model"),),
+    )
+    html = _dashboard_html(Pool([provider]))
+    assert "healthy providers" in html
+    assert "capacity" in html
+    assert "demo" in html

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,6 +35,77 @@ def test_cli_keys_checklist_smoke(monkeypatch, capsys):
     assert "healthy providers" in out or "Manual key checklist" in out
 
 
+def test_cli_keys_add_confirms_fuzzy_external_match(tmp_path, monkeypatch, capsys):
+    from freellmpool.cli import main
+
+    cache = tmp_path / "provider_catalog.json"
+    user_catalog = tmp_path / "providers.toml"
+    config = tmp_path / "config.toml"
+    inventory = tmp_path / "keys.toml"
+    cache.write_text(
+        '{"providers":[{"name":"Hyperbolic","baseUrl":"https://api.hyperbolic.xyz/v1",'
+        '"models":[{"id":"meta-llama/Llama-3.3-70B-Instruct","modality":"Text","rateLimit":"100 RPD"}]}]}',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FREELLMPOOL_EXTERNAL_CATALOG_PATH", str(cache))
+    monkeypatch.setenv("FREELLMPOOL_CONFIG", str(user_catalog))
+    monkeypatch.setenv("FREELLMPOOL_CONFIG_FILE", str(config))
+    monkeypatch.setenv("FREELLMPOOL_KEYS_PATH", str(inventory))
+    answers = iter(["y", "y"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+
+    assert main(["keys", "add", "Hyperbolc", "--value", "secret"]) == 0
+
+    assert 'id = "hyperbolic"' in user_catalog.read_text()
+    assert 'HYPERBOLIC_API_KEY = "secret"' in config.read_text()
+    assert 'provider = "hyperbolic"' in inventory.read_text()
+    assert "Imported external provider 'Hyperbolic'" in capsys.readouterr().out
+
+
+def test_cli_keys_add_creates_manual_provider(tmp_path, monkeypatch):
+    from freellmpool.cli import main
+
+    user_catalog = tmp_path / "providers.toml"
+    config = tmp_path / "config.toml"
+    inventory = tmp_path / "keys.toml"
+    monkeypatch.setenv("FREELLMPOOL_CONFIG", str(user_catalog))
+    monkeypatch.setenv("FREELLMPOOL_CONFIG_FILE", str(config))
+    monkeypatch.setenv("FREELLMPOOL_KEYS_PATH", str(inventory))
+    monkeypatch.setattr("freellmpool.cli._load_or_sync_external_catalog", lambda: [])
+    answers = iter(["y", "https://api.hyperbolic.xyz/v1", "meta-llama/Llama-3.3-70B-Instruct", "y"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+
+    assert main(["keys", "add", "Hyperbolic", "--value", "secret"]) == 0
+
+    assert 'id = "hyperbolic"' in user_catalog.read_text()
+    assert 'name = "meta-llama/Llama-3.3-70B-Instruct"' in user_catalog.read_text()
+    assert 'HYPERBOLIC_API_KEY = "secret"' in config.read_text()
+
+
+def test_cli_keys_add_autodiscovers_model_when_blank(tmp_path, monkeypatch):
+    from freellmpool.cli import main
+
+    user_catalog = tmp_path / "providers.toml"
+    config = tmp_path / "config.toml"
+    inventory = tmp_path / "keys.toml"
+    monkeypatch.setenv("FREELLMPOOL_CONFIG", str(user_catalog))
+    monkeypatch.setenv("FREELLMPOOL_CONFIG_FILE", str(config))
+    monkeypatch.setenv("FREELLMPOOL_KEYS_PATH", str(inventory))
+    monkeypatch.setattr("freellmpool.cli._load_or_sync_external_catalog", lambda: [])
+    monkeypatch.setattr(
+        "freellmpool.catalog.discover_openai_models",
+        lambda base_url, api_key=None, timeout=10.0: ["model-a", "model-b"],
+    )
+    answers = iter(["y", "https://api.example.test/v1", "", "2", "y"])
+    monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))
+
+    assert main(["keys", "add", "Example", "--value", "secret"]) == 0
+
+    assert 'id = "example"' in user_catalog.read_text()
+    assert 'name = "model-b"' in user_catalog.read_text()
+    assert 'EXAMPLE_API_KEY = "secret"' in config.read_text()
+
+
 def test_cli_providers_health_smoke(monkeypatch, capsys):
     from freellmpool.cli import main
 

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from helpers import make_post
+
+from freellmpool.healthcheck import HealthRow, render_health_table, run_healthcheck
+from freellmpool.models import Model, Provider
+from freellmpool.router import Pool
+
+
+def test_render_health_table_empty():
+    assert render_health_table([]) == "No configured providers to check."
+
+
+def test_render_health_table_rows():
+    text = render_health_table([HealthRow("demo/model", "ok", 12.0, "responded")])
+    assert "demo/model" in text
+    assert "ok" in text
+    assert "1/1 providers ok" in text
+
+
+def test_run_healthcheck_success():
+    provider = Provider(
+        id="demo",
+        label="Demo",
+        adapter="openai",
+        base_url="https://example.test/v1",
+        auth="none",
+        models=(Model("model"),),
+    )
+
+    pool = Pool([provider], post=make_post({}))
+    rows = run_healthcheck(pool, timeout=1)
+    assert len(rows) == 1
+    assert rows[0].ok
+    assert rows[0].target == "demo/model"

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -33,3 +33,62 @@ def test_run_healthcheck_success():
     assert len(rows) == 1
     assert rows[0].ok
     assert rows[0].target == "demo/model"
+
+
+def test_run_healthcheck_failure_and_rate_limit(monkeypatch):
+    from freellmpool import healthcheck
+
+    class FakeRow:
+        def __init__(self, target: str, error: str):
+            self.target = target
+            self.ok = False
+            self.latency_ms = None
+            self.tokens = None
+            self.error = error
+
+    monkeypatch.setattr(
+        healthcheck,
+        "benchmark",
+        lambda *args, **kwargs: [
+            FakeRow("demo/a", "429 Too Many Requests"),
+            FakeRow("demo/b", "500 Internal Error"),
+        ],
+    )
+
+    rows = run_healthcheck(Pool([]), timeout=1)
+
+    assert [row.status for row in rows] == ["rate_limited", "fail"]
+    assert not rows[0].ok
+    assert not rows[1].ok
+
+
+def test_run_healthcheck_notes_for_tokens_and_empty_tokens(monkeypatch):
+    from freellmpool import healthcheck
+
+    class FakeRow:
+        def __init__(self, target: str, tokens):
+            self.target = target
+            self.ok = True
+            self.latency_ms = 10.0
+            self.tokens = tokens
+            self.error = None
+
+    monkeypatch.setattr(
+        healthcheck,
+        "benchmark",
+        lambda *args, **kwargs: [FakeRow("demo/a", 123), FakeRow("demo/b", None)],
+    )
+
+    text = render_health_table(run_healthcheck(Pool([]), timeout=1))
+
+    assert "123 tok" in text
+    assert "responded" in text
+
+
+def test_render_health_table_uses_first_error_line_and_truncates_note():
+    first_line = "X" * 90
+    text = render_health_table([HealthRow("demo/model", "fail", None, first_line + "\nsecond")])
+
+    assert "second" not in text
+    assert "X" * 80 in text
+    assert "X" * 81 not in text

--- a/tests/test_key_inventory.py
+++ b/tests/test_key_inventory.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from freellmpool.key_inventory import load_inventory, records_by_provider, redact_secrets
+
+
+def test_load_inventory_reads_records(tmp_path):
+    path = tmp_path / "keys.toml"
+    path.write_text(
+        '[[keys]]\n'
+        'provider = "groq"\n'
+        'env_var = "GROQ_API_KEY"\n'
+        'label = "main"\n'
+        'created_at = "2026-06-05"\n'
+        'commercial_allowed = true\n'
+    )
+    records = load_inventory(path)
+    assert len(records) == 1
+    assert records[0].provider == "groq"
+    assert records[0].env_var == "GROQ_API_KEY"
+    assert records[0].display_label == "main"
+    assert records[0].commercial_allowed is True
+
+
+def test_load_inventory_missing_file_is_empty(tmp_path):
+    assert load_inventory(tmp_path / "missing.toml") == []
+
+
+def test_records_by_provider_groups_records(tmp_path):
+    path = tmp_path / "keys.toml"
+    path.write_text(
+        '[[keys]]\nprovider = "groq"\nenv_var = "GROQ_API_KEY"\n'
+        '[[keys]]\nprovider = "groq"\nenv_var = "GROQ_API_KEY_2"\n'
+        '[[keys]]\nprovider = "mistral"\nenv_var = "MISTRAL_API_KEY"\n'
+    )
+    grouped = records_by_provider(load_inventory(path))
+    assert len(grouped["groq"]) == 2
+    assert len(grouped["mistral"]) == 1
+
+
+def test_redact_secrets_common_shapes():
+    text = "before gsk_abcdefghijk after"
+    assert redact_secrets(text) == "before [redacted] after"

--- a/tests/test_key_inventory.py
+++ b/tests/test_key_inventory.py
@@ -1,6 +1,13 @@
 from __future__ import annotations
 
-from freellmpool.key_inventory import load_inventory, records_by_provider, redact_secrets
+from freellmpool.key_inventory import (
+    KeyRecord,
+    append_inventory_record,
+    load_inventory,
+    records_by_provider,
+    redact_secrets,
+    upsert_config_key,
+)
 
 
 def test_load_inventory_reads_records(tmp_path):
@@ -40,3 +47,55 @@ def test_records_by_provider_groups_records(tmp_path):
 def test_redact_secrets_common_shapes():
     text = "before gsk_abcdefghijk after"
     assert redact_secrets(text) == "before [redacted] after"
+
+
+def test_upsert_config_key_creates_new_file(tmp_path):
+    path = tmp_path / "config.toml"
+
+    upsert_config_key("GROQ_API_KEY", "secret", path)
+
+    assert path.read_text() == '[keys]\nGROQ_API_KEY = "secret"\n'
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
+
+
+def test_upsert_config_key_updates_keys_without_touching_other_tables(tmp_path):
+    path = tmp_path / "config.toml"
+    path.write_text(
+        "[settings]\n"
+        'default_provider = "groq"\n'
+        "\n"
+        "[keys]\n"
+        'GROQ_API_KEY = "old"\n',
+        encoding="utf-8",
+    )
+
+    upsert_config_key("GROQ_API_KEY", "new", path)
+    upsert_config_key("CEREBRAS_API_KEY", "second", path)
+
+    text = path.read_text()
+    assert '[settings]\ndefault_provider = "groq"' in text
+    assert 'GROQ_API_KEY = "new"' in text
+    assert 'CEREBRAS_API_KEY = "second"' in text
+    assert text.count("GROQ_API_KEY") == 1
+
+
+def test_append_inventory_record_deduplicates_provider_env_pair(tmp_path):
+    path = tmp_path / "keys.toml"
+    record = KeyRecord(provider="groq", env_var="GROQ_API_KEY", label="main")
+
+    append_inventory_record(record, path)
+    append_inventory_record(record, path)
+
+    records = load_inventory(path)
+    assert len(records) == 1
+    assert records[0].provider == "groq"
+    assert records[0].env_var == "GROQ_API_KEY"
+    assert records[0].label == "main"
+
+
+def test_key_record_safe_notes_redacts_secrets():
+    notes = "created with sk-abcdefghijk"
+    record = KeyRecord(provider="groq", notes=notes)
+
+    assert record.safe_notes() == redact_secrets(notes)
+    assert "sk-abcdefghijk" not in record.safe_notes()

--- a/tests/test_toml_utils.py
+++ b/tests/test_toml_utils.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import tomllib
+
+from freellmpool.toml_utils import toml_escape
+
+
+def test_toml_escape_basic():
+    assert toml_escape('a"b\\c') == 'a\\"b\\\\c'
+
+
+def test_toml_escape_control_chars_keep_toml_parseable():
+    # A value with a newline/CR must round-trip through a basic string, not break it.
+    raw = 'x"\n\r\tinjected = "y'
+    rendered = f'v = "{toml_escape(raw)}"'
+    assert tomllib.loads(rendered)["v"] == raw  # tab stays literal; newline/CR escaped


### PR DESCRIPTION
## Summary

This PR adds a local capacity manager for `freellmpool`.

Goal: help users know which free-tier LLM providers are usable now, which ones are missing keys, which ones are near quota, and which external providers could be added next.

The logic stays local-first:
- local `providers.toml` remains the source of truth for routing
- external provider data is advisory only
- no account creation
- no email automation
- no bypass of provider limits

## Why

`freellmpool` pools many free LLM providers, but capacity changes during the day.

Before this PR, users could run the proxy, but they had no simple way to answer:

- How many providers are usable right now?
- Which provider keys are missing?
- Which provider is close to daily quota?
- Which external free providers could be added?
- Are configured providers actually responding?

This PR adds that workflow.

## Main Flow

The main command is:

```bash
freellmpool capacity status --target 5 --all
```

It does this:

1. Loads local executable providers from `providers.toml`.
2. Reads env/config to know which providers are configured.
3. Reads local quota counters.
4. Reads optional key inventory metadata.
5. Syncs an external advisory catalog from:
   `mnfst/awesome-free-llm-apis`
6. Matches external catalog providers against local providers.
7. Prints usable providers first.
8. Shows missing providers and external-only candidates.

External catalog cache path:

```text
~/.config/freellmpool/provider_catalog.json
```

Local provider config still controls real routing. External data is not trusted directly for proxy execution.

## Capacity Logic

New file:

```text
src/freellmpool/capacity.py
```

For each provider, the report computes:

- configured or missing
- enabled model count
- local usage today
- daily quota hint from model `rpd`
- optional key expiry from inventory
- status
- reason

Statuses:

- `healthy`: configured and usable from local state
- `low_quota`: usage above 80% of daily quota hint
- `exhausted`: usage reached quota hint
- `invalid_key`: inventory says key expired
- `missing`: provider exists locally but is not configured

Sorting favors:

1. healthy providers
2. low quota providers
3. exhausted/invalid providers
4. missing providers
5. higher quota hints
6. more enabled models

## External Catalog Logic

New file:

```text
src/freellmpool/catalog.py
```

This syncs provider metadata from the external repo @mnfst /awesome-free-llm-apis :

```text
https://raw.githubusercontent.com/mnfst/awesome-free-llm-apis/main/data.json
```

It extracts:

- provider name
- signup URL
- base URL
- model count
- best RPD/RPM/TPD hints
- generosity score

Then it matches external providers to local providers by:

- base URL
- slugified provider id/label
- known aliases like `google-gemini -> gemini`, `nvidia-nim -> nvidia`

External-only providers can be shown as candidates. They are not used by the router until imported into user config.

## Key Inventory

New file:

```text
src/freellmpool/key_inventory.py
```

Adds optional local metadata for manually-created keys.

Default path:

```text
~/.config/freellmpool/keys.toml
```

Example:

```toml
[[keys]]
provider = "groq"
env_var = "GROQ_API_KEY"
label = "personal-main"
created_at = "2026-06-05"
expires_at = "2026-12-31"
commercial_allowed = true
notes = "created manually"
```

This is metadata only. Raw API keys should stay in env vars, config files, shell profiles, or secret managers.

It also includes secret redaction helpers for notes.

## New CLI Commands

### Capacity

```bash
freellmpool capacity status --target 5
freellmpool capacity status --target 5 --all
freellmpool capacity status --no-catalog-sync
```

Shows local capacity and optional external candidates.

### Keys

```bash
freellmpool keys status --target 5
freellmpool keys checklist --target 5
freellmpool keys add -p groq
```

Helps users manually add provider keys and track metadata.

### Catalog

```bash
freellmpool catalog sync
freellmpool catalog status
```

Syncs and inspects the advisory external provider catalog.

### Provider Health

```bash
freellmpool providers health
freellmpool providers health -p groq,cerebras
freellmpool providers health --timeout 10
```

Sends one tiny request per configured provider and reports latency/failure.

Different from `capacity status`: this touches the network.

## Dashboard

The local proxy dashboard now includes capacity status.

```text
http://127.0.0.1:8080/dashboard
```

It shows:

- healthy providers count
- provider capacity table
- quota usage hints
- status reason
- existing request/cache/savings metrics

## Docs

Added:

```text
docs/CAPACITY.md
```

It documents:

- main commands
- status meanings
- key inventory format
- health checks
- dashboard
- recommended workflow
- limits

## Small Benchmark Improvement

Benchmark failures now include exception details, not only exception class.

Before:

```text
TimeoutError
```

After:

```text
TimeoutError: request timed out
```

## Tests

Added tests for:

- capacity status computation
- capacity sorting
- checklist logic
- expired key handling
- key inventory parsing
- secret redaction
- external catalog parsing
- external provider import
- healthcheck rendering
- healthcheck execution
- CLI smoke paths
- dashboard capacity rendering

Validation:

```bash
ruff check src tests
pytest
```

Result:

```text
All checks passed
170 passed
```

## Safety Notes

This PR does not automate account creation.

It does not send emails.

It does not bypass rate limits.

It does not route through providers from the external repo unless the provider is added to local config.
```

## Summary by Sourcery

Introduce local-first LLM capacity management with CLI commands, dashboard integration, and external catalog support to help users understand and improve free-tier provider availability.

New Features:
- Add capacity reporting over configured providers, including health, quota usage, and key metadata, exposed via new CLI subcommands and the proxy dashboard.
- Introduce a key inventory system and helpers to safely track, append, and store metadata about manually managed provider API keys.
- Integrate an advisory external provider catalog sourced from mnfst/awesome-free-llm-apis, with sync, inspection, and import capabilities for local configuration.
- Add a provider healthcheck utility that runs lightweight test calls across providers and renders a summarized status table.

Enhancements:
- Improve benchmark error reporting by including exception messages alongside the exception type.
- Extend the dashboard UI with capacity counters and a capacity table summarizing provider health and usage.

Documentation:
- Add CAPACITY.md documenting capacity management commands, key inventory format, health checks, dashboard usage, and workflow.

Tests:
- Add tests covering capacity computation and sorting, key inventory parsing and grouping, external catalog parsing and import, healthcheck rendering and execution, CLI smoke tests, and dashboard capacity output.