### PR TITLE
OpenCode integration: embedded live dashboard + status tools + per-request routing

### DIFF
--- a/integrations/.gitignore
+++ b/integrations/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.tgz
+package-lock.json

--- a/integrations/opencode-tui/README.md
+++ b/integrations/opencode-tui/README.md
@@ -1,0 +1,68 @@
+# freellmpool dashboard for OpenCode (embedded TUI)
+
+A live, themed dashboard that renders **inside** [OpenCode](https://opencode.ai) — in the
+session sidebar and on the home screen — showing, in real time, how much your free
+[freellmpool](https://github.com/0xzr/freellmpool) pool is doing for you:
+
+```
+┌─ freellmpool ─────────────────────┐
+│ routing quality                   │
+│ 💸 $0.0006 saved ⚡ 128 tok/s     │
+│ 50 tokens served free · 13 req    │
+│ ── provider race ──               │
+│ 🥇 llm7       ██████████ 9 ⏳53s  │
+│ 🥈 ovh        ████░░░░░░ 4        │
+│ 🥉 github     █░░░░░░░░░ 1/3600   │
+│ latency ███████▇▇▇▇▇ 124ms        │
+│ last: github/codestral-2501       │
+└───────────────────────────────────┘
+```
+
+- **routing mode**, **$ saved**, **tokens served free**, and live **throughput (tok/s)**
+- a medal'd **provider race** — requests used today vs daily cap, with live cooldown timers
+- a **latency sparkline** (best provider EWMA over time)
+- the **most-recently-served** provider/model
+- updates every 1.5s by polling the proxy's `/status`; shows an offline banner if the
+  proxy is down
+
+It's a real OpenTUI/SolidJS plugin (not text in a tool result), so it's themed to match
+your editor and lives alongside OpenCode's own Context / MCP / LSP panels.
+
+## Install
+
+OpenCode TUI plugins are installed with the built-in installer (which wires the OpenTUI
+runtime for you — there are no `node_modules` to manage):
+
+```sh
+# from a clone of the freellmpool repo:
+opencode plugin -g file:/absolute/path/to/integrations/opencode-tui
+```
+
+That records the plugin in `~/.config/opencode/tui.json`. Start the proxy
+(`freellmpool-proxy`) and launch `opencode` — the panel appears on the home screen and in
+the session sidebar.
+
+> TUI plugins are configured in `tui.json`, **not** the `plugin` array in `opencode.json`
+> (that array is for server/event-hook plugins, like the companion `opencode-freellmpool`
+> tools plugin in `../opencode`).
+
+To remove it, delete the entry from `~/.config/opencode/tui.json`.
+
+## Configuration (env)
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `FREELLMPOOL_PROXY_URL` | `http://localhost:8765` | proxy base URL the dashboard polls |
+| `FREELLMPOOL_PROXY_KEY` | _(none)_ | sent as `Authorization: Bearer <key>` if your proxy requires one |
+
+## Controlling routing
+
+Switch OpenCode's model to `freellmpool/fast`, `/quality`, or `/fair` to change routing;
+the dashboard's `routing` line reflects the active mode. See the proxy README for what each
+mode does.
+
+## Requirements
+
+OpenCode ≥ 1.14 (the embedded-TUI plugin API). The OpenTUI runtime (`@opentui/solid`,
+`solid-js`) is provided by OpenCode at load time via its runtime-plugin support — this
+package intentionally ships no runtime dependencies.

--- a/integrations/opencode-tui/index.tsx
+++ b/integrations/opencode-tui/index.tsx
@@ -1,0 +1,221 @@
+/** @jsxImportSource @opentui/solid */
+//
+// freellmpool — embedded live dashboard for OpenCode.
+//
+// A themed panel that renders *inside* opencode (sidebar + home screen), polling the
+// freellmpool proxy's /status endpoint and showing, live: the routing mode, estimated
+// $ saved, tokens served free, a provider "race", current throughput (tok/s), a
+// latency sparkline, and the most-recently-served provider/model.
+//
+// Install:  opencode plugin -g file:/path/to/integrations/opencode-tui
+// Config:   FREELLMPOOL_PROXY_URL (default http://localhost:8765)
+//
+import { createSignal, onCleanup, For, Show } from "solid-js"
+
+const PROXY = (process.env.FREELLMPOOL_PROXY_URL || "http://localhost:8765").replace(/\/+$/, "")
+const PROXY_KEY = process.env.FREELLMPOOL_PROXY_KEY || ""
+const AUTH = PROXY_KEY ? { Authorization: `Bearer ${PROXY_KEY}` } : {}
+const POLL_MS = 1500
+
+// ── formatting helpers ───────────────────────────────────────────────────────
+const BAR = "█"
+const BAR_BG = "░"
+const SPARK = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"]
+const MEDALS = ["🥇", "🥈", "🥉"]
+
+function bar(frac: number, width = 10): string {
+  const f = Math.max(0, Math.min(1, frac || 0))
+  const fill = Math.round(f * width)
+  return BAR.repeat(fill) + BAR_BG.repeat(width - fill)
+}
+
+function sparkline(values: number[], width = 12): string {
+  if (!values.length) return ""
+  const recent = values.slice(-width)
+  const max = Math.max(...recent, 1)
+  const min = Math.min(...recent, 0)
+  const span = max - min || 1
+  return recent.map((v) => SPARK[Math.min(SPARK.length - 1, Math.floor(((v - min) / span) * (SPARK.length - 1)))]).join("")
+}
+
+function money(usd: number): string {
+  const v = Number(usd) || 0
+  return v >= 1 ? `$${v.toFixed(2)}` : `$${v.toFixed(4)}`
+}
+
+function compact(n: number): string {
+  const v = Number(n) || 0
+  if (v >= 1e9) return `${(v / 1e9).toFixed(1)}B`
+  if (v >= 1e6) return `${(v / 1e6).toFixed(1)}M`
+  if (v >= 1e3) return `${(v / 1e3).toFixed(1)}K`
+  return `${v}`
+}
+
+function truncate(s: string, max = 28): string {
+  return s.length > max ? s.slice(0, max - 1) + "…" : s
+}
+
+// ── plugin ───────────────────────────────────────────────────────────────────
+const plugin = async (api) => {
+  const [status, setStatus] = createSignal<any>(null)
+  const [down, setDown] = createSignal(false)
+  const [tps, setTps] = createSignal(0)
+  const [latHist, setLatHist] = createSignal<number[]>([])
+
+  let prev: { tokens: number; t: number } | null = null
+
+  const poll = async () => {
+    try {
+      const res = await fetch(`${PROXY}/status`, { headers: AUTH })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const s = await res.json()
+      setStatus(s)
+      setDown(false)
+
+      // throughput: completion-token delta / elapsed since last sample
+      const tokens = Number(s?.pool?.completion_tokens) || 0
+      const now = Date.now()
+      if (prev && now > prev.t) {
+        const dt = (now - prev.t) / 1000
+        const dTok = tokens - prev.tokens
+        setTps(dTok > 0 ? Math.round(dTok / dt) : 0)
+      }
+      prev = { tokens, t: now }
+
+      // latency history = best per-provider ewma each tick (for the sparkline)
+      const mss: number[] = []
+      for (const p of s?.providers || []) {
+        for (const m of p?.models || []) {
+          if (typeof m.ewma_ms === "number" && m.ewma_ms > 0) mss.push(m.ewma_ms)
+        }
+      }
+      if (mss.length) {
+        const best = Math.min(...mss)
+        setLatHist((h) => [...h.slice(-23), best])
+      }
+    } catch {
+      setDown(true)
+    }
+  }
+  poll()
+  const timer = setInterval(poll, POLL_MS)
+  onCleanup(() => clearInterval(timer))
+
+  // top providers by requests-used-today (the "race")
+  const topProviders = () => {
+    const s = status()
+    if (!s?.providers) return [] as any[]
+    return s.providers
+      .filter((p: any) => p.configured)
+      .map((p: any) => {
+        const models = p.models || []
+        const used = models.reduce((a: number, m: any) => a + (Number(m.used_today) || 0), 0)
+        const cap = models.reduce((a: number, m: any) => a + (m.rpd > 0 ? m.rpd : 0), 0)
+        return { id: p.id, used, cap, cooldown: Number(p.cooldown_remaining_s) || 0 }
+      })
+      .sort((a: any, b: any) => b.used - a.used)
+      .slice(0, 5)
+  }
+  const maxUsed = () => Math.max(1, ...topProviders().map((p: any) => p.used))
+
+  // ── the panel component (used by both the sidebar and the home screen) ──────
+  const Panel = () => {
+    const theme = api.theme.current
+    return (
+      <Show
+        when={!down()}
+        fallback={
+          <box border borderColor={theme.error} paddingLeft={1} paddingRight={1} flexDirection="column">
+            <text fg={theme.error}>● freellmpool</text>
+            <text fg={theme.textMuted}>proxy offline — start `freellmpool-proxy`</text>
+          </box>
+        }
+      >
+        <box border borderColor={theme.success} title=" freellmpool " paddingLeft={1} paddingRight={1} flexDirection="column">
+          <box flexDirection="row" gap={1}>
+            <text fg={theme.textMuted}>routing</text>
+            <text fg={theme.accent}>{status()?.routing ?? "?"}</text>
+          </box>
+
+          <box flexDirection="row" gap={1}>
+            <text fg={theme.success}>💸 {money(status()?.pool?.usd_saved ?? 0)}</text>
+            <text fg={theme.textMuted}>saved</text>
+            <text fg={theme.info}>⚡ {tps()} tok/s</text>
+          </box>
+
+          <text fg={theme.textMuted}>
+            {compact(status()?.pool?.completion_tokens ?? 0)} tokens served free · {status()?.pool?.requests ?? 0} req
+          </text>
+
+          <text fg={theme.textMuted}>── provider race ──</text>
+          <For each={topProviders()}>
+            {(p: any, i) => (
+              <box flexDirection="row" gap={1}>
+                <text fg={theme.text}>
+                  {MEDALS[i()] ?? "  "} {p.id.padEnd(10)}
+                </text>
+                <text fg={p.cooldown > 0 ? theme.warning : theme.success}>{bar(p.used / maxUsed())}</text>
+                <text fg={theme.textMuted}>
+                  {p.used}
+                  {p.cap > 0 ? `/${p.cap}` : ""}
+                  {p.cooldown > 0 ? ` ⏳${Math.ceil(p.cooldown)}s` : ""}
+                </text>
+              </box>
+            )}
+          </For>
+
+          <Show when={latHist().length > 1}>
+            <box flexDirection="row" gap={1}>
+              <text fg={theme.textMuted}>latency</text>
+              <text fg={theme.info}>{sparkline(latHist())}</text>
+              <text fg={theme.textMuted}>{Math.round(latHist()[latHist().length - 1] || 0)}ms</text>
+            </box>
+          </Show>
+
+          <Show when={status()?.recent?.[0]}>
+            <text fg={theme.textMuted}>last: {truncate(`${status().recent[0].provider}/${status().recent[0].model}`)}</text>
+          </Show>
+        </box>
+      </Show>
+    )
+  }
+
+  // sidebar panel (live, while you code) + a compact home-screen teaser
+  api.slots.register({
+    order: 50,
+    slots: {
+      sidebar_content() {
+        return <Panel />
+      },
+      home_bottom() {
+        const theme = api.theme.current
+        return (
+          <Show when={!down()} fallback={<text fg={theme.error}>● freellmpool proxy offline</text>}>
+            <box border borderColor={theme.success} paddingLeft={1} paddingRight={1} marginTop={1} flexDirection="row" gap={1}>
+              <text fg={theme.success}>● freellmpool</text>
+              <text fg={theme.text}>
+                {money(status()?.pool?.usd_saved ?? 0)} saved · {compact(status()?.pool?.completion_tokens ?? 0)} free tokens · {tps()} tok/s · {status()?.routing ?? "?"}
+              </text>
+            </box>
+          </Show>
+        )
+      },
+    },
+  })
+
+  // a command to surface a one-shot summary toast
+  api.command.register(() => [
+    {
+      title: "freellmpool: status",
+      value: "freellmpool.status",
+      category: "freellmpool",
+      onSelect() {
+        const s = status()
+        const msg = down() || !s ? "proxy offline" : `${money(s.pool?.usd_saved ?? 0)} saved · ${s.pool?.requests ?? 0} req · routing ${s.routing}`
+        api.ui.toast({ title: "freellmpool", message: msg, variant: down() ? "warning" : "success" })
+      },
+    },
+  ])
+}
+
+export default { id: "freellmpool-tui", tui: plugin }

--- a/integrations/opencode-tui/package.json
+++ b/integrations/opencode-tui/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "opencode-freellmpool-tui",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    "./tui": "./index.tsx"
+  }
+}

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -1,0 +1,82 @@
+# freellmpool plugin for OpenCode
+
+See which free provider/model is actually serving you, check usage and rate-limits,
+and control routing quality — all from inside [OpenCode](https://opencode.ai).
+
+It talks to a running [freellmpool](https://github.com/0xzr/freellmpool) proxy
+(`freellmpool proxy`, default `http://localhost:8765`).
+
+## What it adds
+
+- **`freellmpool_status` tool** — usage and estimated $ saved, per-provider quota /
+  rate-limit / cooldown / latency, the current routing mode, and the most-recently
+  served provider+model. Pass `verbose: true` for per-model detail. Ask the agent
+  things like *"check freellmpool status"* or *"how much quota is left?"*.
+- **`freellmpool_models` tool** — lists the model ids the proxy exposes (including the
+  routing aliases `auto` / `fast` / `quality` / `fair`).
+- **served-model toast** — after each reply, a small toast shows which provider+model
+  actually answered. OpenCode itself only knows the alias you picked
+  (`freellmpool/auto`), so the real target is read back from the proxy. Silence it with
+  `FREELLMPOOL_TOAST=0`.
+
+## Controlling routing (quality)
+
+Routing is chosen by the **model name** in OpenCode's model picker — no extra config:
+
+| Model | Routing |
+| --- | --- |
+| `freellmpool/auto` | proxy default (whatever `FREELLMPOOL_ROUTING` is set to) |
+| `freellmpool/fast` | lowest-latency provider first |
+| `freellmpool/quality` | match the model's capability to the prompt's difficulty |
+| `freellmpool/fair` | spread load across providers (preserve quota) |
+
+(Advanced: send an `X-Freellmpool-Routing: fast|quality|fair` header instead.)
+
+## Install
+
+**Option A — drop-in (no build):**
+
+```sh
+mkdir -p ~/.config/opencode/plugin
+cp freellmpool.js ~/.config/opencode/plugin/
+```
+
+**Option B — reference from your `opencode.json` / `opencode.jsonc`:**
+
+```jsonc
+{
+  "plugin": ["/absolute/path/to/integrations/opencode/freellmpool.js"]
+}
+```
+
+Then make sure the proxy is running (`freellmpool proxy`) and that OpenCode has a
+`freellmpool` provider pointed at it (`baseURL: http://localhost:8765/v1`). Add the
+routing aliases as models so you can pick them:
+
+```jsonc
+{
+  "provider": {
+    "freellmpool": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": { "baseURL": "http://localhost:8765/v1" },
+      "models": {
+        "auto": {},
+        "fast": {},
+        "quality": {},
+        "fair": {}
+      }
+    }
+  }
+}
+```
+
+## Configuration (env)
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `FREELLMPOOL_PROXY_URL` | `http://localhost:8765` | proxy base URL |
+| `FREELLMPOOL_PROXY_KEY` | _(none)_ | sent as `Authorization: Bearer <key>` if your proxy requires one |
+| `FREELLMPOOL_TOAST` | on | set to `0`/`false`/`off` to silence the served-model toast |
+
+The plugin never throws on a down proxy — the tools return a short message and the
+toast hook stays quiet.

--- a/integrations/opencode/freellmpool.js
+++ b/integrations/opencode/freellmpool.js
@@ -1,0 +1,201 @@
+// freellmpool — OpenCode plugin
+//
+// Surfaces the freellmpool proxy *inside* OpenCode:
+//   • freellmpool_status  — usage, $ saved, per-provider quota / cooldown / latency,
+//                           and the most-recently-served provider+model.
+//   • freellmpool_models  — the model ids the proxy currently exposes.
+//   • a best-effort toast/log of which provider+model actually served each reply
+//     (OpenCode only knows the alias you asked for — e.g. "freellmpool/auto" — so
+//     the real target is read back from the proxy's /status `recent` buffer).
+//
+// Quality/routing control is done through OpenCode's own model picker: switch the
+// model to `freellmpool/fast`, `/quality`, or `/fair` (the proxy maps the name to a
+// routing mode). `freellmpool/auto` uses the proxy's default routing.
+//
+// Zero build step, zero extra deps: drop this file in ~/.config/opencode/plugin/ or
+// reference it from opencode.json `plugin`. Config:
+//   FREELLMPOOL_PROXY_URL   base URL (default http://localhost:8765)
+//   FREELLMPOOL_PROXY_KEY   sent as `Authorization: Bearer <key>` if the proxy needs one
+//   FREELLMPOOL_TOAST       set to 0/false/off to silence the served-model toast
+
+import { tool } from "@opencode-ai/plugin";
+
+const BASE_URL = (
+  process.env.FREELLMPOOL_PROXY_URL || "http://localhost:8765"
+).replace(/\/+$/, "");
+const PROXY_KEY = process.env.FREELLMPOOL_PROXY_KEY || "";
+const TOAST = !/^(0|false|off|no)$/i.test(process.env.FREELLMPOOL_TOAST || "");
+const TIMEOUT_MS = 5000;
+
+function authHeaders() {
+  return PROXY_KEY ? { Authorization: `Bearer ${PROXY_KEY}` } : {};
+}
+
+// GET <path> as JSON. Never throws — returns {ok, data?, error?} so a down proxy
+// surfaces as a friendly message instead of crashing the tool/hook.
+async function getJSON(path) {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(`${BASE_URL}${path}`, {
+      headers: { Accept: "application/json", ...authHeaders() },
+      signal: ac.signal,
+    });
+    const text = await res.text();
+    let data;
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      return { ok: false, error: `non-JSON response (HTTP ${res.status})` };
+    }
+    if (!res.ok) {
+      const msg = data?.error?.message || data?.error || `HTTP ${res.status}`;
+      return { ok: false, error: String(msg) };
+    }
+    return { ok: true, data };
+  } catch (err) {
+    const why = err?.name === "AbortError" ? `timed out after ${TIMEOUT_MS}ms` : err?.message || String(err);
+    return { ok: false, error: `cannot reach freellmpool proxy at ${BASE_URL} (${why})` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const num = (n) => (typeof n === "number" && isFinite(n) ? n : 0);
+const pad = (s, w) => String(s).padEnd(w);
+
+function fmtMoney(usd) {
+  const v = num(usd);
+  return v >= 1 ? `$${v.toFixed(2)}` : `$${v.toFixed(4)}`;
+}
+
+// Build the human-readable status report from a /status payload.
+function renderStatus(s, { verbose }) {
+  const lines = [];
+  const pool = s.pool || {};
+  lines.push(`freellmpool — routing: ${s.routing || "?"}`);
+  lines.push(
+    `usage: ${num(pool.requests)} requests · ` +
+      `${num(pool.prompt_tokens).toLocaleString()} in / ${num(pool.completion_tokens).toLocaleString()} out tok · ` +
+      `${num(pool.cache_hits)} cache hits · ~${fmtMoney(pool.usd_saved)} saved`,
+  );
+
+  const recent = Array.isArray(s.recent) ? s.recent : [];
+  if (recent.length) {
+    const r = recent[0];
+    lines.push(`last served: ${r.provider}/${r.model}${num(r.attempts) > 1 ? ` (after ${r.attempts} attempts)` : ""}`);
+  }
+
+  const providers = Array.isArray(s.providers) ? s.providers : [];
+  // Configured providers first, each with a one-line health summary.
+  const active = providers.filter((p) => p.configured);
+  lines.push("");
+  lines.push(`providers (${active.length}/${providers.length} configured):`);
+  for (const p of providers) {
+    if (!p.configured && !verbose) continue;
+    const models = Array.isArray(p.models) ? p.models : [];
+    // Aggregate quota across this provider's models (rpd-limited ones only).
+    let used = 0;
+    let cap = 0;
+    let capped = false;
+    let bestMs = null;
+    for (const m of models) {
+      used += num(m.used_today);
+      if (typeof m.rpd === "number" && m.rpd > 0) {
+        cap += m.rpd;
+        capped = true;
+      }
+      if (typeof m.ewma_ms === "number" && m.ewma_ms > 0) {
+        bestMs = bestMs === null ? m.ewma_ms : Math.min(bestMs, m.ewma_ms);
+      }
+    }
+    const flag = p.configured ? "✓" : "·";
+    const quota = capped ? `${used}/${cap} req` : `${used} req (no daily cap)`;
+    const cool = num(p.cooldown_remaining_s) > 0 ? ` · cooldown ${Math.ceil(p.cooldown_remaining_s)}s` : "";
+    const lat = bestMs !== null ? ` · ${Math.round(bestMs)}ms` : "";
+    lines.push(`  ${flag} ${pad(p.id, 12)} ${models.length} models · ${quota}${lat}${cool}`);
+
+    if (verbose) {
+      for (const m of models) {
+        const remain =
+          typeof m.remaining === "number" ? `${m.remaining} left` : "no cap";
+        const sr = typeof m.success_rate === "number" ? ` · ${Math.round(m.success_rate * 100)}% ok` : "";
+        const ms = typeof m.ewma_ms === "number" && m.ewma_ms > 0 ? ` · ${Math.round(m.ewma_ms)}ms` : "";
+        const err = m.last_error ? ` · last_err: ${String(m.last_error).slice(0, 60)}` : "";
+        lines.push(`      ${pad(m.name, 28)} ${num(m.used_today)} used · ${remain}${ms}${sr}${err}`);
+      }
+    }
+  }
+  if (!verbose) lines.push("(pass verbose:true for per-model quota/latency/errors)");
+  return lines.join("\n");
+}
+
+export const FreellmpoolPlugin = async ({ client }) => {
+  let lastSeenMsg = null; // dedupe message.updated (it fires repeatedly per message)
+
+  return {
+    tool: {
+      freellmpool_status: {
+        description:
+          "Show freellmpool proxy status: usage, estimated $ saved, per-provider " +
+          "quota/rate-limits/cooldown/latency, current routing mode, and the most " +
+          "recently served provider+model. Use when asked which model/provider is " +
+          "serving, how much quota is left, or how much spend has been saved.",
+        args: {
+          verbose: tool.schema
+            .boolean()
+            .optional()
+            .describe("Include per-model quota, latency, success rate, and last error."),
+        },
+        async execute(args) {
+          const { ok, data, error } = await getJSON("/status");
+          if (!ok) return `freellmpool status unavailable: ${error}`;
+          return renderStatus(data, { verbose: !!args.verbose });
+        },
+      },
+
+      freellmpool_models: {
+        description:
+          "List the model ids the freellmpool proxy currently exposes (including the " +
+          "routing aliases auto/fast/quality/fair). Use to discover what to set as the model.",
+        args: {},
+        async execute() {
+          const { ok, data, error } = await getJSON("/v1/models");
+          if (!ok) return `freellmpool models unavailable: ${error}`;
+          const ids = (data?.data || []).map((m) => m.id).filter(Boolean);
+          if (!ids.length) return "freellmpool: no models reported.";
+          return `freellmpool exposes ${ids.length} models:\n` + ids.map((id) => `  ${id}`).join("\n");
+        },
+      },
+    },
+
+    // Best-effort: when an assistant reply completes, read which provider+model the
+    // proxy actually used (OpenCode only knows the alias we asked for) and surface it.
+    event: async ({ event }) => {
+      if (!TOAST) return;
+      if (event?.type !== "message.updated") return;
+      const info = event.properties?.info;
+      if (!info || info.role !== "assistant" || !info.finish) return;
+      if (info.id === lastSeenMsg) return;
+      lastSeenMsg = info.id;
+
+      const { ok, data } = await getJSON("/status");
+      if (!ok) return;
+      const r = (data.recent || [])[0];
+      if (!r) return;
+      const served = `${r.provider}/${r.model}`;
+
+      const message = `served by ${served}${num(r.attempts) > 1 ? ` (${r.attempts} attempts)` : ""}`;
+      try {
+        await client.tui.showToast({
+          body: { title: "freellmpool", message, variant: "info", duration: 2500 },
+        });
+      } catch {
+        // TUI not attached (e.g. `opencode run`) — fall back to the log.
+        console.log(`[freellmpool] ${message}`);
+      }
+    },
+  };
+};
+
+export default FreellmpoolPlugin;

--- a/integrations/opencode/package.json
+++ b/integrations/opencode/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "opencode-freellmpool",
+  "version": "0.1.0",
+  "description": "OpenCode plugin for freellmpool: see the serving provider/model, usage & rate-limits, and control routing quality.",
+  "type": "module",
+  "main": "freellmpool.js",
+  "exports": "./freellmpool.js",
+  "keywords": ["opencode", "opencode-plugin", "freellmpool", "llm", "proxy"],
+  "license": "MIT",
+  "peerDependencies": {
+    "@opencode-ai/plugin": ">=1.14.0"
+  },
+  "files": ["freellmpool.js", "README.md"]
+}

--- a/src/freellmpool/agents.py
+++ b/src/freellmpool/agents.py
@@ -74,10 +74,17 @@ AGENTS: dict[str, dict] = {
             '    "freellmpool": {',
             '      "npm": "@ai-sdk/openai-compatible",',
             f'      "options": {{ "baseURL": "{_PROXY}" }},',
-            '      "models": { "auto": { "name": "freellmpool (auto)" } }',
+            '      "models": {',
+            '        "auto": {}, "fast": {}, "quality": {}, "fair": {}',
+            "      }",
             "    }",
             "  }",
+            "Pick freellmpool/{auto,fast,quality,fair} to control routing.",
         ],
+        "note": (
+            "Embedded dashboard + status/usage tools live in integrations/opencode "
+            "(server) and integrations/opencode-tui (live TUI panel)."
+        ),
     },
 }
 

