### PR TITLE
Hot-path hardening: stream truncation, response cap, deadline, retryable, embeddings

### DIFF
--- a/src/freellmpool/client.py
+++ b/src/freellmpool/client.py
@@ -18,6 +18,7 @@ import json
 import re
 import sys
 import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -79,6 +80,8 @@ StreamPostFn = Callable[[str, dict, dict, float], "tuple[int, Iterable[str]]"]
 _USER_AGENT = "freellmpool/0.11 (+https://github.com/0xzr/freellmpool)"
 
 _CONNECT_TIMEOUT = 10.0  # fail fast on dead/unreachable providers so failover is quick
+# Cap a single upstream reply so a broken/malicious provider can't OOM the proxy.
+_MAX_RESPONSE_BYTES = 32 * 1024 * 1024  # 32 MiB
 _shared = None  # one pooled, keep-alive httpx.Client shared across calls/threads
 _shared_lock = threading.Lock()
 
@@ -117,13 +120,40 @@ def _timeout(timeout: float):
 
 
 def default_post(url: str, headers: dict, json_body: dict, timeout: float) -> HTTPResult:
-    """Real network POST via the pooled httpx client."""
-    resp = _client().post(url, headers=headers, json=json_body, timeout=_timeout(timeout))
+    """Real network POST via the pooled httpx client.
+
+    Streams the response so we can (1) cap it at ``_MAX_RESPONSE_BYTES`` — a broken
+    or malicious provider can't OOM the proxy — and (2) enforce a wall-clock deadline
+    so a slow-drip upstream (one byte before each per-read timeout) can't pin a worker
+    indefinitely. Either guard raises, which the router treats as a failed attempt and
+    fails over."""
+    deadline = time.monotonic() + timeout
+    with _client().stream(
+        "POST", url, headers=headers, json=json_body, timeout=_timeout(timeout)
+    ) as resp:
+        chunks: list[bytes] = []
+        total = 0
+        for chunk in resp.iter_bytes():
+            total += len(chunk)
+            if total > _MAX_RESPONSE_BYTES:
+                raise ProviderHTTPError(
+                    502, f"upstream response exceeded {_MAX_RESPONSE_BYTES} bytes", retryable=True
+                )
+            if time.monotonic() > deadline:
+                raise ProviderHTTPError(
+                    504, f"upstream exceeded {timeout:.0f}s deadline", retryable=True
+                )
+            chunks.append(chunk)
+        status = resp.status_code
+    raw = b"".join(chunks)
+    text = raw.decode("utf-8", "replace")
     try:
-        body = resp.json()
+        body = json.loads(raw) if raw else {}
+        if not isinstance(body, dict):
+            body = {}
     except (json.JSONDecodeError, ValueError):
         body = {}
-    return HTTPResult(status=resp.status_code, body=body, text=resp.text)
+    return HTTPResult(status=status, body=body, text=text)
 
 
 class _StreamLines:
@@ -132,13 +162,32 @@ class _StreamLines:
     (where the caller closes it before ever iterating). Does NOT close the shared
     client — only the response/stream."""
 
-    def __init__(self, cm, resp):
+    def __init__(self, cm, resp, deadline: float | None = None):
         self._cm, self._resp = cm, resp
         self._closed = False
+        self._deadline = deadline  # monotonic wall-clock cap on the whole stream
 
     def __iter__(self) -> Iterator[str]:
+        # Iterate raw text chunks (not iter_lines) and split lines ourselves, so the
+        # deadline is checked on EVERY chunk received — a slow-drip upstream that
+        # trickles bytes *without a newline* would block iter_lines forever and never
+        # reach a between-lines check. The per-read httpx timeout bounds idle gaps;
+        # this total deadline bounds steady slow-drip that would pin a worker.
+        buf = ""
         try:
-            yield from self._resp.iter_lines()
+            for chunk in self._resp.iter_text():
+                if self._deadline is not None and time.monotonic() > self._deadline:
+                    raise ProviderHTTPError(
+                        504, "upstream exceeded stream deadline", retryable=True
+                    )
+                if not chunk:
+                    continue
+                buf += chunk
+                while "\n" in buf:
+                    line, buf = buf.split("\n", 1)
+                    yield line.rstrip("\r")
+            if buf:
+                yield buf.rstrip("\r")
         finally:
             self.close()
 
@@ -154,13 +203,14 @@ class _StreamLines:
 
 def default_stream_post(url: str, headers: dict, json_body: dict, timeout: float):
     """Open a streaming POST on the pooled client and return (status, line iter)."""
+    deadline = time.monotonic() + timeout
     cm = _client().stream("POST", url, headers=headers, json=json_body, timeout=_timeout(timeout))
     try:
         resp = cm.__enter__()
     except BaseException:  # opening the stream failed — release the connection
         cm.__exit__(*sys.exc_info())
         raise
-    return resp.status_code, _StreamLines(cm, resp)
+    return resp.status_code, _StreamLines(cm, resp, deadline=deadline)
 
 
 def stream_call(

--- a/src/freellmpool/errors.py
+++ b/src/freellmpool/errors.py
@@ -23,8 +23,19 @@ class AllProvidersExhausted(FreeLLMPoolError):
     describing what was tried and why each one was skipped or failed.
     """
 
