### PR TITLE
Balance routing by provider and add Claude Code gateway bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ freellmpool code claude                 # prints the one-line setup for Claude C
 # (also: codex, aider, cline, continue, cursor, opencode)
 ```
 
+Claude Code gateway mode can also be launched directly:
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:8080 \
+ANTHROPIC_AUTH_TOKEN=dummy \
+ANTHROPIC_MODEL=auto \
+ANTHROPIC_SMALL_FAST_MODEL=auto \
+CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 \
+claude
+```
+
 Your existing OpenAI/Anthropic apps work the same way — set `OPENAI_BASE_URL` (or
 `ANTHROPIC_BASE_URL`) to the proxy and keep your code unchanged.
 
@@ -276,8 +287,10 @@ or down, and tracks per-day usage so load spreads across tiers.
 
 **Can I run Claude Code or Codex on free models?** Yes — the proxy speaks both the
 OpenAI and Anthropic APIs. Set `OPENAI_BASE_URL` or `ANTHROPIC_BASE_URL` to the proxy
-and run Codex, Claude Code, aider, Cline, Continue, or Cursor unchanged. See
-`freellmpool code <agent>`. (Claude Code path is experimental: text + tools, no vision.)
+and run Codex, Claude Code, aider, Cline, Continue, or Cursor unchanged. For Claude
+Code, set `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` so `/v1/models` is discovered
+through the Anthropic bridge. See `freellmpool code <agent>`. (Claude Code path is
+experimental: text + tools, no vision.)
 
 **Do I need an API key?** No — Pollinations and OVHcloud work with no key, so a fresh
 install answers immediately. Add free keys for the other providers for more models and

--- a/README.md
+++ b/README.md
@@ -214,15 +214,18 @@ model aliases, and settings instead of env vars.
 ## How routing works
 
 For each request, freellmpool builds the list of `(provider, model)` pairs you
-have access to, orders them least-used-first (so load spreads across tiers), and
-tries them in order until one returns a non-empty result. A provider that returns
-a 429 is set aside for a cooldown window. Daily counts are kept in
-`~/.config/freellmpool/quota.json` and reset at UTC midnight.
+have access to, then orders providers least-used-first and picks a least-used
+model inside that provider. This keeps providers with large catalogs, like
+NVIDIA, from receiving more traffic only because they expose more models. A
+provider that returns a 429 is set aside for a cooldown window. Daily counts are
+kept in `~/.config/freellmpool/quota.json` and reset at UTC midnight.
 
-Every call records latency and success per provider. A provider that is currently
-failing sinks to the back automatically; with `FREELLMPOOL_ROUTING=fast` the
-fastest measured provider goes first instead. `freellmpool benchmark` warms these
-metrics on demand.
+Every call records latency and success per model target. A provider whose targets
+are currently failing sinks to the back automatically; with
+`FREELLMPOOL_ROUTING=fast` the fastest measured provider goes first instead.
+`freellmpool benchmark` warms these metrics on demand. To restore the old
+per-model balancing behavior, set `FREELLMPOOL_ROUTING=legacy` or
+`FREELLMPOOL_ROUTING=model`.
 
 **Context windows.** Free models often have small context windows. freellmpool
 never truncates your input; instead, when a model rejects a request as too long,

--- a/config.toml.example
+++ b/config.toml.example
@@ -17,4 +17,5 @@
 
 [settings]
 # cooldown_seconds = 60     # how long to deprioritize a 429'd provider
+# routing = "fair"          # fair provider balance; fast; legacy/model for per-model balance
 # proxy_key = "secret"      # require this Bearer token on the proxy

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,8 +63,10 @@ client with three adapters, a quota counter, and a proxy that wraps the router.
 
 1. `Pool.chat(messages, ...)` builds candidate `(provider, model)` targets,
    filtered by any `model`/`providers` constraints.