--- a/src/freellmpool/cache.py
+++ b/src/freellmpool/cache.py
@@ -48,7 +48,7 @@ class Cache:
 
     @staticmethod
     def make_key(
-        messages, model, providers, max_tokens, temperature, tools, tool_choice=None
+        messages, model, providers, max_tokens, temperature, tools, tool_choice=None, routing=None
     ) -> str | None:
         try:
             payload = json.dumps(
@@ -60,6 +60,9 @@ class Cache:
                     "temperature": temperature,
                     "tools": tools,
                     "tool_choice": tool_choice,
+                    # routing mode expresses an intent about answer source/quality, so
+                    # a quality request must not be served a cached fast-routed answer.
+                    "routing": routing,
                 },
                 sort_keys=True,
             )

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -21,10 +21,12 @@ Supported routes:
 
 from __future__ import annotations
 
+import collections
 import hmac
 import json
 import os
 import threading
+from collections.abc import Sequence
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import urlsplit
 
@@ -37,12 +39,15 @@ from .errors import (
     NoProvidersConfigured,
 )
 from .router import Pool
+from .savings import usd_saved
 
 _MAX_BODY = 16 * 1024 * 1024  # 16 MB cap on request bodies
 
 
 def _model_ids(pool: Pool) -> list[str]:
-    ids = ["auto"]
+    # "auto" + per-request routing aliases (mapped to a routing mode by the proxy),
+    # then every enabled provider/model id.
+    ids = ["auto", "fast", "quality", "fair"]
     for provider in pool.providers:
         for m in provider.models:
             if m.enabled:
@@ -51,10 +56,7 @@ def _model_ids(pool: Pool) -> list[str]:
 
 
 def _openai_models_payload(pool: Pool) -> dict:
-    data = [
-        {"id": mid, "object": "model", "owned_by": "freellmpool"}
-        for mid in _model_ids(pool)
-    ]
+    data = [{"id": mid, "object": "model", "owned_by": "freellmpool"} for mid in _model_ids(pool)]
     return {"object": "list", "data": data}
 
 
@@ -78,7 +80,94 @@ def _anthropic_models_payload(pool: Pool) -> dict:
     }
 
 
+def _status_payload(pool: Pool, recent: Sequence[dict]) -> dict:
+    """Return a JSON-able status payload for the /status endpoint.
+
+    ``recent`` is a snapshot (most-recent-first) of the served-target ring buffer,
+    taken under its lock by the caller so iteration here is race-free.
+    """
+    now = pool._clock()
+    quota_snap = pool.quota.snapshot()
+    metrics_snap = pool.metrics.snapshot()
+
+    providers_list = []
+    for p in pool.providers:
+        cooldown_until = pool._cooldown_until.get(p.id, 0.0)
+        cooldown_remaining = max(0.0, cooldown_until - now)
+
+        models_list = []
+        for m in p.models:
+            if not m.enabled:
+                continue
+            key = f"{p.id}::{m.name}"
+            used = quota_snap.get(key, 0)
+            remaining = (m.rpd - used) if m.rpd > 0 else None
+            stat = metrics_snap.get(f"{p.id}/{m.name}")
+            models_list.append(
+                {
+                    "name": m.name,
+                    "rpd": m.rpd,
+                    "used_today": used,
+                    "remaining": remaining,
+                    "ewma_ms": stat.ewma_ms if stat else None,
+                    "success_rate": stat.success_rate if stat else None,
+                    "last_error": stat.last_error if stat else None,
+                }
+            )
+
+        providers_list.append(
+            {
+                "id": p.id,
+                "configured": p.is_configured(pool.env),
+                "cooldown_remaining_s": cooldown_remaining,
+                "models": models_list,
+            }
+        )
+
+    s = pool.stats
+    saved = usd_saved(s.get("prompt_tokens", 0), s.get("completion_tokens", 0))
+
+    return {
+        "routing": pool.routing,
+        "pool": {
+            "requests": s.get("requests", 0),
+            "prompt_tokens": s.get("prompt_tokens", 0),
+            "completion_tokens": s.get("completion_tokens", 0),
+            "cache_hits": s.get("cache_hits", 0),
+            "usd_saved": saved,
+        },
+        "providers": providers_list,
+        "recent": list(recent),
+    }
+
+
+_ROUTING_MODES = frozenset({"fair", "fast", "quality", "legacy", "model", "model-fast"})
+
+
+def _routing_and_model(headers, requested: str) -> tuple[str | None, str]:
+    """Resolve a per-request routing override. A valid mode in the
+    ``X-Freellmpool-Routing`` header, or the model name itself being a routing
+    keyword (e.g. ``fast``/``quality``), selects that mode and falls back to ``auto``
+    model selection. Returns ``(routing_override, requested_model)``."""
+    override = (headers.get("X-Freellmpool-Routing", "") or "").lower()
+    override = override if override in _ROUTING_MODES else None
+    if isinstance(requested, str) and requested.lower() in _ROUTING_MODES:
+        override = override or requested.lower()
+        requested = "auto"
+    return override, requested
+
+
 def make_handler(pool: Pool, api_key: str | None = None):