-    def __init__(self, attempts: list[tuple[str, str]]):
+    def __init__(
+        self,
+        attempts: list[tuple[str, str]],
+        *,
+        client_status: int | None = None,
+        client_message: str | None = None,
+    ):
         self.attempts = attempts
+        # If the failures were caused by a non-retryable *client* error (a 4xx that
+        # means the request itself is wrong, not the provider), carry its status so
+        # the proxy can surface that instead of a generic 502.
+        self.client_status = client_status
+        self.client_message = client_message
         detail = "; ".join(f"{name}: {reason}" for name, reason in attempts) or "no candidates"
         super().__init__(f"all providers exhausted ({detail})")
 

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -476,7 +476,18 @@ def make_handler(pool: Pool, api_key: str | None = None):
             except ContextWindowExceeded as exc:
                 self._error(413, str(exc), "context_length_exceeded")
             except AllProvidersExhausted as exc:
-                self._error(502, str(exc), "all_providers_exhausted")
+                # If the pool failed because the request itself was rejected as a
+                # client error (non-retryable 4xx), surface that real status instead
+                # of a misleading generic 502.
+                cs = getattr(exc, "client_status", None)
+                if isinstance(cs, int) and 400 <= cs < 500:
+                    self._error(
+                        cs,
+                        getattr(exc, "client_message", None) or str(exc),
+                        "invalid_request_error",
+                    )
+                else:
+                    self._error(502, str(exc), "all_providers_exhausted")
             except FreeLLMPoolError as exc:  # pragma: no cover - defensive
                 self._error(500, str(exc), "freellmpool_error")
             return None
@@ -574,12 +585,26 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 self.wfile.flush()
             except (BrokenPipeError, ConnectionResetError):  # pragma: no cover
                 pass  # client disconnected
-            except Exception:  # noqa: BLE001
-                # Upstream failed mid-stream. Headers are already sent, so we can't
-                # send a JSON error — close the SSE stream cleanly instead of letting
-                # do_POST attempt a 500 into the open event-stream.
+            except Exception as exc:  # noqa: BLE001
+                # Upstream failed AFTER the first token. Do NOT emit finish="stop" +
+                # [DONE] — that would make a truncated answer look complete to the
+                # client and hide the failure. Emit an SSE error event instead (the
+                # recognized streaming-error convention) and record the truncation.
+                # Headers are already sent, so an HTTP error status isn't possible.
+                pool.metrics.record_failure(
+                    f"{provider_id}/{model_name}", f"stream truncated: {exc}"
+                )
                 try:
-                    self.wfile.write(_chunk_block(cid, model_id, finish="stop").encode())
+                    err = json.dumps(
+                        {
+                            "error": {
+                                "message": "upstream stream failed mid-response; output is incomplete",
+                                "type": "upstream_error",
+                                "code": "stream_truncated",
+                            }
+                        }
+                    )
+                    self.wfile.write(f"data: {err}\n\n".encode())
                     self.wfile.write(b"data: [DONE]\n\n")
                     self.wfile.flush()
                 except (BrokenPipeError, ConnectionResetError, OSError):

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -284,7 +284,7 @@ class Pool:
                 if model is not None and m.name != model:
                     continue
                 try:
