### PR TITLE
docs: OpenCode integration guide + SEO page + stats badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ claude
 Your existing OpenAI/Anthropic apps work the same way — set `OPENAI_BASE_URL` (or
 `ANTHROPIC_BASE_URL`) to the proxy and keep your code unchanged.
 
+**OpenCode** gets a deeper integration: a live in-editor **dashboard** (routing mode,
+$ saved, tokens served free, provider race, latency), per-request **quality routing**
+via the model picker (`freellmpool/auto|fast|quality|fair`), and `freellmpool_status`
+/ `freellmpool_models` tools — see [integrations/opencode-tui](integrations/opencode-tui)
+and the [guide](https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html).
+
 **New in 0.11:** capacity tools — `freellmpool capacity status` shows which free
 tiers are usable right now, `freellmpool providers health` live-probes them, and
 `freellmpool keys add` walks you through configuring more (see
@@ -79,7 +85,13 @@ freellmpool ask "Write a haiku about sqlite"
 git diff | freellmpool ask "Write a commit message for this"
 freellmpool providers        # which providers are configured
 freellmpool models           # every provider/model id
+freellmpool stats            # lifetime tokens served free + avoided cost
+freellmpool badge -o badge.svg   # a shareable SVG badge of that total
 ```
+
+`freellmpool stats` is a running, **persistent** lifetime total (it survives restarts
+and upgrades). Embed `freellmpool badge` in a README, or serve it live from the proxy
+at `/badge.svg` (set `FREELLMPOOL_PUBLIC_BADGE=1` to make it publicly embeddable).
 
 Pin a provider or model; common OpenAI/Anthropic model names are mapped to a free
 equivalent so existing scripts keep working:

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -24,15 +24,26 @@ model setting untouched — just set the base URL and any API key.
 ```json
 {
   "$schema": "https://opencode.ai/config.json",
+  "model": "freellmpool/auto",
   "provider": {
     "freellmpool": {
       "npm": "@ai-sdk/openai-compatible",
       "options": { "baseURL": "http://localhost:8080/v1" },
-      "models": { "auto": { "name": "freellmpool (auto)" } }
+      "models": { "auto": {}, "fast": {}, "quality": {}, "fair": {} }
     }
   }
 }
 ```
+Pick `freellmpool/auto|fast|quality|fair` in the model picker to control routing
+(`quality` = capability-matched + latency-aware; `fast` = lowest latency; `fair` =
+spread quota). Full guide: <https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html>.
+
+**Embedded dashboard + tools (optional).** Two OpenCode plugins live in the repo:
+- [`integrations/opencode-tui`](../integrations/opencode-tui) — a live in-editor TUI
+  dashboard (routing mode, $ saved, tokens served free, provider race, latency
+  sparkline, last-served model). Install: `opencode plugin -g file:<repo>/integrations/opencode-tui`.
+- [`integrations/opencode`](../integrations/opencode) — a server plugin adding
+  `freellmpool_status` and `freellmpool_models` tools and a served-model toast.
 
 ### aider
 ```bash

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -15,6 +15,7 @@
 - [Capacity & provider health](https://github.com/0xzr/freellmpool/blob/main/docs/CAPACITY.md): capacity status, health checks, key inventory, external catalog. Guide: https://0xzr.github.io/freellmpool/capacity-management.html
 - [CHANGELOG](https://github.com/0xzr/freellmpool/blob/main/CHANGELOG.md): release history.
 - [Integrations](https://github.com/0xzr/freellmpool/blob/main/docs/INTEGRATIONS.md): opencode, aider, Continue, Cline, Cursor, Open WebUI, LangChain, LlamaIndex, and more.
+- [Run OpenCode on free models](https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html): OpenCode setup with an embedded TUI dashboard, quality routing (auto/fast/quality/fair), and usage tools.
 - [MCP server](https://github.com/0xzr/freellmpool/blob/main/docs/MCP.md): use free models from Claude Desktop/Code/Cursor.
 
 ## Install

--- a/docs/run-opencode-on-free-models.html
+++ b/docs/run-opencode-on-free-models.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Run OpenCode on free LLM models (no API bill) — with a live in-editor dashboard</title>
+<meta name="description" content="Run the OpenCode coding agent on free LLM tiers with freellmpool — a local OpenAI-compatible proxy that pools 16 free providers. Includes an embedded TUI dashboard, per-request quality routing, and usage tools. Keyless to start.">
+<link rel="canonical" href="https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html">
+<meta property="og:title" content="Run OpenCode on free LLM models — with a live dashboard">
+<meta property="og:description" content="Point OpenCode at one local proxy and code on pooled free LLM tiers — with an embedded dashboard, quality routing, and usage tools. Keyless to start.">
+<meta property="og:type" content="article">
+<style>
+ :root{--bg:#0b0e14;--fg:#e6e6e6;--mut:#8a93a2;--card:#141925;--bd:#232a39;--ac:#6ea8ff}
+ *{box-sizing:border-box}
+ body{font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;margin:0;background:var(--bg);color:var(--fg);line-height:1.65}
+ .wrap{max-width:780px;margin:0 auto;padding:40px 20px 80px}
+ h1{font-size:27px;margin:0 0 6px;line-height:1.25}
+ h2{font-size:20px;margin:36px 0 10px;border-bottom:1px solid var(--bd);padding-bottom:6px}
+ h3{font-size:16px;margin:22px 0 4px}
+ .tag{color:var(--mut);font-size:14px}
+ a{color:var(--ac);text-decoration:none}a:hover{text-decoration:underline}
+ code,pre{font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+ pre{background:var(--card);border:1px solid var(--bd);border-radius:8px;padding:14px 16px;overflow:auto;font-size:13.5px}
+ code{background:#1b2230;padding:1px 5px;border-radius:4px;font-size:.92em}
+ pre code{background:none;padding:0}
+ .lead{font-size:17px}
+ .note{background:var(--card);border:1px solid var(--bd);border-left:3px solid var(--ac);border-radius:6px;padding:10px 14px;font-size:14px;margin:14px 0}
+ .meta{color:var(--mut);font-size:13px;margin-top:34px;border-top:1px solid var(--bd);padding-top:14px}
+</style>
+<meta property="og:url" content="https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html">
+<meta name="twitter:card" content="summary">
+</head>
+<body>
+<div class="wrap">
+
+<p class="tag"><a href="https://0xzr.github.io/freellmpool/">freellmpool</a> › guide</p>
+<h1>How to run OpenCode on free LLM models</h1>
+
+<p class="lead"><strong>You can run the <a href="https://opencode.ai">OpenCode</a> coding agent on
+free LLM tiers — no API bill — by pointing it at a local proxy that speaks the OpenAI API. The
+open-source tool <a href="https://github.com/0xzr/freellmpool">freellmpool</a> is that proxy: it pools
+the free tiers of 16 providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere
+and more) behind one endpoint, with automatic failover. Two providers need no API key, so you can start
+for free in under a minute. It also ships an OpenCode plugin with a <strong>live dashboard, quality
+routing, and usage tools</strong> built in.</strong></p>
+
+<h2>1. Install and start the proxy</h2>
+<pre><code>pip install freellmpool
+freellmpool proxy            # serves http://localhost:8080</code></pre>
+<p>The proxy now routes OpenAI-style requests to a free provider and fails over when one is
+rate-limited.</p>
+
+<h2>2. Add freellmpool as an OpenCode provider</h2>
+<p>In your <code>opencode.json</code> (or <code>~/.config/opencode/opencode.jsonc</code>), add a
+freellmpool provider and set it as your model. The routing aliases let you pick how each prompt is
+routed:</p>
+<pre><code>{
+  "model": "freellmpool/auto",
+  "provider": {
+    "freellmpool": {
+      "npm": "@ai-sdk/openai-compatible",
+      "options": { "baseURL": "http://localhost:8080/v1" },
+      "models": {
+        "auto": {}, "fast": {}, "quality": {}, "fair": {}
+      }
+    }
+  }
+}</code></pre>
+<p>Run <code>freellmpool code opencode</code> to print these steps any time.</p>
+
+<h2>3. Control routing quality from the model picker</h2>
+<p>Switch the model in OpenCode's picker to choose how freellmpool routes — no extra config:</p>
+<ul>
+<li><code>freellmpool/auto</code> — the proxy's default routing.</li>
+<li><code>freellmpool/quality</code> — match each prompt's difficulty to the best <em>and fastest</em>
+capable free model (benchmark-scored, latency-aware).</li>
+<li><code>freellmpool/fast</code> — lowest-latency provider first.</li>
+<li><code>freellmpool/fair</code> — spread load across providers to preserve daily quota.</li>
+</ul>
+
+<h2>4. The embedded dashboard (optional, but fun)</h2>
+<p>freellmpool ships a native OpenCode TUI plugin that renders a live panel <em>inside</em> the editor —
+the active routing mode, estimated money saved, tokens served free, a provider "race," a latency
+sparkline, and which provider/model just answered. It updates as you code. Setup is in the
+<a href="https://github.com/0xzr/freellmpool/tree/main/integrations/opencode-tui">integrations/opencode-tui</a>
+folder; a companion server plugin adds <code>freellmpool_status</code> and <code>freellmpool_models</code>
+tools you can ask for in any session.</p>
+
+<div class="note">Free-tier models are smaller than frontier models. They're great for scaffolding,
+refactors, tests, commit messages, and everyday edits — not a substitute for a frontier model on the
+hardest reasoning. Limits reset at UTC midnight; <code>freellmpool/quality</code> keeps effective quality
+high as caps fill.</div>
+
+<h2>5. (Optional) add free keys for more capacity</h2>
+<p>The keyless providers get you started; adding free API keys for Groq, Cerebras, Gemini and others
+unlocks more models and higher daily limits — see the
+<a href="https://github.com/0xzr/freellmpool/blob/main/docs/ACCOUNTS.md">accounts guide</a>. freellmpool
+spreads load across whatever you have and tracks per-day usage so each tier drains evenly. Track your
+running total with <code>freellmpool stats</code> or embed a <code>freellmpool badge</code> in your README.</p>
+
+<h2>FAQ</h2>
+<h3>Can I really use OpenCode for free?</h3>
+<p>Yes. freellmpool's proxy implements the OpenAI Chat Completions API and routes it to free-tier models,
+so OpenCode runs against them with no code changes. Quality is bounded by the free-tier models you have
+access to; <code>freellmpool/quality</code> routing picks the strongest fast-enough one per prompt.</p>
+<h3>Does freellmpool work with OpenCode's tool calls?</h3>
+<p>Yes — the proxy preserves tool/function calls across providers, and the bundled plugin adds extra
+tools (status, model list) plus the in-editor dashboard.</p>
+<h3>Is this against OpenCode's terms?</h3>
+<p>No — you're pointing OpenCode at a custom OpenAI-compatible provider, exactly the mechanism it supports
+for local and custom models. You're using the LLM providers' own free tiers; don't abuse them.</p>
+<h3>How do I see which free model OpenCode is using?</h3>
+<p>The embedded dashboard shows the last-served provider/model live; or ask the agent to run the
+<code>freellmpool_status</code> tool, or curl the proxy's <code>/status</code> endpoint.</p>
+
+<p class="meta">Part of <a href="https://github.com/0xzr/freellmpool">freellmpool</a> (MIT, free, open
+source). Updated 2026-06-07.</p>
+
+</div>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "freellmpool", "item": "https://0xzr.github.io/freellmpool/"}, {"@type": "ListItem", "position": 2, "name": "How to run OpenCode on free LLM models", "item": "https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html"}]}</script>
+</body>
+</html>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -9,6 +9,7 @@
   <url><loc>https://0xzr.github.io/freellmpool/free-alternative-to-openrouter.html</loc><lastmod>2026-06-03</lastmod><priority>0.8</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/use-multiple-free-llm-apis.html</loc><lastmod>2026-06-03</lastmod><priority>0.8</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/run-coding-agents-on-free-models.html</loc><lastmod>2026-06-03</lastmod><priority>0.8</priority></url>
+  <url><loc>https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html</loc><lastmod>2026-06-07</lastmod><priority>0.8</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/capacity-management.html</loc><lastmod>2026-06-06</lastmod><priority>0.8</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/free-groq-api.html</loc><lastmod>2026-06-03</lastmod><priority>0.7</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/free-gemini-api.html</loc><lastmod>2026-06-03</lastmod><priority>0.7</priority></url>


### PR DESCRIPTION
## Docs: OpenCode integration guide + SEO page + stats badge

Documents the shipped OpenCode integration and the new persistent stats/badge.

- **New SEO page** `docs/run-opencode-on-free-models.html` — targets searches like
  *run opencode on free models*, *opencode free LLM backend*, *opencode without API
  costs*, *free opencode dashboard*. Leads with our differentiators: the embedded
  TUI dashboard, per-request quality routing (`auto/fast/quality/fair`), and the
  `freellmpool_status`/`freellmpool_models` tools. Mirrors the existing guide template.
- **sitemap.xml / llms.txt** — list the new guide.
- **INTEGRATIONS.md** — expanded OpenCode section: routing models, embedded dashboard
  + server-plugin tools, link to the guide.
- **README** — OpenCode dashboard callout + `freellmpool stats` / `freellmpool badge`
  (the persistent lifetime "served free" total, embeddable as SVG / `/badge.svg`).

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document OpenCode integration, routing modes, and persistent usage stats, and surface the new OpenCode guide in site navigation and README.

Enhancements:
- Highlight the OpenCode dashboard integration and new persistent stats/badge commands in the README, including guidance on sharing the badge and exposing it via the proxy.

Documentation:
- Add an SEO-focused OpenCode integration guide describing how to run OpenCode on pooled free LLM tiers with freellmpool, including routing modes, dashboard, and usage tools.
- Expand INTEGRATIONS OpenCode section with routing aliases, model picker guidance, and links to the embedded dashboard and server plugins.
- Update sitemap to include the new OpenCode guide URL.