+    # Ring buffer of recently-served (provider, model). Appended from worker
+    # threads and snapshotted by /status, so guard it: a deque append is atomic,
+    # but iterating it (list(recent)) concurrently with an append can raise.
+    recent = collections.deque(maxlen=25)
+    recent_lock = threading.Lock()
+
+    def record_recent(entry: dict) -> None:
+        with recent_lock:
+            recent.appendleft(entry)
+
     class Handler(BaseHTTPRequestHandler):
         server_version = "freellmpool/0.10"
         # Socket read timeout: a slow/stalled client can't pin a worker thread + fd
@@ -170,6 +259,11 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 )
                 self._send(200, payload)
                 return
+            if path in ("/status", "/v1/status"):
+                with recent_lock:
+                    recent_snapshot = list(recent)
+                self._send(200, _status_payload(pool, recent_snapshot))
+                return
             self._error(404, f"unknown route {self.path}", "not_found")
 
         def _do_post(self) -> None:
@@ -231,7 +325,8 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 self._anthropic_error(400, "no usable message content in request")
                 return
             display_model = req.get("model") or "auto"
-            resolved = resolve_alias(str(chat["model"]), pool.env)
+            routing_override, model_str = _routing_and_model(self.headers, str(chat["model"]))
+            resolved = resolve_alias(model_str, pool.env)
             provider_filter, model_filter = _parse_model(resolved, {p.id for p in pool.providers})
             try:
                 reply = pool.chat(
@@ -242,6 +337,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
                     temperature=chat["temperature"],
                     tools=chat["tools"],
                     tool_choice=chat["tool_choice"],
+                    routing=routing_override,
                 )
             except NoProvidersConfigured as exc:
                 self._anthropic_error(503, str(exc), "no_providers")
