### PR TITLE
Degradation-aware (quality) routing with benchmark-scored capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,25 @@ per-model balancing behavior, set `FREELLMPOOL_ROUTING=legacy` or
 `FREELLMPOOL_ROUTING=model` (or `FREELLMPOOL_ROUTING=model-fast` for the old
 per-model fastest-first ordering).
 
+**Quality routing (`FREELLMPOOL_ROUTING=quality`).** Free tiers' strongest models
+have the smallest daily caps, so a naive pool gets weaker as the day fills. Quality
+routing matches each prompt's *difficulty* to each model's *capability*: hard
+prompts (long input, code, reasoning cues) go to the strongest available model, and
+easy ones go to lightweight models — which rations scarce strong-model quota so the
+pool stays sharp for longer. Capability is grounded in real benchmark data, not
+guessed from names; models no benchmark lists fall back to a name heuristic.
+
+The bundled, offline scores come from [LMArena](https://lmarena.ai/) Elo (an
+MIT-licensed snapshot) and the [Aider](https://aider.chat/) code-editing
+leaderboard (Apache-2.0), normalized to a common percentile scale. For much
+broader coverage, run `freellmpool capability sync` with a free
+[Artificial Analysis](https://artificialanalysis.ai/) API key
+(`FREELLMPOOL_AA_API_KEY`) — its Intelligence Index covers most current and
+open-weight models and takes precedence. The fetched AA data is cached locally
+under your own key (never bundled, per AA's terms). `freellmpool capability
+status` shows current coverage. Scores via LMArena and Aider; intelligence index
+via Artificial Analysis when keyed.
+
 **Context windows.** Free models often have small context windows. freellmpool
 never truncates your input; instead, when a model rejects a request as too long,
 it learns that model's limit and stops routing oversized requests there, escalating

--- a/config.toml.example
+++ b/config.toml.example
@@ -17,5 +17,5 @@
 
 [settings]
 # cooldown_seconds = 60     # how long to deprioritize a 429'd provider
-# routing = "fair"          # fair provider balance; fast; legacy/model (per-model); model-fast
+# routing = "fair"          # fair provider balance; fast; quality (match difficulty→capability); legacy/model; model-fast
 # proxy_key = "secret"      # require this Bearer token on the proxy

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -66,7 +66,10 @@ client with three adapters, a quota counter, and a proxy that wraps the router.
 2. Providers are sorted least-used-today first, then targets inside each provider
    are sorted least-used-first. Pools over their daily hint sink to the back but
    remain reachable as a last resort. `FREELLMPOOL_ROUTING=legacy` restores the
-   old per-target ordering.
+   old per-target ordering; `=fast` orders by measured latency; `=quality` orders
+   by benchmark-scored capability matched to the prompt's estimated difficulty
+   (see `capability.py` — strong models for hard prompts, light ones for easy
+   prompts, so scarce strong-model quota is rationed across the day).
 3. For each target: call the provider; on a non-empty success, record one unit
    of quota and return the normalized `Reply`.
 4. If every target fails, raise `AllProvidersExhausted` with the per-target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ packages = ["src/freellmpool"]
 
 [tool.hatch.build.targets.wheel.force-include]
 "src/freellmpool/providers.toml" = "freellmpool/providers.toml"
+"src/freellmpool/capability_scores.json" = "freellmpool/capability_scores.json"
 
 [tool.ruff]
 line-length = 100

--- a/src/freellmpool/aio.py
+++ b/src/freellmpool/aio.py
@@ -18,6 +18,7 @@ import asyncio
 from collections.abc import Awaitable, Callable, Iterable
 
 from . import client as _client
+from .capability import prompt_difficulty
 from .client import (
     _CONNECT_TIMEOUT,
     _THINKING_FLOOR,
@@ -338,7 +339,12 @@ class AsyncPool:
                     cached=True,
                 )
 
-        targets = p._order(p._all_targets(include=provider_list, model=model))
+        difficulty = (
+            prompt_difficulty(messages, max_tokens, tools) if p.routing == "quality" else None
+        )
+        targets = p._order(
+            p._all_targets(include=provider_list, model=model), difficulty=difficulty
+        )
         if not targets:
             raise NoProvidersConfigured("no candidate (provider, model) matched the given filters")
 

--- a/src/freellmpool/capability.py
+++ b/src/freellmpool/capability.py
@@ -24,8 +24,10 @@ import os
 import re
 import urllib.error
 import urllib.request
+from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
+from types import MappingProxyType
 
 from .context import estimate_input_tokens
 
@@ -165,16 +167,16 @@ def _read_scores(path: Path) -> dict[str, float]:
 
 
 @lru_cache(maxsize=8)
-def _table_cached(user_str: str, _user_mtime: int) -> dict[str, float]:
+def _table_cached(user_str: str, _user_mtime: int) -> Mapping[str, float]:
     # Bundle first, user cache overlays it. ``_user_mtime`` is part of the cache
     # key only (not used in the body) so a `capability sync` is picked up without a
-    # restart. Treat the result as read-only (it is shared across callers).
+    # restart. Returned read-only (MappingProxyType) since it is shared across callers.
     table = _read_scores(_BUNDLED_SCORES)
     table.update(_read_scores(Path(user_str)))
-    return table
+    return MappingProxyType(table)
 
 
-def capability_table() -> dict[str, float]:
+def capability_table() -> Mapping[str, float]:
     """Resolved ``{normalized_name: score}`` (bundled overlaid by the user cache).
 
     Cached and mtime-aware, so it is cheap to call once per routing decision.
@@ -187,7 +189,7 @@ def capability_table() -> dict[str, float]:
     return _table_cached(str(user), mtime)
 
 
-def model_capability(name: str, table: dict[str, float] | None = None) -> float:
+def model_capability(name: str, table: Mapping[str, float] | None = None) -> float:
     """Capability of a model on 0–1: benchmark score if known, else name heuristic.
 
     Pass ``table`` (from :func:`capability_table`) to avoid reloading it per call
@@ -336,8 +338,10 @@ def build_capability_table(
     highest-precedence source wins first; failing that, a *same-family, same-size*
     approximation is borrowed (tagged ``…~``). Models nothing covers are omitted —
     they get the name heuristic at runtime. The ``*_scores`` args are raw benchmark
-    dicts (model name → raw number); each is min-max normalized independently.
-    Precedence follows measured correlation with AA (Arena ≈ 0.73 > Aider ≈ 0.60).
+    dicts (model name → raw number); each is percentile-rank normalized independently
+    (see :func:`normalize_scores`), which makes scores from different benchmarks
+    roughly comparable. Precedence follows measured correlation with AA (Arena ≈ 0.73
+    > Aider ≈ 0.60).
     """
     from .config import load_catalog
 
@@ -352,13 +356,24 @@ def build_capability_table(
         _index_source("arena", arena),
         _index_source("aider", aider),
     ]
+    families = set().union(*(r["families"] for r in resolvers))
+
+    # Stems shared by ≥2 distinct *sized* catalog names (e.g. llama-3.1-8b and
+    # llama-3.1-405b both strip to "llama3.1"). The sized→unsized match must not be
+    # used for these, or both sizes would get one (wrong) score.
+    stem_keys: dict[str, set[str]] = {}
+    for name in catalog_names:
+        key = normalize_model_name(name)
+        if key and _largest_params(key) is not None:
+            stem_keys.setdefault(_alnum(_strip_params(key)), set()).add(key)
+    ambiguous_stems = {stem for stem, keys in stem_keys.items() if len(keys) > 1}
 
     table: dict[str, dict] = {}
     for name in catalog_names:
         key = normalize_model_name(name)
         if not key or key in table:
             continue
-        entry = _resolve_capability(key, resolvers)
+        entry = _resolve_capability(key, resolvers, families, ambiguous_stems)
         if entry is not None:
             table[key] = entry
     return table
@@ -378,36 +393,59 @@ def _largest_params(key: str) -> float | None:
     return max(params) if params else None
 
 
+def _leading_family(key: str) -> str:
+    """The leading alpha run of a normalized key (the model family), e.g.
+    ``llama-3.1-8b`` → ``llama``. Empty if shorter than 4 chars."""
+    m = re.match(r"[a-z]+", key)
+    fam = m.group(0) if m else ""
+    return fam if len(fam) >= 4 else ""
+
+
 def _index_source(label: str, norm_scores: dict[str, float]) -> dict:
     """Precompute the lookup indexes for one benchmark source:
     exact-by-name, alphanumeric-core, paramless-core (only entries without a size
-    token, for matching a sized catalog name to an unsized benchmark name), and a
-    (family-token, params) index for same-family/same-size approximation."""
+    token, for matching a sized catalog name to an unsized benchmark name), a
+    (family, params) index for same-family/same-size approximation, and the set of
+    known leading-family tokens (so approximation can't latch onto a stray word)."""
     core: dict[str, float] = {}
     noparam_core: dict[str, float] = {}
     fp: dict[tuple[str, float], float] = {}
+    families: set[str] = set()
     for key, value in norm_scores.items():
         ck = _alnum(key)
         if ck:
             core[ck] = max(core.get(ck, 0.0), value)
+        fam = _leading_family(key)
+        if fam:
+            families.add(fam)
         params = _largest_params(key)
         if params is None:
             if ck:
                 noparam_core[ck] = max(noparam_core.get(ck, 0.0), value)
-        else:
-            for tok in re.findall(r"[a-z]+", key):
-                if len(tok) >= 4:
-                    fp[(tok, params)] = max(fp.get((tok, params), 0.0), value)
-    return {"label": label, "exact": norm_scores, "core": core, "noparam": noparam_core, "fp": fp}
+        elif fam:
+            # Index approximation only under the benchmark entry's own family token.
+            fp[(fam, params)] = max(fp.get((fam, params), 0.0), value)
+    return {
+        "label": label,
+        "exact": norm_scores,
+        "core": core,
+        "noparam": noparam_core,
+        "fp": fp,
+        "families": families,
+    }
 
 
-def _resolve_capability(key: str, resolvers: list[dict]) -> dict | None:
-    """Resolve one normalized model key against ordered resolvers (AA, then Arena).
+def _resolve_capability(
+    key: str, resolvers: list[dict], families: set[str], ambiguous_stems: set[str]
+) -> dict | None:
+    """Resolve one normalized model key against ordered resolvers (AA → Arena → Aider).
 
     Tries, in order: exact name, alphanumeric core, then a sized→unsized core match
-    (so ``mistral-large-3-675b`` finds ``mistral-large-3``). A *direct* match from
-    any source beats a *family+size approximation* from any source — a measured
-    number always wins over a borrowed one. Approximations are tagged ``…~``."""
+    (so ``mistral-large-3-675b`` finds ``mistral-large-3`` — skipped when the stem is
+    shared by multiple catalog sizes, which would conflate them). A *direct* match
+    from any source beats a *same-family/same-size approximation* (tagged ``…~``),
+    and approximation only fires on a token that is a known benchmark family — never
+    a stray word — so an unrelated name can't borrow a family's score."""
     core = _alnum(key)
     np_core = _alnum(_strip_params(key))
     has_params = np_core != core
@@ -416,11 +454,11 @@ def _resolve_capability(key: str, resolvers: list[dict]) -> dict | None:
             return {"score": r["exact"][key], "source": r["label"]}
         if core in r["core"]:
             return {"score": r["core"][core], "source": r["label"]}
-        if has_params and np_core and np_core in r["noparam"]:
+        if has_params and np_core and np_core not in ambiguous_stems and np_core in r["noparam"]:
             return {"score": r["noparam"][np_core], "source": r["label"]}
     params = _largest_params(key)
     if params is not None:
-        tokens = [t for t in re.findall(r"[a-z]+", key) if len(t) >= 4]
+        tokens = [t for t in re.findall(r"[a-z]+", key) if len(t) >= 4 and t in families]
         for r in resolvers:
             for tok in tokens:
                 if (tok, params) in r["fp"]:
@@ -445,6 +483,9 @@ AIDER_URLS = (
     "https://raw.githubusercontent.com/Aider-AI/aider/main/aider/website/_data/edit_leaderboard.yml",
 )
 _MAX_FETCH_BYTES = 8 * 1024 * 1024
+# The AA key may only ever be sent to AA's own host (a misconfigured URL must not
+# leak the secret to a third party).
+_AA_ALLOWED_HOSTS = frozenset({"artificialanalysis.ai", "www.artificialanalysis.ai"})
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -535,8 +576,13 @@ def fetch_aa_scores(
 
     Requires the caller's own AA API key (so AA-licensed data is only ever fetched
     under the user's access, never bundled). Best-effort: tolerates schema drift by
-    scanning common field names; returns {} on any failure.
+    scanning common field names; returns {} on any failure. The key is only ever
+    sent to an AA host (a misconfigured ``url`` cannot leak it elsewhere).
     """
+    from urllib.parse import urlsplit
+
+    if urlsplit(url).hostname not in _AA_ALLOWED_HOSTS:
+        raise ValueError(f"refusing to send the AA key to a non-AA host: {url!r}")
     try:
         data = _get_json(url, timeout=timeout, headers={"x-api-key": api_key})
     except (OSError, ValueError, urllib.error.HTTPError):
@@ -575,6 +621,15 @@ def sync_capability_table(
     arena = fetch_arena_scores(timeout=timeout)
     aider = fetch_aider_scores(timeout=timeout)
     aa = fetch_aa_scores(api_key=aa_api_key, url=aa_url, timeout=timeout) if aa_api_key else {}
+    if aa:
+        # AA data must never be written into the packaged bundle (its terms forbid
+        # redistribution) — only into a user cache outside the package tree.
+        package_dir = Path(__file__).resolve().parent
+        if package_dir == path.resolve().parent or package_dir in path.resolve().parents:
+            raise ValueError(
+                f"refusing to write Artificial Analysis data into the package dir: {path}. "
+                "AA scores may only be cached outside the installed package."
+            )
     table = build_capability_table(aa_scores=aa, arena_scores=arena, aider_scores=aider)
     by_source: dict[str, int] = {}
     for entry in table.values():

--- a/src/freellmpool/capability.py
+++ b/src/freellmpool/capability.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import bisect
 import json
+import math
 import os
 import re
 import urllib.error
@@ -163,11 +164,14 @@ def _read_scores(path: Path) -> dict[str, float]:
         if score is None:
             continue
         try:
-            # Clamp to [0,1] so a corrupt or malicious cache can't inject an
-            # out-of-range capability that would distort routing.
-            out[str(key)] = max(0.0, min(1.0, float(score)))
+            value = float(score)
         except (TypeError, ValueError):
             continue
+        if not math.isfinite(value):  # reject NaN/inf rather than clamp them to 1.0
+            continue
+        # Clamp to [0,1] so a corrupt or malicious cache can't inject an
+        # out-of-range capability that would distort routing.
+        out[str(key)] = max(0.0, min(1.0, value))
     return out
 
 

--- a/src/freellmpool/capability.py
+++ b/src/freellmpool/capability.py
@@ -65,6 +65,7 @@ _VARIANT_SUFFIX_RE = re.compile(
 )
 
 
+@lru_cache(maxsize=8192)
 def normalize_model_name(name: str) -> str:
     """A stable lookup key for a model name, robust to provider/vendor prefixes and
     packaging/date suffixes. The same function keys both the catalog names and the
@@ -154,13 +155,17 @@ def _read_scores(path: Path) -> dict[str, float]:
     except (OSError, json.JSONDecodeError):
         return {}
     raw = data.get("scores", {}) if isinstance(data, dict) else {}
+    if not isinstance(raw, dict):
+        return {}
     out: dict[str, float] = {}
     for key, val in raw.items():
         score = val.get("score") if isinstance(val, dict) else val
         if score is None:
             continue
         try:
-            out[str(key)] = float(score)
+            # Clamp to [0,1] so a corrupt or malicious cache can't inject an
+            # out-of-range capability that would distort routing.
+            out[str(key)] = max(0.0, min(1.0, float(score)))
         except (TypeError, ValueError):
             continue
     return out
@@ -581,8 +586,9 @@ def fetch_aa_scores(
     """
     from urllib.parse import urlsplit
 
-    if urlsplit(url).hostname not in _AA_ALLOWED_HOSTS:
-        raise ValueError(f"refusing to send the AA key to a non-AA host: {url!r}")
+    parts = urlsplit(url)
+    if parts.scheme != "https" or parts.hostname not in _AA_ALLOWED_HOSTS:
+        raise ValueError(f"refusing to send the AA key to a non-AA/non-https URL: {url!r}")
     try:
         data = _get_json(url, timeout=timeout, headers={"x-api-key": api_key})
     except (OSError, ValueError, urllib.error.HTTPError):

--- a/src/freellmpool/capability.py
+++ b/src/freellmpool/capability.py
@@ -1,0 +1,600 @@
+"""Model-capability scoring for quality-tiered ("degradation-aware") routing.
+
+Quality routing (``FREELLMPOOL_ROUTING=quality``) matches prompt *difficulty* to
+model *capability*: hard prompts go to the strongest available model, easy ones to
+lightweight models — which rations scarce strong-model quota so the pool stays
+sharp as the day's daily caps fill.
+
+Capability is grounded in real benchmarks, not guessed from names. The bundled
+``capability_scores.json`` is built from public leaderboard data (LMArena Elo,
+MIT-mirrored) mapped onto catalog model names. ``freellmpool capability sync``
+refreshes it and can layer in the Artificial Analysis Intelligence Index under the
+user's own access. Models the benchmark doesn't cover fall back to a coarse name
+heuristic, then a neutral default.
+
+All scores are normalized to 0.0–1.0 (higher = more capable). The runtime path is
+pure and dependency-free; the optional sync uses stdlib ``urllib``.
+"""
+
+from __future__ import annotations
+
+import bisect
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from functools import lru_cache
+from pathlib import Path
+
+from .context import estimate_input_tokens
+
+_BUNDLED_SCORES = Path(__file__).with_name("capability_scores.json")
+_NEUTRAL = 0.5  # used when neither benchmark nor heuristic can say anything
+
+# ---- name normalization ------------------------------------------------------
+
+# A single leading "provider/" namespace, e.g. "openai/gpt-oss-120b".
+_PROVIDER_PREFIX_RE = re.compile(r"^[^/]+/")
+# A redundant leading vendor-ORG token kept before the family name, e.g.
+# "meta-llama-3.3-70b" → "llama-3.3-70b", "cohere-command-r" → "command-r",
+# "zai-org-glm-4.6" → "glm-4.6". Only true org tokens — never a family name
+# (stripping "qwen"/"mistral"/"gemma" would destroy the model identity).
+_VENDOR_PREFIX_RE = re.compile(
+    r"^(?:meta|mistralai|nvidia|google|microsoft|nousresearch|cognitivecomputations|"
+    r"deepseek-ai|cohere|c4ai|ai21|aisingapore|ibm-granite|ibm|zai-org|zai|"
+    r"moonshotai|opengvlab|sarvamai|01-ai|openai)[-_]",
+    re.IGNORECASE,
+)
+# A doubled family token, e.g. "qwen-qwen3-30b" → "qwen3-30b",
+# "llama-llama-2-7b" → "llama-2-7b" (some catalogs prefix the family twice).
+_DOUBLED_FAMILY_RE = re.compile(r"^([a-z]{3,})[-_](?=\1)", re.IGNORECASE)
+# Trailing date/version stamps: -2025-01-01, -20240620, -2507 (YYMM), -08, -03.
+# Short 2-4 digit tags are versions/dates that benchmarks drop; sizes carry a "b".
+_DATE_SUFFIX_RE = re.compile(r"[-_](?:\d{4}-\d{2}-\d{2}|\d{6,8}|\d{2,4})$")
+# Trailing provider/packaging variant tags that don't change the base model's
+# capability — stripping them lets a catalog name match a benchmark name. (Kept
+# conservative: capability-distinguishing qualifiers like flash/mini/air are NOT
+# stripped, so we never conflate a light variant with its stronger sibling.)
+_VARIANT_SUFFIX_RE = re.compile(
+    r"[-_](?:versatile|instant|latest|instruct|chat|it|hf|fp8|bf16|lora|"
+    r"preview|turbo|tuned|free|online|beta)$",
+    re.IGNORECASE,
+)
+
+
+def normalize_model_name(name: str) -> str:
+    """A stable lookup key for a model name, robust to provider/vendor prefixes and
+    packaging/date suffixes. The same function keys both the catalog names and the
+    benchmark names, so equivalent variants collapse to one key (e.g.
+    ``llama-3.3-70b-versatile`` and ``llama-3.3-70b-instruct`` → ``llama-3.3-70b``).
+    """
+    s = (name or "").strip().lower()
+    s = _PROVIDER_PREFIX_RE.sub("", s)
+    # Normalize separators early (":", "_", spaces → "-"), BEFORE peeling suffixes,
+    # so OpenRouter's "model:free" and the like strip correctly.
+    s = re.sub(r"[^a-z0-9.]+", "-", s).strip("-")
+    s = _VENDOR_PREFIX_RE.sub("", s)
+    s = _DOUBLED_FAMILY_RE.sub("", s)
+    # Peel repeated trailing variant/date tags (a name may carry several).
+    for _ in range(6):
+        peeled = _VARIANT_SUFFIX_RE.sub("", s)
+        peeled = _DATE_SUFFIX_RE.sub("", peeled)
+        if peeled == s:
+            break
+        s = peeled
+    return s.strip("-")
+
+
+def _core(name: str) -> str:
+    """Aggressive alphanumeric-only core, for a relaxed fallback match."""
+    return re.sub(r"[^a-z0-9]+", "", normalize_model_name(name))
+
+
+# ---- name heuristic (fallback only) ------------------------------------------
+
+# Parameter count like "70b" / "8b" / "3.2b"; the look-behind avoids matching the
+# tail of a version/date (so "...-3b" matches but "v0.3b" / "...123b-of-a-date"
+# do not get mis-parsed mid-number).
+_PARAM_RE = re.compile(r"(?<![.\d])(\d+(?:\.\d+)?)\s*b\b", re.IGNORECASE)
+_DOWNWEIGHT_RE = re.compile(r"\b(?:flash|lite|mini|nano|tiny|instant|small|edge)\b", re.IGNORECASE)
+_UPWEIGHT_RE = re.compile(r"\b(?:opus|reasoning|thinking|r1|o[1-9])\b", re.IGNORECASE)
+
+
+def _heuristic_score(name: str) -> float:
+    """Coarse 0–1 capability from the model name alone — the last-resort fallback
+    when the benchmark table has no entry. Driven by parameter count, nudged by
+    well-known size keywords."""
+    s = (name or "").lower()
+    params = [float(x) for x in _PARAM_RE.findall(s)]
+    if params:
+        b = max(params)
+        if b >= 200:
+            score = 0.85
+        elif b >= 100:
+            score = 0.78
+        elif b >= 60:
+            score = 0.68
+        elif b >= 30:
+            score = 0.58
+        elif b >= 12:
+            score = 0.46
+        elif b >= 7:
+            score = 0.38
+        else:
+            score = 0.28
+    else:
+        score = _NEUTRAL
+    if _DOWNWEIGHT_RE.search(s):
+        score = min(score, 0.40)
+    if _UPWEIGHT_RE.search(s):
+        score = max(score, 0.62)
+    return round(score, 4)
+
+
+# ---- bundled / user score table ----------------------------------------------
+
+
+def user_capability_path() -> Path:
+    """Where ``capability sync`` writes the refreshed table (overrides the bundle).
+
+    Honors ``FREELLMPOOL_CAPABILITY_FILE`` for overrides and test injection.
+    """
+    override = os.environ.get("FREELLMPOOL_CAPABILITY_FILE")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".config" / "freellmpool" / "capability_scores.json"
+
+
+def _read_scores(path: Path) -> dict[str, float]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    raw = data.get("scores", {}) if isinstance(data, dict) else {}
+    out: dict[str, float] = {}
+    for key, val in raw.items():
+        score = val.get("score") if isinstance(val, dict) else val
+        if score is None:
+            continue
+        try:
+            out[str(key)] = float(score)
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+@lru_cache(maxsize=8)
+def _table_cached(user_str: str, _user_mtime: int) -> dict[str, float]:
+    # Bundle first, user cache overlays it. ``_user_mtime`` is part of the cache
+    # key only (not used in the body) so a `capability sync` is picked up without a
+    # restart. Treat the result as read-only (it is shared across callers).
+    table = _read_scores(_BUNDLED_SCORES)
+    table.update(_read_scores(Path(user_str)))
+    return table
+
+
+def capability_table() -> dict[str, float]:
+    """Resolved ``{normalized_name: score}`` (bundled overlaid by the user cache).
+
+    Cached and mtime-aware, so it is cheap to call once per routing decision.
+    """
+    user = user_capability_path()
+    try:
+        mtime = user.stat().st_mtime_ns
+    except OSError:
+        mtime = 0
+    return _table_cached(str(user), mtime)
+
+
+def model_capability(name: str, table: dict[str, float] | None = None) -> float:
+    """Capability of a model on 0–1: benchmark score if known, else name heuristic.
+
+    Pass ``table`` (from :func:`capability_table`) to avoid reloading it per call
+    when scoring many candidates in one routing decision.
+    """
+    if table is None:
+        table = capability_table()
+    key = normalize_model_name(name)
+    if key in table:
+        return table[key]
+    core = _core(name)
+    if core and core in table:
+        return table[core]
+    return _heuristic_score(name)
+
+
+# ---- prompt difficulty -------------------------------------------------------
+
+_CODE_RE = re.compile(
+    r"```|\bdef \b|\bclass \b|=>|;\s*$|^\s*(?:diff --git|@@ |[+-]{3} )", re.MULTILINE
+)
+_HARD_RE = re.compile(
+    r"\b(?:debug|refactor|prove|analy[sz]e|algorithm|optimi[sz]e|architect|"
+    r"design|reason|derive|complex|trade-?offs?|step by step|why)\b",
+    re.IGNORECASE,
+)
+
+
+def _messages_text(messages) -> tuple[str, int]:
+    """Concatenated text of all messages, plus the user/assistant turn count."""
+    parts: list[str] = []
+    turns = 0
+    for m in messages or []:
+        if not isinstance(m, dict):
+            continue
+        if m.get("role") in ("user", "assistant"):
+            turns += 1
+        content = m.get("content")
+        if isinstance(content, str):
+            parts.append(content)
+        elif isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and isinstance(part.get("text"), str):
+                    parts.append(part["text"])
+    return "\n".join(parts), turns
+
+
+def prompt_difficulty(messages, max_tokens: int | None = None, tools=None) -> float:
+    """Estimate how much capability a request needs, on 0–1.
+
+    Cheap, dependency-free heuristics: input size (reusing the chars/4 token
+    estimate), presence of code/diffs, reasoning cues, tool use, conversation
+    depth, and a large requested output. A short plain prompt scores low (→ light
+    models); long code/reasoning prompts score high (→ strong models).
+    """
+    text, turns = _messages_text(messages)
+    tokens = estimate_input_tokens(messages, tools)
+    score = 0.35  # baseline for a short, plain prompt
+    if tokens > 8000:
+        score += 0.30
+    elif tokens > 2000:
+        score += 0.20
+    elif tokens > 500:
+        score += 0.10
+    if _CODE_RE.search(text):
+        score += 0.20
+    if _HARD_RE.search(text):
+        score += 0.20
+    if tools:
+        score += 0.15
+    if turns >= 6:
+        score += 0.10
+    if max_tokens and max_tokens >= 2048:
+        score += 0.10
+    return round(max(0.0, min(1.0, score)), 4)
+
+
+# ---- the routing fit penalty -------------------------------------------------
+
+_UNDERPOWER_PENALTY = 100.0  # never under-serve a hard prompt
+_OVERPOWER_PENALTY = 1.0  # gently ration strong models on easy prompts
+
+
+def fit_penalty(capability: float, need: float) -> float:
+    """Routing penalty for using a model of ``capability`` on a request needing
+    ``need`` (both 0–1). Lower is better.
+
+    Asymmetric on purpose: a model weaker than the request is penalized heavily
+    (so hard prompts get a strong model), while a model stronger than needed is
+    penalized only lightly (so easy prompts prefer right-sized models, reserving
+    scarce strong-model quota for when it's actually needed).
+    """
+    gap = capability - need
+    if gap < 0:
+        return (-gap) * _UNDERPOWER_PENALTY
+    return gap * _OVERPOWER_PENALTY
+
+
+# ---- building / refreshing the table -----------------------------------------
+
+
+def normalize_scores(raw: dict[str, float]) -> dict[str, float]:
+    """Convert a benchmark's raw scores (Elo, Index, pass-rate, …) into a 0–1
+    *percentile rank*, keyed by normalized model name (equivalent variants collapse
+    to their best raw score).
+
+    Percentile rank — "the fraction of this benchmark's models it beats" — is used
+    instead of min-max because it is robust to each benchmark's distribution shape
+    and outliers, so scores from *different* benchmarks become roughly comparable
+    when the table mixes sources (a top-decile model reads ~0.9 whether it came from
+    Arena Elo or the AA Index, even though their raw scales differ wildly). It also
+    gives quality routing a clean reading: difficulty ``d`` wants a model above the
+    ``d`` percentile.
+    """
+    if not raw:
+        return {}
+    by_key: dict[str, float] = {}
+    for name, value in raw.items():
+        key = normalize_model_name(name)
+        if not key:
+            continue
+        by_key[key] = max(by_key.get(key, float("-inf")), float(value))
+    values = sorted(by_key.values())
+    n = len(values)
+    out: dict[str, float] = {}
+    for key, value in by_key.items():
+        lo = bisect.bisect_left(values, value)
+        hi = bisect.bisect_right(values, value)
+        out[key] = round((lo + hi) / 2.0 / n, 4)  # midrank percentile
+    return out
+
+
+def build_capability_table(
+    *,
+    aa_scores: dict[str, float] | None = None,
+    arena_scores: dict[str, float] | None = None,
+    aider_scores: dict[str, float] | None = None,
+    catalog_names: list[str] | None = None,
+) -> dict[str, dict]:
+    """Resolve per-model capability with precedence Artificial Analysis → Arena →
+    Aider → (runtime) heuristic, restricted to the catalog's model names.
+
+    Returns ``{normalized_name: {"score": float, "source": ...}}`` for every catalog
+    model a benchmark covers. Each model is resolved in priority order: a *direct*
+    match (exact name, or alphanumeric-core to bridge separator differences) from the
+    highest-precedence source wins first; failing that, a *same-family, same-size*
+    approximation is borrowed (tagged ``…~``). Models nothing covers are omitted —
+    they get the name heuristic at runtime. The ``*_scores`` args are raw benchmark
+    dicts (model name → raw number); each is min-max normalized independently.
+    Precedence follows measured correlation with AA (Arena ≈ 0.73 > Aider ≈ 0.60).
+    """
+    from .config import load_catalog
+
+    if catalog_names is None:
+        catalog_names = [m.name for p in load_catalog() for m in p.models]
+
+    aa = normalize_scores(aa_scores or {})
+    arena = normalize_scores(arena_scores or {})
+    aider = normalize_scores(aider_scores or {})
+    resolvers = [
+        _index_source("aa", aa),
+        _index_source("arena", arena),
+        _index_source("aider", aider),
+    ]
+
+    table: dict[str, dict] = {}
+    for name in catalog_names:
+        key = normalize_model_name(name)
+        if not key or key in table:
+            continue
+        entry = _resolve_capability(key, resolvers)
+        if entry is not None:
+            table[key] = entry
+    return table
+
+
+def _alnum(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", s)
+
+
+def _strip_params(key: str) -> str:
+    """Drop ``Nb`` size tokens, e.g. ``mistral-large-3-675b`` → ``mistral-large-3``."""
+    return re.sub(r"(?<![.\d])\d+(?:\.\d+)?b\b", "", key)
+
+
+def _largest_params(key: str) -> float | None:
+    params = [float(x) for x in re.findall(r"(?<![.\d])(\d+(?:\.\d+)?)b\b", key)]
+    return max(params) if params else None
+
+
+def _index_source(label: str, norm_scores: dict[str, float]) -> dict:
+    """Precompute the lookup indexes for one benchmark source:
+    exact-by-name, alphanumeric-core, paramless-core (only entries without a size
+    token, for matching a sized catalog name to an unsized benchmark name), and a
+    (family-token, params) index for same-family/same-size approximation."""
+    core: dict[str, float] = {}
+    noparam_core: dict[str, float] = {}
+    fp: dict[tuple[str, float], float] = {}
+    for key, value in norm_scores.items():
+        ck = _alnum(key)
+        if ck:
+            core[ck] = max(core.get(ck, 0.0), value)
+        params = _largest_params(key)
+        if params is None:
+            if ck:
+                noparam_core[ck] = max(noparam_core.get(ck, 0.0), value)
+        else:
+            for tok in re.findall(r"[a-z]+", key):
+                if len(tok) >= 4:
+                    fp[(tok, params)] = max(fp.get((tok, params), 0.0), value)
+    return {"label": label, "exact": norm_scores, "core": core, "noparam": noparam_core, "fp": fp}
+
+
+def _resolve_capability(key: str, resolvers: list[dict]) -> dict | None:
+    """Resolve one normalized model key against ordered resolvers (AA, then Arena).
+
+    Tries, in order: exact name, alphanumeric core, then a sized→unsized core match
+    (so ``mistral-large-3-675b`` finds ``mistral-large-3``). A *direct* match from
+    any source beats a *family+size approximation* from any source — a measured
+    number always wins over a borrowed one. Approximations are tagged ``…~``."""
+    core = _alnum(key)
+    np_core = _alnum(_strip_params(key))
+    has_params = np_core != core
+    for r in resolvers:
+        if key in r["exact"]:
+            return {"score": r["exact"][key], "source": r["label"]}
+        if core in r["core"]:
+            return {"score": r["core"][core], "source": r["label"]}
+        if has_params and np_core and np_core in r["noparam"]:
+            return {"score": r["noparam"][np_core], "source": r["label"]}
+    params = _largest_params(key)
+    if params is not None:
+        tokens = [t for t in re.findall(r"[a-z]+", key) if len(t) >= 4]
+        for r in resolvers:
+            for tok in tokens:
+                if (tok, params) in r["fp"]:
+                    return {"score": r["fp"][(tok, params)], "source": f"{r['label']}~"}
+    return None
+
+
+# ---- benchmark fetching (used by `capability sync` and bundle generation) -----
+
+# LMArena Elo via a friendly, daily-updated mirror of the public leaderboard.
+ARENA_DATASET = "mathewhe/chatbot-arena-elo"
+_HF_ROWS_URL = "https://datasets-server.huggingface.co/rows"
+# Artificial Analysis Intelligence Index — fetched only when the user provides
+# their own API key (keeps the bundled snapshot free of AA-licensed data; AA's
+# terms require attribution and don't grant public redistribution, so it is never
+# bundled — only cached locally under the user's own key, as AA requests).
+AA_DEFAULT_URL = "https://artificialanalysis.ai/api/v2/data/llms/models"
+# Aider code-editing leaderboard — Apache-2.0, redistributable. A real benchmark
+# that fills a few open/code models Arena lacks (codestral, command-r, …).
+AIDER_URLS = (
+    "https://raw.githubusercontent.com/Aider-AI/aider/main/aider/website/_data/polyglot_leaderboard.yml",
+    "https://raw.githubusercontent.com/Aider-AI/aider/main/aider/website/_data/edit_leaderboard.yml",
+)
+_MAX_FETCH_BYTES = 8 * 1024 * 1024
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Never auto-follow redirects, so a request carrying an API key can't forward
+    it to a redirect target (credential leak / SSRF)."""
+
+    def redirect_request(self, *args, **kwargs):  # noqa: D102
+        return None
+
+
+_NO_REDIRECT_OPENER = urllib.request.build_opener(_NoRedirect())
+
+
+def _get_text(url: str, *, timeout: float, headers: dict[str, str] | None = None) -> str:
+    if not url.lower().startswith("https://"):
+        raise ValueError(f"refusing non-https benchmark URL: {url!r}")
+    request = urllib.request.Request(url, headers=headers or {})
+    with _NO_REDIRECT_OPENER.open(request, timeout=timeout) as response:
+        raw = response.read(_MAX_FETCH_BYTES + 1)
+    if len(raw) > _MAX_FETCH_BYTES:
+        raise ValueError(f"benchmark response exceeds {_MAX_FETCH_BYTES} bytes; refusing to load")
+    return raw.decode("utf-8")
+
+
+def _get_json(url: str, *, timeout: float, headers: dict[str, str] | None = None):
+    return json.loads(_get_text(url, timeout=timeout, headers=headers))
+
+
+def fetch_aider_scores(*, timeout: float = 20.0) -> dict[str, float]:
+    """Pull the Aider code-editing leaderboards (model name → best pass rate).
+
+    Public, Apache-2.0 data in the Aider repo (no key). The YAML is parsed line by
+    line (``model:`` / ``pass_rate_2:``) to avoid a yaml dependency.
+    """
+    scores: dict[str, float] = {}
+    for url in AIDER_URLS:
+        try:
+            text = _get_text(url, timeout=timeout)
+        except (OSError, ValueError, urllib.error.HTTPError):
+            continue
+        model: str | None = None
+        for line in text.splitlines():
+            name_match = re.match(r"\s*model:\s*(.+?)\s*$", line)
+            if name_match:
+                model = name_match.group(1)
+            rate_match = re.match(r"\s*pass_rate_2:\s*([\d.]+)", line)
+            if rate_match and model:
+                scores[model] = max(scores.get(model, 0.0), float(rate_match.group(1)))
+                model = None
+    return scores
+
+
+def fetch_arena_scores(*, timeout: float = 20.0) -> dict[str, float]:
+    """Pull the full LMArena Elo leaderboard (model name → Arena Elo).
+
+    Reads the public, MIT-mirrored dataset via the HuggingFace datasets-server
+    (no key required). Paginates until exhausted.
+    """
+    scores: dict[str, float] = {}
+    offset = 0
+    page = 100
+    while True:
+        url = (
+            f"{_HF_ROWS_URL}?dataset={ARENA_DATASET.replace('/', '%2F')}"
+            f"&config=default&split=train&offset={offset}&length={page}"
+        )
+        data = _get_json(url, timeout=timeout)
+        rows = data.get("rows", []) if isinstance(data, dict) else []
+        if not rows:
+            break
+        for entry in rows:
+            row = entry.get("row", {}) if isinstance(entry, dict) else {}
+            name = row.get("Model")
+            elo = row.get("Arena Score")
+            if isinstance(name, str) and isinstance(elo, (int, float)):
+                scores[name] = float(elo)
+        total = data.get("num_rows_total") if isinstance(data, dict) else None
+        offset += page
+        if not isinstance(total, int) or offset >= total:
+            break
+    return scores
+
+
+def fetch_aa_scores(
+    *, api_key: str, url: str = AA_DEFAULT_URL, timeout: float = 20.0
+) -> dict[str, float]:
+    """Pull the Artificial Analysis Intelligence Index (model name → index).
+
+    Requires the caller's own AA API key (so AA-licensed data is only ever fetched
+    under the user's access, never bundled). Best-effort: tolerates schema drift by
+    scanning common field names; returns {} on any failure.
+    """
+    try:
+        data = _get_json(url, timeout=timeout, headers={"x-api-key": api_key})
+    except (OSError, ValueError, urllib.error.HTTPError):
+        return {}
+    rows = data.get("data", data) if isinstance(data, dict) else data
+    if not isinstance(rows, list):
+        return {}
+    scores: dict[str, float] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        name = row.get("slug") or row.get("name")
+        evals = row.get("evaluations")
+        value = (
+            evals.get("artificial_analysis_intelligence_index") if isinstance(evals, dict) else None
+        )
+        if isinstance(name, str) and isinstance(value, (int, float)):
+            scores[name] = float(value)
+    return scores
+
+
+def sync_capability_table(
+    *,
+    timeout: float = 20.0,
+    aa_api_key: str | None = None,
+    aa_url: str = AA_DEFAULT_URL,
+    path: Path | None = None,
+) -> tuple[Path, dict]:
+    """Fetch benchmarks, rebuild the score table, and write the user cache.
+
+    Returns ``(path, stats)`` where ``stats`` reports how many models were mapped
+    and from which source. Artificial Analysis is included only when ``aa_api_key``
+    is provided. Clears the in-process table cache so the refresh takes effect.
+    """
+    path = path or user_capability_path()
+    arena = fetch_arena_scores(timeout=timeout)
+    aider = fetch_aider_scores(timeout=timeout)
+    aa = fetch_aa_scores(api_key=aa_api_key, url=aa_url, timeout=timeout) if aa_api_key else {}
+    table = build_capability_table(aa_scores=aa, arena_scores=arena, aider_scores=aider)
+    by_source: dict[str, int] = {}
+    for entry in table.values():
+        by_source[entry["source"]] = by_source.get(entry["source"], 0) + 1
+    payload = {
+        "meta": {
+            "arena_models": len(arena),
+            "aider_models": len(aider),
+            "aa_models": len(aa),
+            "mapped": len(table),
+        },
+        "scores": table,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    _table_cached.cache_clear()
+    return path, {
+        "arena": len(arena),
+        "aider": len(aider),
+        "aa": len(aa),
+        "mapped": len(table),
+        "by_source": by_source,
+    }

--- a/src/freellmpool/capability_scores.json
+++ b/src/freellmpool/capability_scores.json
@@ -2,7 +2,7 @@
   "meta": {
     "aider_models": 158,
     "arena_models": 218,
-    "mapped": 93,
+    "mapped": 92,
     "sources": "LMArena Elo (mathewhe/chatbot-arena-elo, MIT) + Aider leaderboard (Apache-2.0); percentile-rank; ~ = same-family/size approximation"
   },
   "scores": {
@@ -19,8 +19,8 @@
       "source": "aider"
     },
     "codestral-22b-instruct-v0.1": {
-      "score": 0.3906,
-      "source": "arena~"
+      "score": 0.3308,
+      "source": "aider~"
     },
     "command-a": {
       "score": 0.8203,
@@ -53,10 +53,6 @@
     "deepseek-v3": {
       "score": 0.9453,
       "source": "arena"
-    },
-    "devstral-small-2-24b": {
-      "score": 0.6224,
-      "source": "arena~"
     },
     "dolphin-mistral-24b-venice-edition": {
       "score": 0.6224,
@@ -267,7 +263,7 @@
       "source": "arena"
     },
     "mistral-7b-instruct-v0.3": {
-      "score": 0.2292,
+      "score": 0.2214,
       "source": "arena~"
     },
     "mistral-large": {

--- a/src/freellmpool/capability_scores.json
+++ b/src/freellmpool/capability_scores.json
@@ -1,0 +1,382 @@
+{
+  "meta": {
+    "aider_models": 158,
+    "arena_models": 218,
+    "mapped": 93,
+    "sources": "LMArena Elo (mathewhe/chatbot-arena-elo, MIT) + Aider leaderboard (Apache-2.0); percentile-rank; ~ = same-family/size approximation"
+  },
+  "scores": {
+    "aya-expanse-32b": {
+      "score": 0.5156,
+      "source": "arena"
+    },
+    "codellama-70b": {
+      "score": 0.1458,
+      "source": "arena"
+    },
+    "codestral": {
+      "score": 0.3759,
+      "source": "aider"
+    },
+    "codestral-22b-instruct-v0.1": {
+      "score": 0.3906,
+      "source": "arena~"
+    },
+    "command-a": {
+      "score": 0.8203,
+      "source": "arena"
+    },
+    "command-r": {
+      "score": 0.5339,
+      "source": "arena"
+    },
+    "command-r-plus": {
+      "score": 0.1429,
+      "source": "aider"
+    },
+    "command-r7b": {
+      "score": 0.5339,
+      "source": "arena"
+    },
+    "dbrx": {
+      "score": 0.3021,
+      "source": "arena"
+    },
+    "deepseek-r1": {
+      "score": 0.9766,
+      "source": "arena"
+    },
+    "deepseek-r1-distill-qwen-32b": {
+      "score": 0.862,
+      "source": "arena~"
+    },
+    "deepseek-v3": {
+      "score": 0.9453,
+      "source": "arena"
+    },
+    "devstral-small-2-24b": {
+      "score": 0.6224,
+      "source": "arena~"
+    },
+    "dolphin-mistral-24b-venice-edition": {
+      "score": 0.6224,
+      "source": "arena~"
+    },
+    "dracarys-llama-3.1-70b": {
+      "score": 0.6719,
+      "source": "arena~"
+    },
+    "gemini-2.0-flash": {
+      "score": 0.8854,
+      "source": "arena"
+    },
+    "gemini-2.0-flash-lite": {
+      "score": 0.8255,
+      "source": "arena"
+    },
+    "gemini-2.5-flash": {
+      "score": 0.9661,
+      "source": "arena"
+    },
+    "gemma-2-2b": {
+      "score": 0.3776,
+      "source": "arena"
+    },
+    "gemma-2b": {
+      "score": 0.0755,
+      "source": "arena"
+    },
+    "gemma-3-12b": {
+      "score": 0.8438,
+      "source": "arena"
+    },
+    "gemma-3-4b": {
+      "score": 0.7057,
+      "source": "arena"
+    },
+    "gemma-3n-e2b": {
+      "score": 0.3776,
+      "source": "arena~"
+    },
+    "gemma-3n-e4b": {
+      "score": 0.75,
+      "source": "arena"
+    },
+    "gemma-7b": {
+      "score": 0.1328,
+      "source": "arena"
+    },
+    "gemma-sea-lion-v4-27b": {
+      "score": 0.8776,
+      "source": "arena~"
+    },
+    "gemma3-12b": {
+      "score": 0.8438,
+      "source": "arena"
+    },
+    "gemma3-27b": {
+      "score": 0.8776,
+      "source": "arena"
+    },
+    "gemma3-4b": {
+      "score": 0.7057,
+      "source": "arena"
+    },
+    "gpt-4.1": {
+      "score": 0.9505,
+      "source": "arena"
+    },
+    "gpt-4.1-mini": {
+      "score": 0.8438,
+      "source": "arena"
+    },
+    "gpt-4.1-nano": {
+      "score": 0.6875,
+      "source": "arena"
+    },
+    "gpt-4o": {
+      "score": 0.7318,
+      "source": "arena"
+    },
+    "gpt-4o-mini": {
+      "score": 0.6875,
+      "source": "arena"
+    },
+    "granite-3.0-8b": {
+      "score": 0.2812,
+      "source": "arena"
+    },
+    "granite-8b-code": {
+      "score": 0.3724,
+      "source": "arena~"
+    },
+    "grok-3": {
+      "score": 0.9714,
+      "source": "arena"
+    },
+    "grok-3-mini": {
+      "score": 0.8724,
+      "source": "arena"
+    },
+    "hermes-3-llama-3.1-405b": {
+      "score": 0.6541,
+      "source": "aider"
+    },
+    "jamba-1.5-large": {
+      "score": 0.5651,
+      "source": "arena"
+    },
+    "llama-2-7b": {
+      "score": 0.1328,
+      "source": "arena"
+    },
+    "llama-3-3-70b": {
+      "score": 0.638,
+      "source": "arena"
+    },
+    "llama-3.1-405b": {
+      "score": 0.6719,
+      "source": "arena"
+    },
+    "llama-3.1-70b": {
+      "score": 0.6068,
+      "source": "arena"
+    },
+    "llama-3.1-8b": {
+      "score": 0.4271,
+      "source": "arena"
+    },
+    "llama-3.1-nemotron-51b": {
+      "score": 0.5234,
+      "source": "arena"
+    },
+    "llama-3.1-nemotron-70b": {
+      "score": 0.6719,
+      "source": "arena"
+    },
+    "llama-3.1-nemotron-nano-8b-v1": {
+      "score": 0.4557,
+      "source": "arena~"
+    },
+    "llama-3.1-nemotron-nano-vl-8b-v1": {
+      "score": 0.4557,
+      "source": "arena~"
+    },
+    "llama-3.1-nemotron-ultra-253b-v1": {
+      "score": 0.7969,
+      "source": "arena"
+    },
+    "llama-3.2-1b": {
+      "score": 0.1797,
+      "source": "arena"
+    },
+    "llama-3.2-3b": {
+      "score": 0.3021,
+      "source": "arena"
+    },
+    "llama-3.3-70b": {
+      "score": 0.638,
+      "source": "arena"
+    },
+    "llama-3.3-70b-instruct-fp8-fast": {
+      "score": 0.6719,
+      "source": "arena~"
+    },
+    "llama-3.3-nemotron-super-49b-v1": {
+      "score": 0.7656,
+      "source": "arena"
+    },
+    "llama-3.3-nemotron-super-49b-v1.5": {
+      "score": 0.7656,
+      "source": "arena~"
+    },
+    "llama-4-maverick-17b-128e": {
+      "score": 0.7109,
+      "source": "arena"
+    },
+    "llama-4-scout-17b-16e": {
+      "score": 0.6536,
+      "source": "arena"
+    },
+    "llama2-70b": {
+      "score": 0.2812,
+      "source": "arena"
+    },
+    "llama3-chatqa-1.5-70b": {
+      "score": 0.6719,
+      "source": "arena~"
+    },
+    "llama3.1-8b": {
+      "score": 0.4271,
+      "source": "arena"
+    },
+    "magistral-medium": {
+      "score": 0.5755,
+      "source": "arena"
+    },
+    "ministral-3-8b": {
+      "score": 0.4505,
+      "source": "arena~"
+    },
+    "ministral-8b": {
+      "score": 0.4505,
+      "source": "arena"
+    },
+    "mistral-7b-instruct-v0.2": {
+      "score": 0.2214,
+      "source": "arena"
+    },
+    "mistral-7b-instruct-v0.3": {
+      "score": 0.2292,
+      "source": "arena~"
+    },
+    "mistral-large": {
+      "score": 0.6172,
+      "source": "arena"
+    },
+    "mistral-large-2": {
+      "score": 0.5902,
+      "source": "aider"
+    },
+    "mistral-medium": {
+      "score": 0.3906,
+      "source": "arena"
+    },
+    "mistral-medium-3": {
+      "score": 0.9297,
+      "source": "arena"
+    },
+    "mistral-nemo-12b": {
+      "score": 0.1692,
+      "source": "aider~"
+    },
+    "mistral-small": {
+      "score": 0.8359,
+      "source": "arena"
+    },
+    "mistral-small-3.1-24b": {
+      "score": 0.6224,
+      "source": "arena"
+    },
+    "mistral-small-3.2-24b": {
+      "score": 0.6224,
+      "source": "arena~"
+    },
+    "mixtral-8x22b-v0.1": {
+      "score": 0.3906,
+      "source": "arena~"
+    },
+    "mixtral-8x7b-instruct-v0.1": {
+      "score": 0.3359,
+      "source": "arena"
+    },
+    "nemotron-4-340b": {
+      "score": 0.5156,
+      "source": "arena"
+    },
+    "o1": {
+      "score": 0.9089,
+      "source": "arena"
+    },
+    "o1-mini": {
+      "score": 0.7839,
+      "source": "arena"
+    },
+    "o3": {
+      "score": 0.9818,
+      "source": "arena"
+    },
+    "o3-mini": {
+      "score": 0.7786,
+      "source": "arena"
+    },
+    "o4-mini": {
+      "score": 0.8958,
+      "source": "arena"
+    },
+    "phi-4": {
+      "score": 0.4896,
+      "source": "arena"
+    },
+    "qwen-3-235b-a22b": {
+      "score": 0.9141,
+      "source": "arena"
+    },
+    "qwen-qwq-32b": {
+      "score": 0.862,
+      "source": "arena~"
+    },
+    "qwen2.5-coder-32b": {
+      "score": 0.5469,
+      "source": "arena"
+    },
+    "qwen2.5-vl-72b": {
+      "score": 0.6328,
+      "source": "arena~"
+    },
+    "qwen3-235b": {
+      "score": 0.9557,
+      "source": "arena~"
+    },
+    "qwen3-30b-a3b": {
+      "score": 0.7969,
+      "source": "arena"
+    },
+    "qwen3-32b": {
+      "score": 0.862,
+      "source": "arena"
+    },
+    "qwen3-coder-30b-a3b": {
+      "score": 0.7969,
+      "source": "arena~"
+    },
+    "qwen3-vl-235b": {
+      "score": 0.9557,
+      "source": "arena~"
+    },
+    "solar-10.7b": {
+      "score": 0.1901,
+      "source": "arena~"
+    }
+  }
+}

--- a/src/freellmpool/cli.py
+++ b/src/freellmpool/cli.py
@@ -563,7 +563,7 @@ def cmd_capability_status(args: argparse.Namespace) -> int:
     return 0
 
 
-def _in_table(name: str, table: dict) -> bool:
+def _in_table(name: str, table) -> bool:
     from .capability import normalize_model_name
 
     return normalize_model_name(name) in table

--- a/src/freellmpool/cli.py
+++ b/src/freellmpool/cli.py
@@ -555,7 +555,7 @@ def cmd_capability_status(args: argparse.Namespace) -> int:
     print(f"  user cache: {user if user.exists() else '(none — using bundled snapshot)'}")
     names = sorted({m.name for p in load_catalog() for m in p.models})
     scored = sorted(((model_capability(n, table), n) for n in names), reverse=True)
-    covered = sum(1 for n in names if model_capability(n, table) >= 0 and _in_table(n, table))
+    covered = sum(1 for n in names if _in_table(n, table))
     print(f"  catalog models with a benchmark score: {covered}/{len(names)} (rest use heuristic)")
     print(f"  top {args.limit} catalog models by capability:")
     for cap, name in scored[: args.limit]:

--- a/src/freellmpool/cli.py
+++ b/src/freellmpool/cli.py
@@ -519,6 +519,56 @@ def cmd_catalog_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_capability_sync(args: argparse.Namespace) -> int:
+    from .capability import sync_capability_table
+
+    aa_key = os.environ.get("FREELLMPOOL_AA_API_KEY")
+    path, stats = sync_capability_table(timeout=args.timeout, aa_api_key=aa_key)
+    by_source = ", ".join(f"{k}={v}" for k, v in sorted(stats["by_source"].items()))
+    print(f"Synced capability scores → {path}")
+    print(
+        f"  benchmark models fetched: arena={stats['arena']}  "
+        f"aider={stats['aider']}  aa={stats['aa']}"
+    )
+    print(f"  catalog models mapped: {stats['mapped']} ({by_source or 'none'})")
+    if not aa_key:
+        print(
+            "  Artificial Analysis skipped — set FREELLMPOOL_AA_API_KEY for much broader "
+            "coverage (its Intelligence Index covers most current/open models and wins)."
+        )
+    print("  Models not covered by a benchmark fall back to a name heuristic at runtime.")
+    # Source attribution (required for Artificial Analysis; courtesy for the rest).
+    sources = ["LMArena (https://lmarena.ai/)", "Aider (https://aider.chat/)"]
+    if stats["aa"]:
+        sources.append("Artificial Analysis (https://artificialanalysis.ai/)")
+    print("  Scores via " + ", ".join(sources) + ".")
+    return 0
+
+
+def cmd_capability_status(args: argparse.Namespace) -> int:
+    from .capability import capability_table, model_capability, user_capability_path
+    from .config import load_catalog
+
+    table = capability_table()
+    user = user_capability_path()
+    print(f"Capability scores: {len(table)} benchmark-scored models")
+    print(f"  user cache: {user if user.exists() else '(none — using bundled snapshot)'}")
+    names = sorted({m.name for p in load_catalog() for m in p.models})
+    scored = sorted(((model_capability(n, table), n) for n in names), reverse=True)
+    covered = sum(1 for n in names if model_capability(n, table) >= 0 and _in_table(n, table))
+    print(f"  catalog models with a benchmark score: {covered}/{len(names)} (rest use heuristic)")
+    print(f"  top {args.limit} catalog models by capability:")
+    for cap, name in scored[: args.limit]:
+        print(f"    {cap:.3f}  {name}")
+    return 0
+
+
+def _in_table(name: str, table: dict) -> bool:
+    from .capability import normalize_model_name
+
+    return normalize_model_name(name) in table
+
+
 def cmd_proxy(args: argparse.Namespace) -> int:
     from .proxy import serve  # lazy: avoids http.server import on other paths
 
@@ -697,6 +747,21 @@ def build_parser() -> argparse.ArgumentParser:
         "--limit", type=int, default=10, help="number of providers to show"
     )
     p_catalog_status.set_defaults(func=cmd_catalog_status)
+
+    p_capability = sub.add_parser(
+        "capability", help="benchmark-scored model capability for quality routing"
+    )
+    capability_sub = p_capability.add_subparsers(dest="capability_command", required=True)
+    p_cap_sync = capability_sub.add_parser(
+        "sync", help="refresh capability scores from public benchmarks (Arena; AA with a key)"
+    )
+    p_cap_sync.add_argument("--timeout", type=float, default=20.0, help="download timeout seconds")
+    p_cap_sync.set_defaults(func=cmd_capability_sync)
+    p_cap_status = capability_sub.add_parser(
+        "status", help="show capability-score coverage and the top-scoring models"
+    )
+    p_cap_status.add_argument("--limit", type=int, default=15, help="number of models to show")
+    p_cap_status.set_defaults(func=cmd_capability_status)
 
     p_capacity = sub.add_parser("capacity", help="summarize legitimate LLM capacity")
     capacity_sub = p_capacity.add_subparsers(dest="capacity_command", required=True)

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 
 from . import client as _client
 from .cache import Cache
+from .capability import capability_table, fit_penalty, model_capability, prompt_difficulty
 from .client import PostFn, StreamPostFn, default_post, default_stream_post
 from .config import (
     configured_embedders,
@@ -112,12 +113,14 @@ class Pool:
         self.cooldown_seconds = cooldown_seconds
         self._clock = clock or time.monotonic
         self.metrics = metrics or Metrics()
-        # "fair"  — least-used provider first, then least-used model in provider.
-        # "fast"  — lowest measured provider latency / failure penalty first.
+        # "fair"   — least-used provider first, then least-used model in provider.
+        # "fast"   — lowest measured provider latency / failure penalty first.
+        # "quality"— match prompt difficulty to model capability (benchmark-scored),
+        #            so hard prompts get strong models and easy ones get light ones.
         # "legacy"/"model" keep the old per-(provider, model) balancing behavior.
         self.routing = (
             routing
-            if routing in ("fair", "fast", "legacy", "model", "model-fast")
+            if routing in ("fair", "fast", "quality", "legacy", "model", "model-fast")
             else "fair"
         )
         self._on_event = on_event
@@ -280,7 +283,7 @@ class Pool:
                 targets.append(Target(provider, m.name, m.rpd, m.context))
         return targets
 
-    def _order(self, targets: list[Target]) -> list[Target]:
+    def _order(self, targets: list[Target], difficulty: float | None = None) -> list[Target]:
         """Order candidate targets for failover.
 
         ``fair`` (default): least-used provider first, then least-used model inside
@@ -288,8 +291,15 @@ class Pool:
         because they expose more models.
 
         ``fast``: lowest measured provider latency / failure penalty first, then
-        least-used provider. ``legacy``/``model`` preserve the previous per-target
-        balancing. Either way the ordering is a hint — failover still reaches all.
+        least-used provider.
+
+        ``quality``: match the request's ``difficulty`` (0–1) to each model's
+        benchmark-scored capability — strong models for hard prompts, light models
+        for easy ones (rationing scarce strong-model quota). Ordered globally, not
+        provider-grouped, since capability match is the opted-in intent.
+
+        ``legacy``/``model`` preserve the previous per-target balancing. Either way
+        the ordering is a hint — failover still reaches all.
         """
 
         # One snapshot instead of a locked read per target (matters for large catalogs).
@@ -301,6 +311,22 @@ class Pool:
 
         def over_of(t: Target) -> int:
             return 1 if (t.rpd > 0 and used_of(t) >= t.rpd) else 0
+
+        if self.routing == "quality":
+            table = capability_table()
+            need = difficulty if difficulty is not None else 0.5
+
+            def quality_key(t: Target) -> tuple[int, int, float, int]:
+                # over-budget, then known-failing sink to the back (still reachable);
+                # then best capability-fit; then least-used as a fairness tiebreak.
+                return (
+                    over_of(t),
+                    1 if metrics.failing(t.name) else 0,
+                    fit_penalty(model_capability(t.model, table), need),
+                    used_of(t),
+                )
+
+            return sorted(targets, key=quality_key)
 
         if self.routing in ("legacy", "model", "model-fast"):
 
@@ -432,7 +458,12 @@ class Pool:
                     cached=True,
                 )
 
-        targets = self._order(self._all_targets(include=provider_list, model=model))
+        difficulty = (
+            prompt_difficulty(messages, max_tokens, tools) if self.routing == "quality" else None
+        )
+        targets = self._order(
+            self._all_targets(include=provider_list, model=model), difficulty=difficulty
+        )
         if not targets:
             raise NoProvidersConfigured("no candidate (provider, model) matched the given filters")
 
@@ -578,7 +609,10 @@ class Pool:
         """
         if not self.providers:
             raise NoProvidersConfigured("no provider has an API key set")
-        targets = self._order(self._all_targets(include=providers, model=model))
+        difficulty = prompt_difficulty(messages, max_tokens) if self.routing == "quality" else None
+        targets = self._order(
+            self._all_targets(include=providers, model=model), difficulty=difficulty
+        )
         targets = [t for t in targets if t.provider.adapter != "gemini"]
         if not targets:
             raise NoProvidersConfigured("no streamable (provider, model) matched the filters")

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -1,0 +1,112 @@
+"""Capability scoring + prompt-difficulty for quality-tiered routing."""
+
+from __future__ import annotations
+
+import json
+
+from freellmpool import capability as c
+
+
+def test_normalize_collapses_variants_and_strips_vendor():
+    assert c.normalize_model_name("openai/gpt-oss-120b") == "gpt-oss-120b"
+    # packaging/variant suffixes drop, so equivalent names collapse to one key
+    assert c.normalize_model_name("llama-3.3-70b-versatile") == c.normalize_model_name(
+        "llama-3.3-70b-instruct"
+    )
+    # redundant leading vendor org token is stripped
+    assert c.normalize_model_name("Meta-Llama-3.3-70B-Instruct").startswith("llama-3.3-70b")
+
+
+def test_heuristic_orders_by_size_and_keywords():
+    assert c._heuristic_score("llama-3.1-405b") > c._heuristic_score("llama-3.1-8b-instant")
+    assert c._heuristic_score("foo-flash") <= 0.40  # downweight keyword
+    assert c._heuristic_score("brand-new-unknown") == 0.5  # neutral when nothing parses
+
+
+def test_prompt_difficulty_easy_below_hard():
+    easy = [{"role": "user", "content": "hi"}]
+    hard = [
+        {
+            "role": "user",
+            "content": "Debug and refactor this algorithm:\n```python\ndef f():\n  pass\n```\n"
+            "Explain step by step why it is slow.",
+        }
+    ]
+    assert c.prompt_difficulty(easy) < c.prompt_difficulty(hard)
+    # tool use bumps difficulty
+    assert c.prompt_difficulty(easy, tools=[{"type": "function"}]) > c.prompt_difficulty(easy)
+
+
+def test_fit_penalty_is_asymmetric():
+    # a hard prompt: under-powered model penalized far more than an over-powered one
+    assert c.fit_penalty(0.4, 0.9) > c.fit_penalty(0.95, 0.9)
+    # an easy prompt: a light model beats an over-powered one (rationing)
+    assert c.fit_penalty(0.2, 0.1) < c.fit_penalty(0.95, 0.1)
+    # an exact match is free
+    assert c.fit_penalty(0.5, 0.5) == 0.0
+
+
+def test_normalize_scores_percentile_rank():
+    scores = c.normalize_scores({"a-1b": 1000.0, "b-7b": 1200.0, "c-70b": 1400.0, "d-405b": 1500.0})
+    n = c.normalize_model_name
+    # percentile rank preserves order; top model near 1.0, bottom near 0.0
+    assert scores[n("a-1b")] < scores[n("b-7b")] < scores[n("c-70b")] < scores[n("d-405b")]
+    assert scores[n("d-405b")] > 0.8
+    assert scores[n("a-1b")] < 0.2
+
+
+def test_build_table_precedence_and_relaxed_match():
+    catalog = ["qwen-3-235b-a22b-instruct-2507", "llama-3.3-70b-versatile"]
+    arena = {"Qwen3-235B-A22B": 1400.0, "Llama-3.3-70B-Instruct": 1300.0, "tiny-1b": 1000.0}
+    aa = {"Llama 3.3 70B": 60.0}  # AA must win for llama
+    table = c.build_capability_table(aa_scores=aa, arena_scores=arena, catalog_names=catalog)
+    # qwen matched despite "qwen3" vs "qwen-3" separator difference (core match)
+    assert c.normalize_model_name("qwen-3-235b-a22b-instruct-2507") in table
+    # AA takes precedence over Arena for the same model
+    llama_key = c.normalize_model_name("llama-3.3-70b-versatile")
+    assert table[llama_key]["source"] == "aa"
+
+
+def test_build_table_precedence_aa_arena_aider():
+    # AA > Arena > Aider; a model only Aider has still gets covered, tagged "aider".
+    catalog = ["frontier-100b", "only-on-aider-70b"]
+    aa = {"frontier-100b": 60.0, "other-a": 10.0}
+    arena = {"frontier-100b": 1500.0, "other-b": 1000.0}
+    aider = {"only-on-aider-70b": 80.0, "other-c": 5.0}
+    table = c.build_capability_table(
+        aa_scores=aa, arena_scores=arena, aider_scores=aider, catalog_names=catalog
+    )
+    assert table[c.normalize_model_name("frontier-100b")]["source"] == "aa"  # AA wins
+    assert table[c.normalize_model_name("only-on-aider-70b")]["source"] == "aider"
+
+
+def test_build_table_family_param_approximation():
+    # An uncovered variant borrows the same-family, same-size score, tagged approx.
+    catalog = ["llama-3.1-nemotron-nano-8b-v1"]
+    arena = {"Llama-3.1-8B-Instruct": 1200.0, "GPT-5": 1500.0}
+    table = c.build_capability_table(arena_scores=arena, catalog_names=catalog)
+    key = c.normalize_model_name("llama-3.1-nemotron-nano-8b-v1")
+    assert key in table
+    assert table[key]["source"] == "arena~"  # same family (llama) + size (8b)
+
+
+def test_direct_match_beats_family_param_approximation():
+    # A model with an exact name should never be downgraded to an approximation.
+    catalog = ["llama-3.1-8b-instruct"]
+    arena = {"Llama-3.1-8B-Instruct": 1200.0}
+    table = c.build_capability_table(arena_scores=arena, catalog_names=catalog)
+    key = c.normalize_model_name("llama-3.1-8b-instruct")
+    assert table[key]["source"] == "arena"  # direct, not "arena~"
+
+
+def test_model_capability_prefers_table_then_heuristic(tmp_path, monkeypatch):
+    cap_file = tmp_path / "cap.json"
+    cap_file.write_text(
+        json.dumps({"scores": {"my-model": {"score": 0.77, "source": "arena"}}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FREELLMPOOL_CAPABILITY_FILE", str(cap_file))
+    c._table_cached.cache_clear()
+    assert c.model_capability("my-model") == 0.77
+    # a model in neither the table nor the bundle falls back to the heuristic neutral
+    assert c.model_capability("totally-unknown-zzz") == 0.5

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from freellmpool import capability as c
 
 
@@ -110,3 +112,55 @@ def test_model_capability_prefers_table_then_heuristic(tmp_path, monkeypatch):
     assert c.model_capability("my-model") == 0.77
     # a model in neither the table nor the bundle falls back to the heuristic neutral
     assert c.model_capability("totally-unknown-zzz") == 0.5
+
+
+def test_read_scores_clamps_and_rejects_bad_values(tmp_path):
+    f = tmp_path / "cap.json"
+    f.write_text(
+        json.dumps(
+            {
+                "scores": {
+                    "hi": 999,  # clamps to 1.0
+                    "lo": -5,  # clamps to 0.0
+                    "ok": {"score": 0.4},
+                    "nan": float("nan"),
+                    "inf": float("inf"),
+                    "str": "abc",
+                    "none": {"score": None},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = c._read_scores(f)
+    assert out["hi"] == 1.0 and out["lo"] == 0.0 and out["ok"] == 0.4
+    assert all(0.0 <= v <= 1.0 for v in out.values())
+    for bad in ("nan", "inf", "str", "none"):  # non-finite / unparseable dropped
+        assert bad not in out
+
+
+def test_read_scores_rejects_non_dict_payloads(tmp_path):
+    for body in ("[1,2,3]", "42", "{not json", '{"scores": [1,2]}'):
+        f = tmp_path / "x.json"
+        f.write_text(body, encoding="utf-8")
+        assert c._read_scores(f) == {}
+
+
+def test_fetch_aa_scores_refuses_unsafe_url_without_calling_network(monkeypatch):
+    import freellmpool.capability as cap
+
+    called = {"n": 0}
+
+    def boom(*a, **k):
+        called["n"] += 1
+        raise AssertionError("network must not be called for an unsafe AA URL")
+
+    monkeypatch.setattr(cap, "_get_json", boom)
+    for bad in (
+        "http://artificialanalysis.ai/x",
+        "https://evil.example/x",
+        "https://evil.artificialanalysis.ai.attacker.com/x",
+    ):
+        with pytest.raises(ValueError):
+            cap.fetch_aa_scores(api_key="secret", url=bad, timeout=1)
+    assert called["n"] == 0  # key never sent

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
-from helpers import make_post
+from helpers import make_post, make_stream_post
 
 from freellmpool import capability as _capability
 from freellmpool.models import Model, Provider
 from freellmpool.router import Pool
+
+_EASY = [{"role": "user", "content": "hi"}]
+_HARD = [
+    {
+        "role": "user",
+        "content": "Debug and refactor this algorithm:\n```python\ndef f():\n  pass\n```\n"
+        "Explain step by step why it is slow.",
+    }
+]
 
 
 def _names(pool, **kw):
@@ -14,7 +23,11 @@ def _names(pool, **kw):
 
 
 def _quality_pool(tmp_path, monkeypatch, quota, *, scores, models):
-    """A quality-routing pool over ``models`` with an injected capability table."""
+    """A quality-routing pool over ``models`` with an injected capability table.
+
+    All providers succeed (200), so whichever target quality routing puts first is
+    the one that actually serves — letting end-to-end tests assert on `reply.model`.
+    """
     import json
 
     cap_file = tmp_path / "cap.json"
@@ -32,7 +45,14 @@ def _quality_pool(tmp_path, monkeypatch, quota, *, scores, models):
         key_env="X_KEY",
         models=tuple(models),
     )
-    return Pool([provider], quota=quota, env={"X_KEY": "k"}, post=make_post({}), routing="quality")
+    return Pool(
+        [provider],
+        quota=quota,
+        env={"X_KEY": "k"},
+        post=make_post({}),
+        stream_post=make_stream_post({}),
+        routing="quality",
+    )
 
 
 def test_fair_default_is_least_used(providers, env, quota):
@@ -155,3 +175,53 @@ def test_quality_failing_model_sinks(tmp_path, monkeypatch, quota):
         pool.metrics.record_failure("x/big", "boom")
     order = [t.model for t in pool._order(pool._all_targets(), difficulty=0.9)]
     assert order[0] == "small"  # a healthy light model beats a failing strong one
+
+
+# ---- end-to-end: difficulty is computed and threaded through the public APIs ----
+
+
+def _qpool(tmp_path, monkeypatch, quota):
+    # Both capabilities sit ABOVE the easy-prompt difficulty floor (~0.35), so the
+    # easy/hard split exercises rationing (prefer the right-sized model) rather than
+    # the under-powered penalty. small (0.5) wins easy; big (0.95) wins hard.
+    return _quality_pool(
+        tmp_path,
+        monkeypatch,
+        quota,
+        scores={"big": 0.95, "small": 0.5},
+        models=[Model("big"), Model("small")],
+    )
+
+
+def test_quality_chat_end_to_end(tmp_path, monkeypatch, quota):
+    # All providers return 200, so the model that actually serves is the one quality
+    # routing ordered first — proving difficulty is computed and threaded in chat().
+    pool = _qpool(tmp_path, monkeypatch, quota)
+    assert pool.chat(_EASY).model == "small"
+    assert pool.chat(_HARD).model == "big"
+
+
+def test_quality_stream_chat_end_to_end(tmp_path, monkeypatch, quota):
+    pool = _qpool(tmp_path, monkeypatch, quota)
+
+    def served(messages):
+        meta = next(pool.stream_chat(messages))  # first yield is {"provider","model"}
+        return meta["model"]
+
+    assert served(_EASY) == "small"
+    assert served(_HARD) == "big"
+
+
+def test_quality_achat_end_to_end(tmp_path, monkeypatch, quota):
+    import asyncio
+
+    from freellmpool.aio import AsyncPool
+
+    pool = _qpool(tmp_path, monkeypatch, quota)
+
+    async def apost(url, headers, body, timeout):
+        return pool._post(url, headers, body, timeout)
+
+    apool = AsyncPool(pool, apost=apost)
+    assert asyncio.run(apool.achat(_EASY)).model == "small"
+    assert asyncio.run(apool.achat(_HARD)).model == "big"

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -4,11 +4,35 @@ from __future__ import annotations
 
 from helpers import make_post
 
+from freellmpool import capability as _capability
+from freellmpool.models import Model, Provider
 from freellmpool.router import Pool
 
 
 def _names(pool, **kw):
     return [t.name for t in pool._order(pool._all_targets(**kw))]
+
+
+def _quality_pool(tmp_path, monkeypatch, quota, *, scores, models):
+    """A quality-routing pool over ``models`` with an injected capability table."""
+    import json
+
+    cap_file = tmp_path / "cap.json"
+    cap_file.write_text(
+        json.dumps({"scores": {k: {"score": v, "source": "arena"} for k, v in scores.items()}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("FREELLMPOOL_CAPABILITY_FILE", str(cap_file))
+    _capability._table_cached.cache_clear()
+    provider = Provider(
+        id="x",
+        label="X",
+        adapter="openai",
+        base_url="https://x.test/v1",
+        key_env="X_KEY",
+        models=tuple(models),
+    )
+    return Pool([provider], quota=quota, env={"X_KEY": "k"}, post=make_post({}), routing="quality")
 
 
 def test_fair_default_is_least_used(providers, env, quota):
@@ -88,3 +112,46 @@ def test_402_capability_error_not_health_failure(providers, env, quota):
     pool.chat([{"role": "user", "content": "hi"}], providers=["alpha", "beta"])
     st = pool.metrics.get("alpha/alpha-small")
     assert st is None or st.fail == 0
+
+
+def test_quality_matches_difficulty_to_capability(tmp_path, monkeypatch, quota):
+    pool = _quality_pool(
+        tmp_path,
+        monkeypatch,
+        quota,
+        scores={"big": 0.9, "small": 0.2},
+        models=[Model("big"), Model("small")],
+    )
+    targets = pool._all_targets()
+    # hard prompt → strong model first; easy prompt → light model first (rationing)
+    assert pool._order(targets, difficulty=0.9)[0].model == "big"
+    assert pool._order(targets, difficulty=0.1)[0].model == "small"
+
+
+def test_quality_over_budget_model_sinks(tmp_path, monkeypatch, quota):
+    pool = _quality_pool(
+        tmp_path,
+        monkeypatch,
+        quota,
+        scores={"big": 0.9, "small": 0.2},
+        models=[Model("big", rpd=1), Model("small")],
+    )
+    quota.record("x", "big", 1)  # big is now over its daily cap
+    # even for a hard prompt, an over-budget strong model sinks behind a usable one
+    order = [t.model for t in pool._order(pool._all_targets(), difficulty=0.9)]
+    assert order[0] == "small"
+    assert order[-1] == "big"  # still reachable, just last
+
+
+def test_quality_failing_model_sinks(tmp_path, monkeypatch, quota):
+    pool = _quality_pool(
+        tmp_path,
+        monkeypatch,
+        quota,
+        scores={"big": 0.9, "small": 0.2},
+        models=[Model("big"), Model("small")],
+    )
+    for _ in range(3):  # enough samples to mark "big" as failing
+        pool.metrics.record_failure("x/big", "boom")
+    order = [t.model for t in pool._order(pool._all_targets(), difficulty=0.9)]
+    assert order[0] == "small"  # a healthy light model beats a failing strong one


### PR DESCRIPTION
## Summary

Adds an opt-in routing mode, `FREELLMPOOL_ROUTING=quality`, that matches each prompt's **difficulty** to each model's **capability** — hard prompts (long input, code, reasoning cues) go to the strongest *available* model, easy ones to lightweight models. This rations scarce strong-model quota so the pool stays sharp as daily caps fill (the "the pool gets dumber by evening" problem).

Default stays `fair`; this is fully opt-in and backward-compatible.

## Capability is grounded in real benchmarks, not guessed from names

- **Offline bundle** (`capability_scores.json`): [LMArena](https://lmarena.ai/) Elo (MIT mirror) + [Aider](https://aider.chat/) code-editing leaderboard (Apache-2.0), ~40% of the catalog.
- **Runtime (much broader, ~77%):** `freellmpool capability sync` with a free [Artificial Analysis](https://artificialanalysis.ai/) key (`FREELLMPOOL_AA_API_KEY`) layers in the Intelligence Index. AA data is cached locally under the user's own key and **never bundled** (their terms forbid redistribution; attribution is shown).
- Sources are **percentile-rank normalized** so scores from different benchmarks are comparable, and resolved by precedence **AA → Arena → Aider → name heuristic** (precedence follows measured correlation with AA: Arena ≈ 0.73, Aider ≈ 0.60). Name matching is vendor/date/param/family-aware with a same-family/size approximation for fine-tunes (tagged `~`).

## What's included

- `src/freellmpool/capability.py` (new): normalization, scoring, prompt-difficulty heuristics, asymmetric `fit_penalty` (never under-serves a hard prompt).
- `quality` branch in `Pool._order`; `difficulty` threaded from `chat`/`stream_chat`/`achat`. Over-budget and failing targets still sink and stay reachable.
- CLI: `freellmpool capability sync` / `status`.
- Bundled score table + packaging; README / ARCHITECTURE / config docs.

## Testing

- `pytest` — 251 pass (new `tests/test_capability.py` + quality cases in `tests/test_routing.py`).
- `ruff check src/freellmpool tests` — clean.
- Pre-PR Codex review; addressed: param-strip conflation guard, family-allowlist for approximation, AA-key host allowlist, refuse AA writes into the package dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add benchmark-based model capability scoring and a new quality routing mode that matches prompt difficulty to model capability, along with CLI support, documentation, and tests.

New Features:
- Introduce quality-based routing mode that orders targets by benchmark-scored capability matched to prompt difficulty for chat, streaming, and async chat paths.
- Add capability scoring module that normalizes public benchmark data and heuristics into per-model capability scores for routing decisions.
- Provide CLI subcommands to sync capability scores from benchmarks and to report coverage and top-scoring models.

Enhancements:
- Include bundled capability score snapshot in the package build and expose capability-based ordering in the router while preserving existing routing modes.
- Document the quality routing strategy, benchmark sources, and capability sync/status usage in README and architecture docs.

Tests:
- Add unit tests for capability scoring, prompt difficulty estimation, and table building, plus routing tests covering quality mode behavior and failure/over-budget sinking.