-2. Targets are sorted least-used-today first; pools over their daily hint sink
-   to the back but remain reachable as a last resort.
+2. Providers are sorted least-used-today first, then targets inside each provider
+   are sorted least-used-first. Pools over their daily hint sink to the back but
+   remain reachable as a last resort. `FREELLMPOOL_ROUTING=legacy` restores the
+   old per-target ordering.
 3. For each target: call the provider; on a non-empty success, record one unit
    of quota and return the normalized `Reply`.
 4. If every target fails, raise `AllProvidersExhausted` with the per-target

--- a/docs/free-claude-api.html
+++ b/docs/free-claude-api.html
@@ -37,7 +37,10 @@ speaking the Anthropic API unchanged.</strong></p>
 <pre><code>pip install freellmpool
 freellmpool proxy
 export ANTHROPIC_BASE_URL=http://localhost:8080
-export ANTHROPIC_API_KEY=anything   # ignored
+export ANTHROPIC_AUTH_TOKEN=dummy
+export ANTHROPIC_MODEL=auto
+export ANTHROPIC_SMALL_FAST_MODEL=auto
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
 claude</code></pre>
 <p>Run <code>freellmpool code claude</code> to print this setup. See the full
 <a href="run-coding-agents-on-free-models.html">coding-agents guide</a> for Codex, Aider, Cline and more.</p>

--- a/docs/use-multiple-free-llm-apis.html
+++ b/docs/use-multiple-free-llm-apis.html
@@ -56,10 +56,11 @@ reply = Pool.from_default_config().ask("Write a haiku about sqlite")
 #   freellmpool proxy  →  OPENAI_BASE_URL=http://localhost:8080/v1</code></pre>
 
 <h2>How routing works</h2>
-<p>freellmpool orders the providers you have access to least-used-first (so load spreads across tiers),
-tries them until one returns a non-empty result, and sets a rate-limited provider aside for a cooldown.
-Daily counts reset at UTC midnight. Set <code>FREELLMPOOL_ROUTING=fast</code> to prefer the lowest-latency
-provider instead.</p>
+<p>freellmpool orders the providers you have access to least-used-first, then picks a least-used model
+inside that provider. This keeps large catalogs from getting extra traffic just because they expose more
+models. It tries candidates until one returns a non-empty result, and sets a rate-limited provider aside
+for a cooldown. Daily counts reset at UTC midnight. Set <code>FREELLMPOOL_ROUTING=fast</code> to prefer the
+lowest-latency provider, or <code>FREELLMPOOL_ROUTING=legacy</code> to restore per-model balancing.</p>
 
 <h2>FAQ</h2>
 <h3>How do I use Groq and Cerebras and Gemini together?</h3>