@@ -252,6 +348,10 @@ def make_handler(pool: Pool, api_key: str | None = None):
             except AllProvidersExhausted as exc:
                 self._anthropic_error(502, str(exc), "all_providers_exhausted")
                 return
+            # Record recent served
+            record_recent(
+                {"provider": reply.provider_id, "model": reply.model, "attempts": reply.attempts}
+            )
             if req.get("stream"):
                 self._send_sse(reply_to_sse(reply, display_model))
             else:
@@ -295,6 +395,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
             if not isinstance(requested, str):
                 self._error(400, "'model' must be a string", "invalid_request_error")
                 return None
+            routing_override, requested = _routing_and_model(self.headers, requested)
             requested = resolve_alias(requested, pool.env)  # gpt-4o-mini → free target
             provider_filter, model_filter = _parse_model(requested, {p.id for p in pool.providers})
             try:
@@ -315,6 +416,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
                     temperature=temperature,
                     tools=tools,
                     tool_choice=tool_choice,
+                    routing=routing_override,
                 )
             except NoProvidersConfigured as exc:
                 self._error(503, str(exc), "no_providers")
@@ -343,6 +445,10 @@ def make_handler(pool: Pool, api_key: str | None = None):
             reply = self._resolve(req, norm, tools=tools, tool_choice=req.get("tool_choice"))
             if reply is None:
                 return