-                    return _client.embed(
+                    reply = _client.embed(
                         emb,
                         m.name,
                         inputs,
@@ -295,6 +295,12 @@ class Pool:
                     )
                 except Exception as exc:  # noqa: BLE001 — try the next embedder
                     attempts.append((f"{emb.id}/{m.name}", f"{type(exc).__name__}: {exc}"))
+                    continue
+                # Account for embeddings like chat: per-day quota + lifetime stats, so
+                # a heavy embedding workload doesn't bypass RPD pacing / usage totals.
+                self.quota.record(emb.id, m.name)
+                self._bump_stats(requests=1, prompt_tokens=reply.prompt_tokens or 0)
+                return reply
         raise AllProvidersExhausted(attempts)
 
     # ---- candidate ordering -------------------------------------------
@@ -544,6 +550,7 @@ class Pool:
 
         attempts: list[tuple[str, str]] = []
         rate_limited: set[str] = set()  # providers that 429'd during THIS request
+        client_error: ProviderHTTPError | None = None  # first non-retryable 4xx seen
         # Context-window awareness: estimate the request size once, skip models we
         # already know are too small, and fail loudly if nothing fits.
         est_tokens = estimate_input_tokens(messages, tools)
@@ -602,6 +609,12 @@ class Pool:
                 # Any non-context failure (incl. a rate-limit, which might have fit)
                 # means "too long" isn't provably the whole story — stay generic.
                 non_ctx_failure = True
+                # A non-retryable 4xx usually means the request itself is invalid;
+                # remember the first one so an exhausted pool can surface the real
+                # client error instead of a generic 502. (Failover still proceeds —
+                # another provider may accept it.)
+                if not exc.retryable and client_error is None:
+                    client_error = exc
                 if _is_health_failure(exc):
                     self.metrics.record_failure(target.name, str(exc))
                 emit(self._on_event, "error", target=target.name, reason=str(exc))
@@ -655,6 +668,10 @@ class Pool:
         emit(self._on_event, "exhausted", attempts=len(attempts))
         if ctx_overflow and not non_ctx_failure:
             raise ContextWindowExceeded(attempts, est_tokens=est_tokens)
+        if client_error is not None:
+            raise AllProvidersExhausted(
+                attempts, client_status=client_error.status, client_message=str(client_error)
+            )
         raise AllProvidersExhausted(attempts)
 
     def stream_chat(

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,216 @@
+"""Hot-path hardening: retryable client errors, embeddings accounting, stream
+truncation signalling, and the non-stream response cap + wall-clock deadline."""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+
+import pytest
+from helpers import make_post, make_stream_post, openai_body
+
+from freellmpool import client as C
+from freellmpool.errors import AllProvidersExhausted, ProviderHTTPError
+from freellmpool.models import Model, Provider
+from freellmpool.proxy import serve
+from freellmpool.router import Pool
+
+
+def _serve(pool):
+    httpd = serve(pool, host="127.0.0.1", port=0)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return httpd, f"http://127.0.0.1:{httpd.server_address[1]}"
+
+
+# ---- #6: honor ProviderHTTPError.retryable ----
+
+
+def test_nonretryable_client_error_is_surfaced(providers, env, quota):
+    post = make_post({"test": (400, {"error": {"message": "bad request"}})})  # all *.test 400
+    pool = Pool(providers, quota=quota, env=env, post=post)
+    with pytest.raises(AllProvidersExhausted) as ei:
+        pool.chat([{"role": "user", "content": "hi"}], providers=["alpha", "beta"])
+    assert ei.value.client_status == 400
+
+
+def test_retryable_5xx_sets_no_client_status(providers, env, quota):
+    post = make_post({"test": (503, {"error": "down"})})
+    pool = Pool(providers, quota=quota, env=env, post=post)
+    with pytest.raises(AllProvidersExhausted) as ei:
+        pool.chat([{"role": "user", "content": "hi"}], providers=["alpha", "beta"])
+    assert ei.value.client_status is None  # 5xx is retryable, not a client error
+
+
+def test_proxy_surfaces_client_error_status(providers, env, quota):
+    post = make_post({"test": (400, {"error": {"message": "bad request"}})})
+    pool = Pool(providers, quota=quota, env=env, post=post, stream_post=make_stream_post({}))
+    httpd, base = _serve(pool)
+    try:
+        req = urllib.request.Request(
+            base + "/v1/chat/completions",
+            data=json.dumps(
+                {"model": "auto", "messages": [{"role": "user", "content": "hi"}]}
+            ).encode(),
+            headers={"content-type": "application/json"},
+        )
+        with pytest.raises(urllib.error.HTTPError) as ei:
+            urllib.request.urlopen(req)  # noqa: S310
+        assert ei.value.code == 400  # the real client error, not a generic 502
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+# ---- #4: embeddings recorded in quota + stats ----
+
+
+def test_embed_records_quota_and_stats(quota):
+    emb = Provider(
+        id="cohere",
+        label="cohere",
+        adapter="openai",
+        base_url="https://cohere.test/v1",
+        key_env="COHERE_API_KEY",
+        models=(Model("emb-1"),),
+    )
+    post = make_post(
+        {
+            "cohere.test": (
+                200,
+                {"data": [{"embedding": [0.1, 0.2, 0.3]}], "usage": {"prompt_tokens": 4}},
+            )
+        }
+    )
+    pool = Pool([], quota=quota, env={"COHERE_API_KEY": "x"}, post=post, embedders=[emb])
+    pool.embed("hello")
+    assert quota.used("cohere", "emb-1") == 1
+    assert pool.stats["requests"] == 1
+    assert pool.stats["prompt_tokens"] == 4
+
+
+# ---- #2: mid-stream failure signals an error, not a fake clean stop ----
+
+
+def test_stream_midstream_failure_signals_error(providers, env, quota):
+    def raising_stream_post(url, headers, body, timeout):
+        def gen():
+            yield "data: " + json.dumps({"choices": [{"delta": {"content": "par"}}]})
+            raise RuntimeError("upstream died mid-stream")
+
+        return 200, gen()
+
+    pool = Pool(
+        providers, quota=quota, env=env, post=make_post({}), stream_post=raising_stream_post
+    )
+    httpd, base = _serve(pool)
+    try:
+        req = urllib.request.Request(
+            base + "/v1/chat/completions",
+            data=json.dumps(
+                {"model": "auto", "stream": True, "messages": [{"role": "user", "content": "hi"}]}
+            ).encode(),
+            headers={"content-type": "application/json"},
+        )
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            body = resp.read().decode()
+        assert "stream_truncated" in body  # explicit truncation signal
+        assert '"error"' in body
+        assert '"finish_reason": "stop"' not in body  # must NOT look like a clean completion
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+# ---- #3 / #7: non-stream response byte cap + wall-clock deadline ----
+
+
+class _FakeCM:
+    def __init__(self, resp):
+        self._resp = resp
+
+    def __enter__(self):
+        return self._resp
+
+    def __exit__(self, *a):
+        return False
+
+
+class _FakeResp:
+    status_code = 200
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def iter_bytes(self):
+        yield from self._chunks
+
+
+def test_default_post_caps_oversized_response(monkeypatch):
+    big = [b"x" * (8 * 1024 * 1024)] * 6  # 48 MiB > 32 MiB cap
+
+    class Client:
+        def stream(self, *a, **k):
+            return _FakeCM(_FakeResp(big))
+
+    monkeypatch.setattr(C, "_client", lambda: Client())
+    with pytest.raises(ProviderHTTPError):
+        C.default_post("https://x.test/v1", {}, {}, 30.0)
+
+
+def test_default_post_enforces_deadline(monkeypatch):
+    monkeypatch.setattr(
+        C,
+        "_client",
+        lambda: type(
+            "Cl", (), {"stream": lambda self, *a, **k: _FakeCM(_FakeResp([b"a", b"b"]))}
+        )(),
+    )
+    times = iter([1000.0, 1000.5, 9999.0])  # deadline calc, chunk1 ok, chunk2 past deadline
+    monkeypatch.setattr(C.time, "monotonic", lambda: next(times))
+    with pytest.raises(ProviderHTTPError):
+        C.default_post("https://x.test/v1", {}, {}, 30.0)
+
+
+class _FakeStreamResp:
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def iter_text(self):
+        yield from self._chunks
+
+
+class _NoopCM:
+    def __exit__(self, *a):
+        return False
+
+
+def test_streamlines_splits_lines_and_releases():
+    closed = []
+    cm = _NoopCM()
+    cm.__exit__ = lambda *a: (closed.append(True), False)[1]  # noqa: E731
+    sl = C._StreamLines(cm, _FakeStreamResp(["data: a\r\ndata: ", "b\n"]), deadline=None)
+    assert list(sl) == ["data: a", "data: b"]  # CRLF stripped, split across chunks
+    assert closed  # connection released on exhaustion
+
+
+def test_streamlines_deadline_fires_without_a_newline():
+    # the Codex blocker: a slow-drip upstream that never sends a newline must still
+    # hit the deadline (checked per chunk, not only between completed lines).
+    sl = C._StreamLines(_NoopCM(), _FakeStreamResp(["partial-no-newline-ever"]), deadline=0.0)
+    with pytest.raises(ProviderHTTPError):
+        list(sl)
+
+
+def test_default_post_normal_response_ok(monkeypatch):
+    raw = json.dumps(openai_body("hi")).encode()
+
+    class Client:
+        def stream(self, *a, **k):
+            return _FakeCM(_FakeResp([raw]))
+
+    monkeypatch.setattr(C, "_client", lambda: Client())
+    res = C.default_post("https://x.test/v1", {}, {}, 30.0)
+    assert res.status == 200
+    assert res.body["choices"][0]["message"]["content"] == "hi"


### PR DESCRIPTION
## Hot-path hardening: stream truncation, response cap, deadline, retryable, embeddings

Fixes the remaining 5 findings from the full-codebase audit (the HIGH/MED hot-path set).

- **#2 silent stream truncation (HIGH)** — when an upstream stream fails *after* the first
  token, the proxy no longer emits a fake `finish=stop` + `[DONE]` (which made a truncated
  answer look complete). It emits an SSE error event (`code: stream_truncated`) and records a
  failure metric.
- **#3 response OOM cap (HIGH)** — `client.default_post` streams the reply and fails over if it
  exceeds 32 MiB, inside a `with` that releases the connection.
- **#7 wall-clock deadline (MED)** — `default_post` bounds total time; `_StreamLines` bounds the
  whole stream and checks the deadline on **every text chunk** (so a slow-drip upstream that
  never sends a newline can't block `iter_lines` forever), with manual CRLF-aware line
  splitting + partial-line buffering.
- **#6 honor `retryable=False` (MED)** — `chat()` captures the first non-retryable 4xx and, only
  if the pool fully exhausts, raises `AllProvidersExhausted(client_status=…)` so the proxy
  surfaces the real 4xx instead of a generic 502. Failover still tries every provider; the
  exception type is unchanged (CLI/MCP/aio handlers keep working).
- **#4 embeddings accounting (MED)** — `pool.embed()` records quota + bumps lifetime stats.

### Review
Tests in `tests/test_hardening.py` (incl. the slow-drip-no-newline deadline case + cap/deadline
paths). **308 tests, ruff clean.** Reviewed by **Codex + MiMo 2.5 Pro + MiniMax M3 — unanimous
SHIP** after Codex's `_StreamLines` deadline-granularity blocker was fixed and regression-tested.

This completes the 8 audit findings (PR #15 covered SSRF/header-injection/locks; this covers the rest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden hot-path request handling by capping response size, enforcing deadlines, surfacing client errors accurately, and improving streaming and embeddings accounting behavior.

Bug Fixes:
- Prevent silent truncation of streaming responses by emitting an SSE error event with explicit truncation signaling instead of a fake clean finish.
- Ensure non-streaming responses are capped in size and bounded by a wall-clock deadline so misbehaving providers cannot exhaust memory or pin workers.
- Honor non-retryable 4xx client errors during chat failover, propagating the original client status when all providers are exhausted instead of a generic 502.
- Record embeddings usage in quota and lifetime statistics so embedding workloads are properly accounted and paced.

Enhancements:
- Refine streaming line iteration to check deadlines per text chunk and handle CRLF-aware splitting, ensuring slow-drip streams without newlines still respect deadlines.

Tests:
- Add hardening tests covering retryable vs non-retryable errors, embeddings accounting, stream truncation signaling, response size cap, and wall-clock deadlines for both normal and streaming responses.