### PR TITLE
Make quality routing latency-aware (stop parking on slow giants)

### DIFF
--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -44,6 +44,14 @@ _MIN_LEARNABLE_CONTEXT = 256
 # Learned limits expire so a transient/edge provider error can't park a model for
 # the whole process lifetime (providers drift; some report per-request limits).
 _CTX_LIMIT_TTL = 1800.0  # seconds (30 min)
+# Quality-routing latency tuning. A target whose smoothed latency reaches
+# _QUALITY_SLOW_S counts as fully slow (penalty 1.0); interactive coding wants
+# sub-handful-of-seconds, so 8s is "slow". An unmeasured target gets a neutral mid
+# penalty (~2.7s-equivalent) so it is still sampled but loses to a proven-fast model.
+# Both stay well under the capability under-power penalty (>=5), so latency only
+# breaks ties among models that already clear the difficulty bar.
+_QUALITY_SLOW_S = 8.0
+_QUALITY_UNKNOWN_LAT = 0.34
 
 
 def _is_health_failure(exc: Exception) -> bool:
@@ -322,14 +330,29 @@ class Pool:
         if mode == "quality":
             table = capability_table()
             need = difficulty if difficulty is not None else 0.5
+            msnap = metrics.snapshot()  # one locked read for failing + latency
+
+            def lat_pen(t: Target) -> float:
+                # Latency penalty in [0,1]: a measured target's smoothed latency
+                # scaled so anything >= _QUALITY_SLOW_S counts as fully slow; an
+                # unmeasured one gets a neutral mid value so it is still sampled.
+                # Because the capability under-power penalty is >=5 for any model
+                # below the difficulty bar, this term only re-orders models that
+                # *already clear* the bar — so quality stops parking on a giant that
+                # takes tens of seconds when a comparably-capable model answers in ~1s.
+                st = msnap.get(t.name)
+                if st is None or st.ewma_ms is None:
+                    return _QUALITY_UNKNOWN_LAT
+                return min(st.ewma_ms / 1000.0, _QUALITY_SLOW_S) / _QUALITY_SLOW_S
 
             def quality_key(t: Target) -> tuple[int, int, float, int]:
                 # over-budget, then known-failing sink to the back (still reachable);
-                # then best capability-fit; then least-used as a fairness tiebreak.
+                # then capability-fit blended with latency; then least-used.
+                st = msnap.get(t.name)
                 return (
                     over_of(t),
-                    1 if metrics.failing(t.name) else 0,
-                    fit_penalty(model_capability(t.model, table), need),
+                    1 if (st and st.failing) else 0,
+                    fit_penalty(model_capability(t.model, table), need) + lat_pen(t),
                     used_of(t),
                 )
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -163,6 +163,39 @@ def test_quality_over_budget_model_sinks(tmp_path, monkeypatch, quota):
     assert order[-1] == "big"  # still reachable, just last
 
 
+def test_quality_latency_breaks_capability_near_tie(tmp_path, monkeypatch, quota):
+    # Both models clear a hard prompt's bar. "slowbig" is the closest capability fit
+    # (it would win on capability alone) but is painfully slow; "fastbig" is snappy.
+    # Latency-aware quality must avoid the slow giant.
+    pool = _quality_pool(
+        tmp_path,
+        monkeypatch,
+        quota,
+        scores={"slowbig": 0.90, "fastbig": 0.95},
+        models=[Model("slowbig"), Model("fastbig")],
+    )
+    pool.metrics.record_success("x/slowbig", 30000.0)  # 30s
+    pool.metrics.record_success("x/fastbig", 700.0)  # 0.7s
+    order = [t.model for t in pool._order(pool._all_targets(), difficulty=0.90)]
+    assert order[0] == "fastbig"  # capability-fit alone would put slowbig first
+
+
+def test_quality_latency_never_overrides_capability_bar(tmp_path, monkeypatch, quota):
+    # A fast but under-powered model must NOT leapfrog a capable one on a hard prompt:
+    # the latency term is bounded below the under-power penalty.
+    pool = _quality_pool(
+        tmp_path,
+        monkeypatch,
+        quota,
+        scores={"weakfast": 0.30, "strongslow": 0.95},
+        models=[Model("weakfast"), Model("strongslow")],
+    )
+    pool.metrics.record_success("x/weakfast", 200.0)  # blazing
+    pool.metrics.record_success("x/strongslow", 30000.0)  # slow
+    order = [t.model for t in pool._order(pool._all_targets(), difficulty=0.90)]
+    assert order[0] == "strongslow"  # hard prompt still gets the capable model
+
+
 def test_quality_failing_model_sinks(tmp_path, monkeypatch, quota):
     pool = _quality_pool(
         tmp_path,


### PR DESCRIPTION
## Make quality routing latency-aware

**Problem (found live in OpenCode):** quality routing ordered candidates purely by
capability-fit, so hard prompts always went to the highest-capability model
regardless of speed. On free tiers the top models are huge (nvidia `qwen3.5-397b`,
`kimi-k2.6`, nemotron-ultra) and take **10–35s** to respond. Failover and cooldown
were working fine — nvidia wasn't even rate-limited; it was *slowly succeeding* — so
an agentic session would visibly stall on a giant for tens of seconds.

**Fix:** blend a bounded latency penalty into the quality sort key:
- `lat_pen ∈ [0,1]`: smoothed EWMA latency, `≥ _QUALITY_SLOW_S` (8s) = fully slow;
  unmeasured targets get a neutral mid value so they're still sampled.
- The capability **under-power** penalty is `≥5` for any model below the difficulty
  bar, so this `0–1` term can only re-order models that **already clear the bar** —
  a hard prompt still gets a capable model, just the fastest comparably-capable one.
- Self-corrects: the EWMA learns within a few requests and converges to fast capable
  models. Live, a tools+large-context agentic load went from 34s giants to
  `cerebras/zai-glm-4.7` in **~0.6s** after warm-up.

**Tests:** latency breaks a capability near-tie (`test_quality_latency_breaks_capability_near_tie`);
latency never overrides the capability bar (`test_quality_latency_never_overrides_capability_bar`).
Full suite green (269), ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make quality routing latency-aware so that similarly capable models are ordered by response speed, avoiding slow large models for interactive workloads.

Bug Fixes:
- Prevent quality routing from consistently selecting very slow high-capability models when faster comparably capable models are available.

Enhancements:
- Incorporate a bounded latency penalty into the quality routing sort key while preserving the capability difficulty bar semantics.

Tests:
- Add tests ensuring latency breaks ties between near-equal capability models and never allows under-powered models to outrank capable ones.