+            # Record recent served
+            record_recent(
+                {"provider": reply.provider_id, "model": reply.model, "attempts": reply.attempts}
+            )
             if req.get("stream"):
                 self._send_sse(_sse_chunks(reply))
             else:
@@ -353,6 +459,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
             if not isinstance(requested, str):
                 self._error(400, "'model' must be a string", "invalid_request_error")
                 return
+            routing_override, requested = _routing_and_model(self.headers, requested)
             provider_filter, model_filter = _parse_model(
                 resolve_alias(requested, pool.env), {p.id for p in pool.providers}
             )
@@ -372,6 +479,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
                     providers=provider_filter,
                     max_tokens=max_tokens,
                     temperature=temperature,
+                    routing=routing_override,
                 )
                 meta = next(gen)  # provider/model chosen, or raises before any bytes
             except NoProvidersConfigured as exc:
@@ -385,6 +493,13 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 # nothing streamable succeeded — fall back to a buffered completion
                 reply = self._resolve(req, norm)
                 if reply is not None:
+                    record_recent(
+                        {
+                            "provider": reply.provider_id,
+                            "model": reply.model,
+                            "attempts": reply.attempts,
+                        }
+                    )
                     self._send_sse(_sse_chunks(reply))
                 return
 
@@ -418,6 +533,8 @@ def make_handler(pool: Pool, api_key: str | None = None):
                     pass
             finally:
                 gen.close()  # release the upstream stream even on early disconnect
+            # Record recent served (stream)
+            record_recent({"provider": provider_id, "model": model_name, "attempts": 1})
 
         def _handle_responses(self, req: dict) -> None:
             """Minimal OpenAI Responses API (/v1/responses) shim for Codex CLI
@@ -429,6 +546,9 @@ def make_handler(pool: Pool, api_key: str | None = None):
             reply = self._resolve(req, messages)
             if reply is None:
                 return
+            record_recent(
+                {"provider": reply.provider_id, "model": reply.model, "attempts": reply.attempts}
+            )
             if req.get("stream"):
                 self._send_sse(_responses_sse_events(reply))
             else:

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -283,7 +283,9 @@ class Pool:
                 targets.append(Target(provider, m.name, m.rpd, m.context))
         return targets
 
-    def _order(self, targets: list[Target], difficulty: float | None = None) -> list[Target]:
+    def _order(
+        self, targets: list[Target], difficulty: float | None = None, routing: str | None = None
+    ) -> list[Target]:
         """Order candidate targets for failover.
 
         ``fair`` (default): least-used provider first, then least-used model inside
@@ -305,6 +307,11 @@ class Pool:
         # One snapshot instead of a locked read per target (matters for large catalogs).
         snap = self.quota.snapshot()
         metrics = self.metrics
+        mode = (
+            routing
+            if routing in ("fair", "fast", "quality", "legacy", "model", "model-fast")
+            else self.routing
+        )
 
         def used_of(t: Target) -> int:
             return int(snap.get(f"{t.provider.id}::{t.model}", 0))
@@ -312,7 +319,7 @@ class Pool:
         def over_of(t: Target) -> int:
             return 1 if (t.rpd > 0 and used_of(t) >= t.rpd) else 0
 
-        if self.routing == "quality":
+        if mode == "quality":
             table = capability_table()
             need = difficulty if difficulty is not None else 0.5
 
@@ -328,7 +335,7 @@ class Pool:
 
             return sorted(targets, key=quality_key)
 
-        if self.routing in ("legacy", "model", "model-fast"):
+        if mode in ("legacy", "model", "model-fast"):
 
             def legacy_fast_key(t: Target) -> tuple[int, float, int]:
                 return (over_of(t), metrics.score(t.name), used_of(t))
@@ -336,7 +343,7 @@ class Pool:
             def legacy_fair_key(t: Target) -> tuple[int, int, int]:
                 return (over_of(t), 1 if metrics.failing(t.name) else 0, used_of(t))
 
-            key = legacy_fast_key if self.routing == "model-fast" else legacy_fair_key
+            key = legacy_fast_key if mode == "model-fast" else legacy_fair_key
             return sorted(targets, key=key)
 
         by_provider: dict[str, _ProviderOrderStats] = {}
@@ -358,7 +365,7 @@ class Pool:
         def target_fast_key(t: Target) -> tuple[int, float, int]:
             return (over_of(t), metrics.score(t.name), used_of(t))
 
-        if self.routing == "fast":
+        if mode == "fast":
 
             def provider_fast_key(provider_id: str) -> tuple[int, float, int]:
                 stats = by_provider[provider_id]
@@ -431,6 +438,7 @@ class Pool:
         timeout: float = 90.0,
         tools: list | None = None,
         tool_choice=None,