--- a/src/freellmpool/agents.py
+++ b/src/freellmpool/agents.py
@@ -11,10 +11,13 @@ AGENTS: dict[str, dict] = {
         "label": "Claude Code",
         "steps": [
             "freellmpool proxy --port 8080",
-            "export ANTHROPIC_BASE_URL=http://localhost:8080 ANTHROPIC_API_KEY=anything",
-            "claude   # now running on free models via the /v1/messages shim",
+            "export ANTHROPIC_BASE_URL=http://localhost:8080",
+            "export ANTHROPIC_AUTH_TOKEN=dummy ANTHROPIC_API_KEY=dummy",
+            "export ANTHROPIC_MODEL=auto ANTHROPIC_SMALL_FAST_MODEL=auto",
+            "export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1",
+            "claude   # now running on freellmpool via the /v1/messages bridge",
         ],
-        "note": "Experimental: routes Claude Code's Anthropic API to free models.",
+        "note": "Pin a model with ANTHROPIC_MODEL=provider/model, e.g. alibaba_cloud_model_studio/qwen3-plus.",
     },
     "codex": {
         "label": "OpenAI Codex CLI",

--- a/src/freellmpool/config.py
+++ b/src/freellmpool/config.py
@@ -75,6 +75,21 @@ def resolve_alias(name: str, env: dict[str, str] | None = None) -> str:
     return name
 
 
+def known_aliases(env: dict[str, str] | None = None) -> list[str]:
+    """Model aliases understood by :func:`resolve_alias`.
+
+    Used by gateway model discovery so clients can choose a well-known Claude or
+    OpenAI model name and still have the proxy resolve it to the free pool.
+    """
+    env = env if env is not None else dict(os.environ)
+    aliases = set(_DEFAULT_ALIASES)
+    aliases.update(str(k) for k in load_config_file(env).get("aliases", {}))
+    for key in env:
+        if key.startswith(_ALIAS_ENV_PREFIX):
+            aliases.add(key[len(_ALIAS_ENV_PREFIX) :])
+    return sorted(aliases)
+
+
 def _user_catalog_path() -> Path | None:
     override = os.environ.get("FREELLMPOOL_CONFIG")
     if override:

--- a/src/freellmpool/config.py
+++ b/src/freellmpool/config.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import os
 import re
 import tomllib
+from functools import lru_cache
 from pathlib import Path
 
 from .models import Model, Provider
@@ -82,12 +83,41 @@ def known_aliases(env: dict[str, str] | None = None) -> list[str]:
     OpenAI model name and still have the proxy resolve it to the free pool.
     """
     env = env if env is not None else dict(os.environ)
+    return list(_known_aliases_cached(_alias_cache_key(env)))
+
+
+def _alias_cache_key(env: dict[str, str]) -> tuple:
+    """Stable cache key for alias discovery.
+
+    Only alias-related env vars and config-file path metadata affect
+    ``known_aliases``. File mtime/size keep gateway discovery fresh after config
+    edits without re-reading TOML on every `/v1/models` request.
+    """
+    path = _config_file_path(env)
+    try:
+        stat = path.stat() if path is not None else None
+    except OSError:
+        stat = None
+    config_sig = (
+        str(path) if path is not None else "",
+        stat.st_mtime_ns if stat is not None else 0,
+        stat.st_size if stat is not None else 0,
+    )
+    env_aliases = tuple(
+        sorted((k, v) for k, v in env.items() if k.startswith(_ALIAS_ENV_PREFIX))
+    )
+    return config_sig + (env_aliases,)
+
+
+@lru_cache(maxsize=64)
+def _known_aliases_cached(cache_key: tuple) -> tuple[str, ...]:
+    path_str, _, _, env_aliases = cache_key
     aliases = set(_DEFAULT_ALIASES)
-    aliases.update(str(k) for k in load_config_file(env).get("aliases", {}))
-    for key in env:
-        if key.startswith(_ALIAS_ENV_PREFIX):
-            aliases.add(key[len(_ALIAS_ENV_PREFIX) :])
-    return sorted(aliases)
+    if path_str:
+        cfg = load_config_file({"FREELLMPOOL_CONFIG_FILE": path_str})
+        aliases.update(str(k) for k in cfg.get("aliases", {}))
+    aliases.update(k[len(_ALIAS_ENV_PREFIX) :] for k, _ in env_aliases)
+    return tuple(sorted(aliases))
 
 
 def _user_catalog_path() -> Path | None:

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -26,9 +26,10 @@ import json
 import os
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlsplit
 
 from .anthropic_shim import estimate_tokens, reply_to_message, reply_to_sse, request_to_chat
-from .config import resolve_alias
+from .config import known_aliases, resolve_alias
 from .errors import (
     AllProvidersExhausted,
     ContextWindowExceeded,
@@ -47,6 +48,34 @@ def _model_ids(pool: Pool) -> list[str]:
             if m.enabled:
                 ids.append(f"{provider.id}/{m.name}")
     return ids
+
+
+def _openai_models_payload(pool: Pool) -> dict:
+    data = [
+        {"id": mid, "object": "model", "owned_by": "freellmpool"}
+        for mid in _model_ids(pool)
+    ]
+    return {"object": "list", "data": data}
+
+
+def _anthropic_models_payload(pool: Pool) -> dict:
+    ids = _model_ids(pool)
+    ids.extend(a for a in known_aliases(pool.env) if a.startswith("claude-") and a not in ids)
+    data = [
+        {
+            "type": "model",
+            "id": mid,
+            "display_name": mid,
+            "created_at": "2024-01-01T00:00:00Z",
+        }
+        for mid in ids
+    ]
+    return {
+        "data": data,
+        "has_more": False,
+        "first_id": ids[0] if ids else None,
+        "last_id": ids[-1] if ids else None,
+    }
 
 
 def make_handler(pool: Pool, api_key: str | None = None):
@@ -92,6 +121,17 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 return True
             return hmac.compare_digest(self.headers.get("x-api-key", ""), api_key)
 
+        def _wants_anthropic_models(self) -> bool:
+            """Claude Code gateway model discovery calls Anthropic's model list
+            shape on the same `/v1/models` route OpenAI clients use."""
+            headers = {k.lower(): v.lower() for k, v in self.headers.items()}
+            user_agent = headers.get("user-agent", "")
+            return (
+                "anthropic-version" in headers
+                or "anthropic-beta" in headers
+                or "claude" in user_agent
+            )
+
         def do_GET(self) -> None:  # noqa: N802
             try:
                 self._do_get()
@@ -105,7 +145,8 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 self._error(500, f"internal error: {type(exc).__name__}", "internal_error")
 
         def _do_get(self) -> None:
-            if self.path.rstrip("/") == "/healthz":
+            path = urlsplit(self.path).path.rstrip("/") or "/"
+            if path == "/healthz":
                 self._send(200, {"status": "ok"})
                 return
             # /dashboard and /v1/models leak inventory/usage, so gate them behind
@@ -113,7 +154,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
             if not self._authorized():
                 self._error(401, "invalid or missing API key", "invalid_api_key")
                 return
-            if self.path.rstrip("/") in ("/dashboard", "/"):
+            if path in ("/dashboard", "/"):
                 html = _dashboard_html(pool).encode("utf-8")
                 self.send_response(200)
                 self.send_header("Content-Type", "text/html; charset=utf-8")
@@ -121,17 +162,18 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 self.end_headers()
                 self.wfile.write(html)
                 return
-            if self.path.rstrip("/").endswith("/v1/models") or self.path.rstrip("/") == "/models":
-                data = [
-                    {"id": mid, "object": "model", "owned_by": "freellmpool"}
-                    for mid in _model_ids(pool)
-                ]
-                self._send(200, {"object": "list", "data": data})
+            if path.endswith("/v1/models") or path == "/models":
+                payload = (
+                    _anthropic_models_payload(pool)
+                    if self._wants_anthropic_models()
+                    else _openai_models_payload(pool)
+                )
+                self._send(200, payload)
                 return
             self._error(404, f"unknown route {self.path}", "not_found")
 
         def _do_post(self) -> None:
-            route = self.path.rstrip("/")
+            route = urlsplit(self.path).path.rstrip("/")
             is_chat = route.endswith("/v1/chat/completions") or route == "/chat/completions"
             is_responses = route.endswith("/v1/responses") or route == "/responses"
             is_embeddings = route.endswith("/v1/embeddings") or route == "/embeddings"

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -74,6 +74,17 @@ class Target:
         return f"{self.provider.id}/{self.model}"
 
 
+@dataclass
+class _ProviderOrderStats:
+    """Precomputed routing stats for one provider in a candidate set."""
+
+    targets: list[Target]
+    used: int = 0
+    all_over: bool = True
+    all_failing: bool = True
+    best_score: float = float("inf")
+
+
 class Pool:
     def __init__(
         self,
@@ -302,21 +313,18 @@ class Pool:
             key = legacy_fast_key if self.routing == "model-fast" else legacy_fair_key
             return sorted(targets, key=key)
 
-        targets_by_provider: dict[str, list[Target]] = {}
+        by_provider: dict[str, _ProviderOrderStats] = {}
         for target in targets:
-            targets_by_provider.setdefault(target.provider.id, []).append(target)
-
-        def provider_used(provider_id: str) -> int:
-            prefix = f"{provider_id}::"
-            return sum(int(v) for k, v in snap.items() if k.startswith(prefix))
-
-        def provider_over(provider_id: str) -> int:
-            provider_targets = targets_by_provider[provider_id]
-            return 1 if provider_targets and all(over_of(t) for t in provider_targets) else 0
-
-        def provider_failing(provider_id: str) -> int:
-            provider_targets = targets_by_provider[provider_id]
-            return 1 if provider_targets and all(metrics.failing(t.name) for t in provider_targets) else 0
+            provider_id = target.provider.id
+            stats = by_provider.setdefault(provider_id, _ProviderOrderStats(targets=[]))
+            stats.targets.append(target)
+            target_used = used_of(target)
+            target_over = over_of(target)
+            target_failing = metrics.failing(target.name)
+            stats.used += target_used
+            stats.all_over = stats.all_over and bool(target_over)
+            stats.all_failing = stats.all_failing and target_failing
+            stats.best_score = min(stats.best_score, metrics.score(target.name))
 
         def target_fair_key(t: Target) -> tuple[int, int, int]:
             return (over_of(t), 1 if metrics.failing(t.name) else 0, used_of(t))
@@ -327,26 +335,27 @@ class Pool:
         if self.routing == "fast":
 
             def provider_fast_key(provider_id: str) -> tuple[int, float, int]:
-                scores = [metrics.score(t.name) for t in targets_by_provider[provider_id]]
-                return (provider_over(provider_id), min(scores), provider_used(provider_id))
+                stats = by_provider[provider_id]
+                return (1 if stats.all_over else 0, stats.best_score, stats.used)
 
-            provider_order = sorted(targets_by_provider, key=provider_fast_key)
+            provider_order = sorted(by_provider, key=provider_fast_key)
             target_key = target_fast_key
         else:
 
             def provider_fair_key(provider_id: str) -> tuple[int, int, int]:
+                stats = by_provider[provider_id]
                 return (
-                    provider_over(provider_id),
-                    provider_failing(provider_id),
-                    provider_used(provider_id),
+                    1 if stats.all_over else 0,
+                    1 if stats.all_failing else 0,
+                    stats.used,
                 )
 
-            provider_order = sorted(targets_by_provider, key=provider_fair_key)
+            provider_order = sorted(by_provider, key=provider_fair_key)
             target_key = target_fair_key
 
         ordered: list[Target] = []
         for provider_id in provider_order:
-            ordered.extend(sorted(targets_by_provider[provider_id], key=target_key))
+            ordered.extend(sorted(by_provider[provider_id].targets, key=target_key))
         return ordered
 
     # ---- the main entrypoint ------------------------------------------

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -101,9 +101,14 @@ class Pool:
         self.cooldown_seconds = cooldown_seconds
         self._clock = clock or time.monotonic
         self.metrics = metrics or Metrics()
-        # "fair"  — least-used-first (spread load), failing targets sink to the back.
-        # "fast"  — lowest measured latency / failure penalty first, then least-used.
-        self.routing = routing if routing in ("fair", "fast") else "fair"
+        # "fair"  — least-used provider first, then least-used model in provider.
+        # "fast"  — lowest measured provider latency / failure penalty first.
+        # "legacy"/"model" keep the old per-(provider, model) balancing behavior.
+        self.routing = (
+            routing
+            if routing in ("fair", "fast", "legacy", "model", "model-fast")
+            else "fair"
+        )
         self._on_event = on_event
         # provider_id -> monotonic time until which to deprioritize after a 429
         self._cooldown_until: dict[str, float] = {}
@@ -267,13 +272,13 @@ class Pool:
     def _order(self, targets: list[Target]) -> list[Target]:
         """Order candidate targets for failover.
 
-        ``fair`` (default): least-used-first, so load spreads across free tiers.
-        Targets over their daily budget hint, or measured to be currently failing,
-        sink to the back (still tried if everything else fails).
+        ``fair`` (default): least-used provider first, then least-used model inside
+        that provider. This prevents wide catalogs from getting extra traffic only
+        because they expose more models.
 
-        ``fast``: lowest measured latency / failure penalty first (then least-used).
-        Targets with no measurements yet are treated as neutral so they still get
-        sampled. Either way the ordering is a hint — failover still reaches all.
+        ``fast``: lowest measured provider latency / failure penalty first, then
+        least-used provider. ``legacy``/``model`` preserve the previous per-target
+        balancing. Either way the ordering is a hint — failover still reaches all.
         """
 
         # One snapshot instead of a locked read per target (matters for large catalogs).
@@ -286,18 +291,63 @@ class Pool:
         def over_of(t: Target) -> int:
             return 1 if (t.rpd > 0 and used_of(t) >= t.rpd) else 0
 
-        if self.routing == "fast":
+        if self.routing in ("legacy", "model", "model-fast"):
 
-            def fast_key(t: Target) -> tuple[int, float, int]:
+            def legacy_fast_key(t: Target) -> tuple[int, float, int]:
                 return (over_of(t), metrics.score(t.name), used_of(t))
 
-            return sorted(targets, key=fast_key)
+            def legacy_fair_key(t: Target) -> tuple[int, int, int]:
+                return (over_of(t), 1 if metrics.failing(t.name) else 0, used_of(t))
 
-        def fair_key(t: Target) -> tuple[int, int, int]:
-            # over-budget, then known-failing, then least-used.
+            key = legacy_fast_key if self.routing == "model-fast" else legacy_fair_key
+            return sorted(targets, key=key)
+
+        targets_by_provider: dict[str, list[Target]] = {}
+        for target in targets:
+            targets_by_provider.setdefault(target.provider.id, []).append(target)
+
+        def provider_used(provider_id: str) -> int:
+            prefix = f"{provider_id}::"
+            return sum(int(v) for k, v in snap.items() if k.startswith(prefix))
+
+        def provider_over(provider_id: str) -> int:
+            provider_targets = targets_by_provider[provider_id]
+            return 1 if provider_targets and all(over_of(t) for t in provider_targets) else 0
+
+        def provider_failing(provider_id: str) -> int:
+            provider_targets = targets_by_provider[provider_id]
+            return 1 if provider_targets and all(metrics.failing(t.name) for t in provider_targets) else 0
+
+        def target_fair_key(t: Target) -> tuple[int, int, int]:
             return (over_of(t), 1 if metrics.failing(t.name) else 0, used_of(t))
 
-        return sorted(targets, key=fair_key)
+        def target_fast_key(t: Target) -> tuple[int, float, int]:
+            return (over_of(t), metrics.score(t.name), used_of(t))
+
+        if self.routing == "fast":
+
+            def provider_fast_key(provider_id: str) -> tuple[int, float, int]:
+                scores = [metrics.score(t.name) for t in targets_by_provider[provider_id]]
+                return (provider_over(provider_id), min(scores), provider_used(provider_id))
+
+            provider_order = sorted(targets_by_provider, key=provider_fast_key)
+            target_key = target_fast_key
+        else:
+
+            def provider_fair_key(provider_id: str) -> tuple[int, int, int]:
+                return (
+                    provider_over(provider_id),
+                    provider_failing(provider_id),
+                    provider_used(provider_id),
+                )
+
+            provider_order = sorted(targets_by_provider, key=provider_fair_key)
+            target_key = target_fair_key
+
+        ordered: list[Target] = []
+        for provider_id in provider_order:
+            ordered.extend(sorted(targets_by_provider[provider_id], key=target_key))
+        return ordered
 
     # ---- the main entrypoint ------------------------------------------
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from freellmpool.config import configured_providers, load_catalog, resolve_alias
+from freellmpool.config import configured_providers, known_aliases, load_catalog, resolve_alias
 
 
 def test_alias_default_maps_to_auto():
@@ -18,6 +18,11 @@ def test_alias_unknown_passthrough():
 def test_alias_env_override():
     env = {"FREELLMPOOL_ALIAS_GPT_4O_MINI": "groq/llama-3.3-70b-versatile"}
     assert resolve_alias("gpt-4o-mini", env) == "groq/llama-3.3-70b-versatile"
+
+
+def test_known_aliases_include_env_alias():
+    env = {"FREELLMPOOL_ALIAS_MY_MODEL": "groq/llama-3.3-70b-versatile"}
+    assert "MY_MODEL" in known_aliases(env)
 
 
 def test_packaged_catalog_loads():

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from freellmpool.config import effective_env, load_config_file, resolve_alias, settings
+from freellmpool.config import (
+    effective_env,
+    known_aliases,
+    load_config_file,
+    resolve_alias,
+    settings,
+)
 
 
 def _write(tmp_path, body: str) -> dict[str, str]:
@@ -26,6 +32,11 @@ def test_keys_fill_under_env(tmp_path):
 def test_config_alias(tmp_path):
     env = _write(tmp_path, '[aliases]\n"gpt-4o-mini" = "groq/llama-3.1-8b-instant"\n')
     assert resolve_alias("gpt-4o-mini", env) == "groq/llama-3.1-8b-instant"
+
+
+def test_known_aliases_include_config_alias(tmp_path):
+    env = _write(tmp_path, '[aliases]\n"my-model" = "groq/llama-3.1-8b-instant"\n')
+    assert "my-model" in known_aliases(env)
 
 
 def test_env_alias_beats_config(tmp_path):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -54,6 +54,28 @@ def test_models_route(server):
     assert any(i.startswith("alpha/") for i in ids)
 
 
+def test_models_route_accepts_query_string(server):
+    with urllib.request.urlopen(server + "/v1/models?limit=100") as resp:  # noqa: S310
+        body = json.load(resp)
+    assert body["object"] == "list"
+    assert any(m["id"] == "auto" for m in body["data"])
+
+
+def test_anthropic_model_discovery_shape(server):
+    req = urllib.request.Request(
+        server + "/v1/models?limit=100",
+        headers={"anthropic-version": "2023-06-01", "User-Agent": "claude-code"},
+    )
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
+        body = json.load(resp)
+    assert body["has_more"] is False
+    assert body["data"][0]["type"] == "model"
+    assert body["data"][0]["id"] == "auto"
+    assert body["data"][0]["display_name"] == "auto"
+    ids = {m["id"] for m in body["data"]}
+    assert "claude-3-5-haiku-latest" in ids
+
+
 def test_dashboard(server):
     with urllib.request.urlopen(server + "/dashboard") as resp:  # noqa: S310
         assert resp.status == 200
@@ -296,6 +318,19 @@ def test_auth_required_on_all_post_routes(providers, env, quota):
     finally:
         httpd.shutdown()
         httpd.server_close()
+
+
+def test_anthropic_messages_route_accepts_query_string(server):
+    status, body = _post_json(
+        server + "/v1/messages?beta=true",
+        {
+            "model": "claude-3-5-sonnet",
+            "max_tokens": 10,
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert status == 200
+    assert body["type"] == "message"
 
 
 def test_gemini_adapter_via_proxy(providers, env, quota):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -19,6 +19,22 @@ def test_fair_default_is_least_used(providers, env, quota):
     assert "beta/beta-1" in order
 
 
+def test_fair_default_balances_by_provider_before_model(providers, env, quota):
+    quota.record("alpha", "alpha-small", 1)
+    pool = Pool(providers, quota=quota, env=env, post=make_post({}))
+    order = _names(pool, include=["alpha", "beta"])
+
+    assert order.index("beta/beta-1") < order.index("alpha/alpha-big")
+
+
+def test_legacy_routing_balances_by_model(providers, env, quota):
+    quota.record("alpha", "alpha-small", 1)
+    pool = Pool(providers, quota=quota, env=env, post=make_post({}), routing="legacy")
+    order = _names(pool, include=["alpha", "beta"])
+
+    assert order.index("alpha/alpha-big") < order.index("beta/beta-1")
+
+
 def test_fair_sinks_a_failing_target(providers, env, quota):
     pool = Pool(providers, quota=quota, env=env, post=make_post({}))
     # make beta look broken


### PR DESCRIPTION
## Summary

This PR changes default routing to balance usage by provider first, then by model inside that provider. It prevents providers with large model catalogs, such as NVIDIA, from receiving disproportionate traffic only because they expose more models.

It also adds a Claude Code gateway bridge improvement so Claude Code can discover models and run through freellmpool using Anthropic-compatible environment variables.

## Changes

- Default `fair` routing now balances by provider usage before model usage.
- Added legacy model-level routing via:
  - `FREELLMPOOL_ROUTING=legacy`
  - `FREELLMPOOL_ROUTING=model`
- Added `model-fast` for previous fast per-model behavior.
- Updated routing docs and `config.toml.example`.
- Added Anthropic-shaped `/v1/models` discovery for Claude Code gateway mode.
- Added support for query strings on `/v1/models` and `/v1/messages`.
- Added Claude aliases to gateway model discovery.
- Updated `freellmpool code claude` with:
  - `ANTHROPIC_AUTH_TOKEN`
  - `ANTHROPIC_MODEL`
  - `ANTHROPIC_SMALL_FAST_MODEL`
  - `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY`

## Why

Previous routing balanced by `(provider, model)` target. Providers with many models received more total traffic than providers with smaller catalogs. Provider-first balancing makes usage fairer across actual providers while preserving model-level choice inside each provider.

Claude Code gateway mode also needed better discovery compatibility. The proxy now returns Anthropic-style model discovery when Claude/Anthropic headers are detected.

## Testing

- `pytest`
- `ruff check src/freellmpool/proxy.py src/freellmpool/agents.py src/freellmpool/config.py tests/test_proxy.py`
- Manual smoke test with Claude Code:

```bash
ANTHROPIC_BASE_URL="http://127.0.0.1:18080" \
ANTHROPIC_AUTH_TOKEN="dummy" \
ANTHROPIC_MODEL="auto" \
ANTHROPIC_SMALL_FAST_MODEL="auto" \
CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 \
claude -p "reply exactly ok"

## Summary by Sourcery

Adjust routing to balance usage by provider before model while preserving legacy behaviors, and enhance Claude Code gateway compatibility and discovery.

New Features:
- Add provider-first routing strategy with optional legacy per-model and model-fast routing modes.
- Expose Anthropic-compatible /v1/models discovery, including Claude aliases, when Anthropic or Claude headers are present.
- Support query strings on /v1/models and /v1/messages routes for better client compatibility.
- Add a helper to enumerate known model aliases for use in gateway model discovery.

Enhancements:
- Refine routing documentation and architecture docs to describe provider-level balancing and configuration options.
- Update Claude Code agent setup and examples to use Anthropic-style environment variables and gateway model discovery.

Documentation:
- Expand README and HTML docs with updated routing behavior, Claude Code gateway launch instructions, and Anthropic bridge usage details.

Tests:
- Add routing tests to verify provider-before-model ordering and legacy per-model behavior.
- Add proxy tests for query-string handling, Anthropic model discovery payload shape, and messages endpoint behavior in gateway mode.