+        routing: str | None = None,
     ) -> Reply:
         """Like :meth:`ask` but takes raw OpenAI-style ``messages``."""
         if not self.providers:
@@ -439,10 +447,18 @@ class Pool:
             )
 
         provider_list = list(providers) if providers else None
+        # Resolve the effective routing mode *before* the cache key so that a
+        # per-request override (fast/quality/fair/…) keys its own cache bucket and
+        # never serves a reply produced under a different mode's intent.
+        eff = (
+            routing
+            if routing in ("fair", "fast", "quality", "legacy", "model", "model-fast")
+            else self.routing
+        )
         cache_key = None
         if self._cache is not None:
             cache_key = self._cache.make_key(
-                messages, model, provider_list, max_tokens, temperature, tools, tool_choice
+                messages, model, provider_list, max_tokens, temperature, tools, tool_choice, eff
             )
             hit = self._cache.get(cache_key)
             if hit is not None:
@@ -458,11 +474,11 @@ class Pool:
                     cached=True,
                 )
 
-        difficulty = (
-            prompt_difficulty(messages, max_tokens, tools) if self.routing == "quality" else None
-        )
+        difficulty = prompt_difficulty(messages, max_tokens, tools) if eff == "quality" else None
         targets = self._order(
-            self._all_targets(include=provider_list, model=model), difficulty=difficulty
+            self._all_targets(include=provider_list, model=model),
+            difficulty=difficulty,
+            routing=routing,
         )
         if not targets:
             raise NoProvidersConfigured("no candidate (provider, model) matched the given filters")
@@ -599,6 +615,7 @@ class Pool:
         max_tokens: int = 1024,
         temperature: float = 0.0,
         timeout: float = 90.0,
+        routing: str | None = None,
     ):
         """Stream content deltas with token-level streaming.
 
@@ -609,9 +626,16 @@ class Pool:
         """
         if not self.providers:
             raise NoProvidersConfigured("no provider has an API key set")
-        difficulty = prompt_difficulty(messages, max_tokens) if self.routing == "quality" else None
+        eff = (
+            routing
+            if routing in ("fair", "fast", "quality", "legacy", "model", "model-fast")
+            else self.routing
+        )
+        difficulty = prompt_difficulty(messages, max_tokens) if eff == "quality" else None
         targets = self._order(
-            self._all_targets(include=providers, model=model), difficulty=difficulty
+            self._all_targets(include=providers, model=model),
+            difficulty=difficulty,
+            routing=routing,
         )
         targets = [t for t in targets if t.provider.adapter != "gemini"]
         if not targets:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -26,6 +26,15 @@ def test_make_key_includes_tool_choice():
     assert k_auto != k_req  # different tool_choice → different cache entry
 
 
+def test_make_key_includes_routing():
+    # a per-request routing override must not collide with a different mode's cache:
+    # a "quality" ask should never be served a cached "fast"-routed reply.
+    args = ([{"role": "user", "content": "hi"}], None, None, 1024, 0.0, None, None)
+    assert Cache.make_key(*args, routing="fast") != Cache.make_key(*args, routing="quality")
+    # the same effective mode still shares a bucket
+    assert Cache.make_key(*args, routing="fair") == Cache.make_key(*args, routing="fair")
+
+
 def test_pool_uses_cache(providers, env, quota, tmp_path):
     cache = Cache(ttl=999.0, path=tmp_path / "c.db")
     post = make_post({})  # returns "ok", counts calls

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -460,3 +460,75 @@ def test_null_assistant_content_not_stringified():
     out = _normalize_messages([{"role": "assistant", "content": None, "tool_calls": [{"id": "x"}]}])
     assert out[0]["content"] == ""
     assert out[0]["tool_calls"] == [{"id": "x"}]
+
+
+# ---- JSON /status endpoint + per-request routing control ----
+
+
+def _get_json(url, headers=None):
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req) as resp:  # noqa: S310 (localhost test)
+        return resp.status, json.load(resp)
+
+
+def test_status_endpoint_shape(server):
+    status, body = _get_json(server + "/status")
+    assert status == 200
+    assert "routing" in body
+    for k in ("requests", "prompt_tokens", "completion_tokens", "cache_hits", "usd_saved"):
+        assert k in body["pool"]
+    assert isinstance(body["providers"], list) and body["providers"]
+    p = body["providers"][0]
+    assert {"id", "configured", "cooldown_remaining_s", "models"} <= set(p)
+    assert isinstance(body["recent"], list)
+
+
+def test_status_v1_alias(server):
+    assert _get_json(server + "/v1/status")[0] == 200
+
+
+def test_status_records_served_target(server):
+    _post_json(
+        server + "/v1/chat/completions",
+        {"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    _, body = _get_json(server + "/status")
+    assert body["recent"], "expected a recent entry after a chat"
+    assert {"provider", "model", "attempts"} <= set(body["recent"][0])
+    assert body["pool"]["requests"] >= 1
+
+
+def test_models_route_includes_routing_aliases(server):
+    with urllib.request.urlopen(server + "/v1/models") as resp:  # noqa: S310
+        ids = {m["id"] for m in json.load(resp)["data"]}
+    assert {"auto", "fast", "quality", "fair"} <= ids
+
+
+def test_model_name_is_treated_as_routing_keyword(server):
+    # "fast" is a routing keyword, not a literal model id → served as auto + fast routing
+    status, body = _post_json(
+        server + "/v1/chat/completions",
+        {"model": "fast", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert status == 200
+    assert "x_freellmpool" in body
+
+
+def test_header_routing_override_accepted(server):
+    status, body = _post_json_with_headers(
+        server + "/v1/chat/completions",
+        {"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+        {"X-Freellmpool-Routing": "fast"},
+    )
+    assert status == 200
+    assert "x_freellmpool" in body
+
+
+def _post_json_with_headers(url, payload, headers):
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json", **headers},
+    )
+    with urllib.request.urlopen(req) as resp:  # noqa: S310 (localhost test)
+        return resp.status, json.load(resp)

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -225,3 +225,47 @@ def test_quality_achat_end_to_end(tmp_path, monkeypatch, quota):
     apool = AsyncPool(pool, apost=apost)
     assert asyncio.run(apool.achat(_EASY)).model == "small"
     assert asyncio.run(apool.achat(_HARD)).model == "big"
+
+
+# ---- per-request routing override (thread-safe; does not mutate self.routing) ----
+
+
+def test_order_routing_override_beats_default(tmp_path, monkeypatch, quota):
+    """A pool whose default is *not* quality still honors routing='quality' per call."""
+    pool = _quality_pool(
+        tmp_path,
+        monkeypatch,
+        quota,
+        scores={"big": 0.9, "small": 0.2},
+        models=[Model("big"), Model("small")],
+    )
+    pool.routing = "fair"  # flip default away from quality
+    targets = pool._all_targets()
+    # the per-call override reorders by capability even though the default is fair
+    assert pool._order(targets, difficulty=0.9, routing="quality")[0].model == "big"
+    # and it never mutates the pool's default
+    assert pool.routing == "fair"
+
+
+def test_order_invalid_routing_override_falls_back_to_default(tmp_path, monkeypatch, quota):
+    pool = _quality_pool(
+        tmp_path,
+        monkeypatch,
+        quota,
+        scores={"big": 0.9, "small": 0.2},
+        models=[Model("big"), Model("small")],
+    )
+    pool.routing = "fair"
+    targets = pool._all_targets()
+    # a bogus override is ignored → identical to the pool default ordering
+    assert [t.model for t in pool._order(targets, routing="bogus")] == [
+        t.model for t in pool._order(targets)
+    ]
+
+
+def test_chat_routing_override_end_to_end(tmp_path, monkeypatch, quota):
+    pool = _qpool(tmp_path, monkeypatch, quota)
+    pool.routing = "fast"  # default no longer computes difficulty
+    # a per-call routing="quality" still sends the hard prompt to the strong model
+    assert pool.chat(_HARD, routing="quality").model == "big"
+    assert pool.routing == "fast"  # default untouched


### PR DESCRIPTION
## OpenCode integration: an embedded live dashboard, status tools, and per-request routing control

Brings three things to [OpenCode](https://opencode.ai) users running on freellmpool: **(1)** see which provider/model is actually serving, **(2)** see usage + rate-limits/quota, and **(3)** control routing quality — without leaving the editor.

### ✨ The headline: a live dashboard *embedded in OpenCode*

A themed SolidJS/OpenTUI panel that renders right inside OpenCode (session sidebar + home screen) and updates every 1.5s off the proxy's `/status`:

```
┌─ freellmpool ─────────────────────┐
│ routing quality                   │
│ 💸 $0.0006 saved ⚡ 128 tok/s     │
│ 50 tokens served free · 13 req    │
│ ── provider race ──               │
│ 🥇 llm7       ██████████ 9 ⏳53s  │
│ 🥈 ovh        ████░░░░░░ 4        │
│ 🥉 github     █░░░░░░░░░ 1/3600   │
│ latency ███████▇▇▇▇▇ 124ms        │
│ last: github/codestral-2501       │
└───────────────────────────────────┘
```

Routing mode · estimated $ saved · tokens-served-free · live throughput · a medal'd **provider race** (requests-used vs daily cap, with live cooldown timers) · latency sparkline · last-served model. It's themed to match the user's editor and sits alongside OpenCode's own Context/MCP/LSP panels.

### What's included

**`integrations/opencode-tui/`** — the embedded TUI dashboard (`opencode plugin -g file:…`).

**`integrations/opencode/`** — a server plugin with `freellmpool_status` + `freellmpool_models` tools (work in headless `opencode run` too) and a best-effort served-model toast.

**Proxy / core** (`src/freellmpool/`):
- **Per-request routing override** — pick `freellmpool/fast|quality|fair` in the model picker, or send `X-Freellmpool-Routing: …`. Threaded through `_order`/`chat`/`stream_chat` with **no shared-state mutation** (the proxy is multi-threaded).
- **JSON `/status` endpoint** (+ `/v1/status`) — pool usage, $ saved, and per-provider quota / cooldown / latency / success-rate, behind the same auth gate as `/dashboard`.
- A thread-safe **recent-served ring buffer** feeding `/status`.
- `fast`/`quality`/`fair` advertised in `/v1/models`.

### Reliability / correctness (Codex-audited)

A Codex review pass surfaced 6 issues; 5 fixed, 1 intentional:
- **Cache key now includes the routing mode** — a `quality` request can no longer be served a cached `fast`-routed reply.
- **Thread-safe `recent` buffer** — `/status` snapshots under a lock so concurrent appends can't crash iteration.
- **TUI honors `FREELLMPOOL_PROXY_KEY`** — no false "offline" when a proxy key is set.
- **`/v1/responses` now records `recent`** (was missing).
- Removed an over-aggressive toast dedupe in the server plugin.
- (Intentionally kept `/v1/models` to the curated `auto/fast/quality/fair`; `legacy/model/model-fast` still work via header/model-name.)

### Testing

- New tests: routing override + invalid-fallback (`test_routing.py`), `/status` shape + model-name & header routing (`test_proxy.py`), routing-aware cache key (`test_cache.py`).
- Full suite green (267 tests), `ruff` clean.
- Live-verified end to end: the dashboard loads, renders, and updates on real `/status` data inside OpenCode; `/status` + header/model-name routing confirmed against a running proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an OpenCode integration with an embedded live dashboard and tools for inspecting freellmpool proxy status, while introducing per-request routing overrides and a JSON /status endpoint in the proxy.

New Features:
- Expose routing aliases auto/fast/quality/fair as models in the proxy API for easier routing control from clients.
- Provide an OpenCode TUI plugin that embeds a live freellmpool dashboard inside the editor, showing routing mode, savings, usage, provider race, latency, and last-served model.
- Add an OpenCode server-side plugin that exposes freellmpool_status and freellmpool_models tools and surfaces the actually served provider/model in toasts or logs.

Bug Fixes:
- Ensure the proxy cache key incorporates the routing mode so responses are not shared across different routing strategies.
- Record recently served targets for the /v1/responses API so they appear in status reporting.

Enhancements:
- Introduce a JSON /status (/v1/status) endpoint exposing pool usage, estimated savings, provider quota/cooldowns, latency metrics, and a recent-served ring buffer.
- Support per-request routing overrides via X-Freellmpool-Routing or routing keyword model names without mutating global routing state, and make routing-aware target ordering thread-safe.
- Include routing aliases in the models list and document their usage in the agents configuration note.

Build:
- Add package metadata for the OpenCode tools and TUI integrations so they can be consumed as plugins from the repo.

Documentation:
- Add README documentation for the OpenCode tools plugin and embedded TUI dashboard, including installation, configuration, and routing control guidance.

Tests:
- Add tests covering the /status endpoint shape and alias, routing alias exposure in /v1/models, and that recent served targets and pool stats are recorded.
- Add tests verifying per-request routing overrides, invalid override fallbacks, and that routing-aware cache keys do not collide across modes.