### PR TITLE
MCP toolbox (panel, tokenmax, route, stats) + savings vs Claude Opus 4.8

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -12,9 +12,13 @@ and it works (keyless providers). Add keys to unlock more.
 
 | Tool | What it does |
 |---|---|
-| `free_llm_ask` | Ask a free model (`prompt`, optional `system` / `model` / `provider`). |
+| `free_llm_ask` | Ask a free model (`prompt`, optional `system` / `model` / `provider` / `routing` / `max_tokens`). The reply names the serving model. |
+| `free_llm_panel` | Ask the **same** prompt to N different free models at once and compare — a free second opinion / ensemble. Optional `synthesize` merges them into one best answer. |
+| `tokenmax` | 🌈 Gloriously excessive: blast the prompt to a big swarm of free models, then the **calling** model synthesizes them all. Tongue-in-cheek, genuinely useful for hard questions (throbs a rainbow `TOKENMAXXING` banner while it runs). |
+| `free_llm_route` | Explain where a prompt **would** route (estimated difficulty + ranked candidate models) **without spending a token**. |
 | `free_llm_models` | List available `provider/model` ids. |
 | `free_llm_quota` | Today's per-provider usage + daily-limit headroom, plus session totals and estimated cost avoided. |
+| `free_llm_stats` | Lifetime tokens served free + estimated cost avoided vs Claude Opus 4.8 (persists across restarts). |
 
 ## Claude Desktop
 

--- a/src/freellmpool/mcp_server.py
+++ b/src/freellmpool/mcp_server.py
@@ -2,7 +2,8 @@
 
 `freellmpool mcp` speaks MCP over stdio (newline-delimited JSON-RPC 2.0), so an
 MCP client — Claude Desktop, Claude Code, Cursor, etc. — can offload subtasks to
-free LLMs:
+free LLMs, get a free *second opinion* from several models at once, see exactly
+where a prompt would route, and watch the free tokens add up:
 
     {
       "mcpServers": {
@@ -11,30 +12,45 @@ free LLMs:
     }
 
 Tools exposed:
-    free_llm_ask     ask a free model a question (prompt + optional system/model/provider)
+    free_llm_ask     ask a free model (routing-aware; tells you which model served)
+    free_llm_panel   ask N free models in parallel and compare — a free second opinion
+    tokenmax         🌈 blast the prompt to a swarm of models; you synthesize them all
+    free_llm_route   explain where a prompt WOULD route (difficulty + ranked models), $0
     free_llm_models  list available provider/model ids
-    free_llm_quota   today's per-provider usage + daily-limit headroom and session totals
+    free_llm_quota   today's per-provider usage + daily-limit headroom
+    free_llm_stats   lifetime tokens served free + estimated cost avoided
 
 Implemented on the standard library only — no MCP SDK required.
 """
 
 from __future__ import annotations
 
+import concurrent.futures as _cf
+import itertools
 import json
 import sys
+import threading
+import time
 
 from .config import resolve_alias
 from .router import Pool
 
 _DEFAULT_PROTOCOL = "2025-06-18"
+_ROUTING_MODES = ("fair", "fast", "quality", "legacy", "model", "model-fast")
+_MAX_PANEL = 5
+# tokenmax fans out to EVERY model by default (the whole point). A high hard ceiling
+# only stops a pathological catalog from spawning thousands; workers stay bounded.
+_TOKENMAX_HARD_CAP = 256
+_TOKENMAX_WORKERS = 32
 
 TOOLS = [
     {
         "name": "free_llm_ask",
         "description": (
-            "Ask a free LLM (pooled across 16 free providers, with failover). "
-            "Use this to offload a self-contained subtask — drafting, summarizing, "
-            "classifying, brainstorming, or a quick lookup — to a free model."
+            "Ask a free LLM (pooled across 16 free providers, with automatic failover). "
+            "Offload a self-contained subtask — drafting, summarizing, classifying, "
+            "brainstorming, a quick lookup — to a free model. The reply tells you which "
+            "provider/model actually served it."
         ),
         "inputSchema": {
             "type": "object",
@@ -48,6 +64,93 @@ TOOLS = [
                 "provider": {
                     "type": "string",
                     "description": "Optional provider id to restrict to (e.g. groq, cerebras).",
+                },
+                "routing": {
+                    "type": "string",
+                    "enum": ["auto", "fast", "quality", "fair"],
+                    "description": "How to pick the model: quality (best capable model for the prompt), fast (lowest latency), fair (spread quota), or auto (server default).",
+                },
+                "max_tokens": {
+                    "type": "integer",
+                    "description": "Max output tokens (default 1024).",
+                },
+            },
+            "required": ["prompt"],
+        },
+    },
+    {
+        "name": "free_llm_panel",
+        "description": (
+            "Ask the SAME prompt to several different free models at once and get every "
+            "answer back side by side — a free 'second opinion' / ensemble. Great for "
+            "cross-checking a fact, comparing approaches, or reducing single-model bias. "
+            "Optionally have a strong model synthesize the best combined answer."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "The question or task to ask every model.",
+                },
+                "system": {"type": "string", "description": "Optional system instruction."},
+                "n": {
+                    "type": "integer",
+                    "description": f"How many distinct models to ask (2-{_MAX_PANEL}, default 3).",
+                },
+                "synthesize": {
+                    "type": "boolean",
+                    "description": "If true, a quality-routed model synthesizes the panel into one best answer.",
+                },
+                "max_tokens": {
+                    "type": "integer",
+                    "description": "Max output tokens per model (default 512).",
+                },
+            },
+            "required": ["prompt"],
+        },
+    },
+    {
+        "name": "tokenmax",
+        "description": (
+            "🌈 TOKENMAX 🌈 — gloriously excessive: fan the SAME prompt out to EVERY available "
+            "model across EVERY configured provider at once (a deliberate maximum-effort stress "
+            "test), then YOU (the calling model) synthesize the single best answer from all of "
+            "them. Maximum free tokens, maximum cross-checking. Tongue-in-cheek, but genuinely "
+            "useful for the hardest questions where you want every model's take."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string", "description": "The prompt to blast to every model."},
+                "system": {"type": "string", "description": "Optional system instruction."},
+                "max_models": {
+                    "type": "integer",
+                    "description": f"Optional cap on how many models to hit (default: ALL of them; hard max {_TOKENMAX_HARD_CAP}).",
+                },
+                "max_tokens": {
+                    "type": "integer",
+                    "description": "Max output tokens per model (default 400).",
+                },
+            },
+            "required": ["prompt"],
+        },
+    },
+    {
+        "name": "free_llm_route",
+        "description": (
+            "Explain where a prompt WOULD be routed without spending a single token: the "
+            "estimated difficulty and the ranked list of candidate models (with capability "
+            "scores) for the chosen routing mode. Use it to understand or debug routing."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "prompt": {"type": "string", "description": "The prompt to analyze."},
+                "routing": {
+                    "type": "string",
+                    "enum": ["auto", "fast", "quality", "fair"],
+                    "description": "Routing mode to explain (default: the server's mode).",
                 },
             },
             "required": ["prompt"],
@@ -66,6 +169,14 @@ TOOLS = [
         ),
         "inputSchema": {"type": "object", "properties": {}},
     },
+    {
+        "name": "free_llm_stats",
+        "description": (
+            "Show freellmpool's LIFETIME totals (persisted across restarts): tokens served "
+            "free, requests, and estimated cost avoided vs Claude Opus 4.8 — the number that keeps growing."
+        ),
+        "inputSchema": {"type": "object", "properties": {}},
+    },
 ]
 
 
@@ -81,36 +192,268 @@ def _text(text: str, is_error: bool = False) -> dict:
     return {"content": [{"type": "text", "text": text}], "isError": is_error}
 
 
+def _routing_arg(value) -> str | None:
+    """Map the tool's routing arg to a pool routing override (auto/unknown -> None)."""
+    return value if isinstance(value, str) and value in _ROUTING_MODES else None
+
+
+def _messages(system, prompt: str) -> list[dict[str, str]]:
+    msgs: list[dict[str, str]] = []
+    if isinstance(system, str) and system.strip():
+        msgs.append({"role": "system", "content": system})
+    msgs.append({"role": "user", "content": prompt})
+    return msgs
+
+
+def _clamp_int(value, default: int, lo: int, hi: int) -> int:
+    try:
+        return max(lo, min(hi, int(value)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _max_tokens(value, default: int) -> int:
+    return _clamp_int(value, default, 1, 8192)
+
+
+def _resolve_model(model, env) -> tuple[list[str] | None, str | None]:
+    """Resolve a model arg to (providers, model) filters, honoring aliases."""
+    if not (isinstance(model, str) and model):
+        return None, None
+    model = resolve_alias(model, env)
+    if model == "auto":
+        return None, None
+    if "/" in model:
+        p, _, m = model.partition("/")
+        return [p], m
+    return None, model
+
+
 def _call_tool(pool: Pool, params: dict) -> dict:
     name = params.get("name")
     args = params.get("arguments") or {}
     if name == "free_llm_ask":
-        prompt = args.get("prompt")
-        if not isinstance(prompt, str) or not prompt.strip():
-            return _text("'prompt' is required", is_error=True)
-        provider = args.get("provider")
-        providers = [provider] if provider else None
-        model = args.get("model")
-        if isinstance(model, str) and model:
-            model = resolve_alias(model, pool.env)
-            if model == "auto":
-                model = None
-            elif "/" in model:
-                p, _, m = model.partition("/")
-                providers, model = [p], m
-        else:
-            model = None
-        try:
-            reply = pool.ask(prompt, system=args.get("system"), model=model, providers=providers)
-        except Exception as exc:  # noqa: BLE001 — surface as a tool error
-            return _text(f"{type(exc).__name__}: {exc}", is_error=True)
-        return _text(reply.text)
+        return _tool_ask(pool, args)
+    if name == "free_llm_panel":
+        return _tool_panel(pool, args)
+    if name == "tokenmax":
+        return _tool_tokenmax(pool, args)
+    if name == "free_llm_route":
+        return _tool_route(pool, args)
     if name == "free_llm_models":
         ids = [f"{p.id}/{m.name}" for p in pool.providers for m in p.models if m.enabled]
         return _text("\n".join(ids) or "no providers configured")
     if name == "free_llm_quota":
         return _text(_quota_summary(pool))
+    if name == "free_llm_stats":
+        return _text(_lifetime_summary(pool))
     return _text(f"unknown tool: {name}", is_error=True)
+
+
+def _tool_ask(pool: Pool, args: dict) -> dict:
+    prompt = args.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return _text("'prompt' is required", is_error=True)
+    provider = args.get("provider")
+    providers = [provider] if provider else None
+    p_filter, model = _resolve_model(args.get("model"), pool.env)
+    if p_filter is not None:
+        providers = p_filter
+    routing = _routing_arg(args.get("routing"))
+    started = time.monotonic()
+    try:
+        reply = pool.chat(
+            _messages(args.get("system"), prompt),
+            model=model,
+            providers=providers,
+            routing=routing,
+            max_tokens=_max_tokens(args.get("max_tokens"), 1024),
+        )
+    except Exception as exc:  # noqa: BLE001 — surface as a tool error
+        return _text(f"{type(exc).__name__}: {exc}", is_error=True)
+    ms = round((time.monotonic() - started) * 1000)
+    tag = "cache" if reply.cached else f"{ms}ms"
+    return _text(f"{reply.text}\n\n— via {reply.provider_id}/{reply.model} ({tag})")
+
+
+def _tool_panel(pool: Pool, args: dict) -> dict:
+    prompt = args.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return _text("'prompt' is required", is_error=True)
+    n = _clamp_int(args.get("n"), 3, 2, _MAX_PANEL)
+    max_tokens = _max_tokens(args.get("max_tokens"), 512)
+    msgs = _messages(args.get("system"), prompt)
+    # Pick the top N candidates across DISTINCT providers for diverse opinions.
+    picks, seen = [], set()
+    for t in pool.rank_targets(msgs, routing="quality"):
+        if t.provider.id in seen:
+            continue
+        seen.add(t.provider.id)
+        picks.append(t)
+        if len(picks) >= n:
+            break
+    if not picks:
+        return _text("no providers configured", is_error=True)
+
+    def ask_one(t):
+        started = time.monotonic()
+        try:
+            r = pool.chat(msgs, model=t.model, providers=[t.provider.id], max_tokens=max_tokens)
+            return (
+                f"{r.provider_id}/{r.model}",
+                r.text,
+                round((time.monotonic() - started) * 1000),
+                None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            return (f"{t.provider.id}/{t.model}", None, 0, f"{type(exc).__name__}: {exc}")
+
+    with _cf.ThreadPoolExecutor(max_workers=len(picks)) as ex:
+        results = list(ex.map(ask_one, picks))
+
+    out = [f'freellmpool panel — {len(results)} free models on: "{prompt[:70]}"', ""]
+    answers = []
+    for label, text, ms, err in results:
+        if err:
+            out.append(f"### {label}  (failed)\n{err}\n")
+        else:
+            answers.append((label, text))
+            out.append(f"### {label}  ({ms}ms)\n{text}\n")
+
+    if args.get("synthesize") and answers:
+        blob = "\n\n".join(f"[{lbl}]\n{txt}" for lbl, txt in answers)
+        syn_prompt = (
+            "Below are several models' answers to the same question. Synthesize the single "
+            f"best, correct, concise answer, resolving any disagreements.\n\nQuestion: {prompt}\n\n{blob}"
+        )
+        try:
+            syn = pool.chat(
+                _messages(None, syn_prompt), routing="quality", max_tokens=max(max_tokens, 1024)
+            )
+            out.append(f"### synthesis — via {syn.provider_id}/{syn.model}\n{syn.text}")
+        except Exception as exc:  # noqa: BLE001
+            out.append(f"### synthesis (failed)\n{type(exc).__name__}: {exc}")
+    return _text("\n".join(out))
+
+
+class _RainbowThrob:
+    """Tongue-in-cheek: pulse a rainbow 'TOKENMAXXING' banner while a long fan-out
+    runs, so the harness shows it working. Writes to STDERR only — never stdout,
+    which is the JSON-RPC channel. On a real TTY it animates in place; piped (the
+    usual MCP-client case) it prints one plain start line + a done line, so logs
+    don't fill with escape codes."""
+
+    _COLORS = (196, 208, 226, 46, 51, 21, 201)  # ANSI-256 rainbow
+    _PULSE = "▁▂▃▄▅▆▇█▇▆▅▄▃▂"
+
+    def __init__(self, label: str):
+        self.label = label
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._tty = bool(getattr(sys.stderr, "isatty", lambda: False)())
+
+    def __enter__(self) -> _RainbowThrob:
+        if self._tty:
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+        else:
+            sys.stderr.write(f"🌈 {self.label} …\n")
+            sys.stderr.flush()
+        return self
+
+    def _run(self) -> None:
+        for i in itertools.count():
+            if self._stop.wait(0.1):
+                break
+            c = self._COLORS[i % len(self._COLORS)]
+            p = self._PULSE[i % len(self._PULSE)]
+            sys.stderr.write(f"\r\033[38;5;{c}m{p} 🌈 {self.label} {p}\033[0m\033[K")
+            sys.stderr.flush()
+
+    def __exit__(self, *exc) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+            sys.stderr.write("\r\033[K")  # clear the animated line
+            sys.stderr.flush()
+        elif not self._tty:
+            sys.stderr.write(f"🌈 {self.label} — done\n")
+            sys.stderr.flush()
+
+
+def _tool_tokenmax(pool: Pool, args: dict) -> dict:
+    prompt = args.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return _text("'prompt' is required", is_error=True)
+    max_tokens = _max_tokens(args.get("max_tokens"), 350)
+    msgs = _messages(args.get("system"), prompt)
+    # EVERY model across EVERY configured provider — round-robin interleaved so the swarm
+    # spans all providers (best-first within each) instead of pounding one provider's list.
+    by_provider: dict[str, list] = {}
+    for t in pool.rank_targets(msgs):
+        by_provider.setdefault(t.provider.id, []).append(t)
+    interleaved = [t for tier in itertools.zip_longest(*by_provider.values()) for t in tier if t]
+    # Default: ALL of them (the whole point), but never above the hard ceiling — that
+    # guards against a pathological catalog even on the default path. max_models only lowers it.
+    default_limit = min(len(interleaved), _TOKENMAX_HARD_CAP)
+    limit = _clamp_int(args.get("max_models"), default_limit, 1, _TOKENMAX_HARD_CAP)
+    picks = interleaved[:limit]
+    if not picks:
+        return _text("no providers configured", is_error=True)
+    n_providers = len({t.provider.id for t in picks})  # providers actually hit, not pool size
+
+    def ask_one(t):
+        try:
+            r = pool.chat(msgs, model=t.model, providers=[t.provider.id], max_tokens=max_tokens)
+            return (f"{r.provider_id}/{r.model}", r.text, None)
+        except Exception as exc:  # noqa: BLE001
+            return (f"{t.provider.id}/{t.model}", None, f"{type(exc).__name__}: {exc}")
+
+    with (
+        _RainbowThrob(f"TOKENMAXXING {len(picks)} models across {n_providers} providers"),
+        _cf.ThreadPoolExecutor(max_workers=min(_TOKENMAX_WORKERS, len(picks))) as ex,
+    ):
+        results = list(ex.map(ask_one, picks))
+
+    answered = [(lbl, txt) for lbl, txt, err in results if not err]
+    failed = [lbl for lbl, _txt, err in results if err]
+    head = [
+        f"🌈 TOKENMAX — blasted your prompt to {len(picks)} models across "
+        f"{n_providers} providers; {len(answered)} answered, {len(failed)} unavailable.",
+        "Synthesize the single best, correct answer from every response below "
+        "(weigh agreement, discard outliers):",
+        "",
+    ]
+    body = [f"### {lbl}\n{txt}\n" for lbl, txt in answered]
+    if failed:
+        shown = ", ".join(failed[:30]) + ("…" if len(failed) > 30 else "")
+        body.append(f"_{len(failed)} unavailable (rate-limited / errored): {shown}_")
+    return _text("\n".join(head + body))
+
+
+def _tool_route(pool: Pool, args: dict) -> dict:
+    from .capability import capability_table, model_capability, prompt_difficulty
+
+    prompt = args.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return _text("'prompt' is required", is_error=True)
+    routing = _routing_arg(args.get("routing")) or pool.routing
+    msgs = _messages(None, prompt)
+    difficulty = prompt_difficulty(msgs)
+    targets = pool.rank_targets(msgs, routing=routing)
+    table = capability_table()
+    lines = [
+        f"routing mode: {routing}",
+        f"estimated prompt difficulty: {difficulty:.2f}  (0 = trivial, 1 = hardest)",
+        "",
+        f"top candidates (in failover order){' — strongest-fit first' if routing == 'quality' else ''}:",
+    ]
+    for i, t in enumerate(targets[:8], 1):
+        cap = model_capability(t.model, table)
+        lines.append(f"  {i:>2}. {t.provider.id}/{t.model}  (capability {cap:.2f})")
+    if not targets:
+        lines.append("  (no configured candidates)")
+    return _text("\n".join(lines))
 
 
 def _quota_summary(pool: Pool) -> str:
@@ -142,8 +485,28 @@ def _quota_summary(pool: Pool) -> str:
         "",
         f"session: {s.get('requests', 0)} requests, {s.get('cache_hits', 0)} cache hits, "
         f"{s.get('completion_tokens', 0)} output tokens",
-        f"cost avoided vs gpt-4o: ~${usd_saved(s.get('prompt_tokens'), s.get('completion_tokens')):.4f}",
+        f"cost avoided vs Claude Opus 4.8: ~${usd_saved(s.get('prompt_tokens'), s.get('completion_tokens')):.4f}",
     ]
+    return "\n".join(lines)
+
+
+def _lifetime_summary(pool: Pool) -> str:
+    from .savings import usd_saved
+
+    life = pool.lifetime_stats()
+    tokens = int(life.get("prompt_tokens", 0)) + int(life.get("completion_tokens", 0))
+    saved = usd_saved(life.get("prompt_tokens"), life.get("completion_tokens"))
+    lines = [
+        "freellmpool — served free (lifetime):",
+        f"  requests:   {life.get('requests', 0):,}",
+        f"  tokens:     {tokens:,}",
+        f"  cache hits: {life.get('cache_hits', 0):,}",
+        f"  cost avoided vs Claude Opus 4.8: ~${saved:,.2f}"
+        if saved >= 1
+        else f"  cost avoided vs Claude Opus 4.8: ~${saved:.4f}",
+    ]
+    if life.get("first_seen"):
+        lines.append(f"  since: {life['first_seen']}")
     return "\n".join(lines)
 
 

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -840,7 +840,7 @@ def _dashboard_html(pool) -> str:
         ("requests served", str(s.get("requests", 0))),
         ("cache hits", str(s.get("cache_hits", 0))),
         ("healthy providers", f"{capacity.healthy_count}/{capacity.target}"),
-        ("not paid to OpenAI", f"${saved:,.2f}"),
+        ("not spent (Claude Opus 4.8)", f"${saved:,.2f}"),
     ]
     card_html = "\n".join(
         f"<div class=card><div class=big>{v}</div><div class=lbl>{k}</div></div>" for k, v in cards

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -177,6 +177,31 @@ class Pool:
             return self._stats_store.snapshot()
         return {**self.stats_snapshot(), "first_seen": None}
 
+    def rank_targets(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        routing: str | None = None,
+        model: str | None = None,
+        providers: Iterable[str] | None = None,
+    ) -> list[Target]:
+        """Public: the ordered candidate (provider, model) targets for ``messages``,
+        using the same ordering the failover loop would. Powers the MCP route
+        explainer and multi-model panel (which fan out across the top targets) without
+        re-implementing routing. Read-only — does not call any provider."""
+        provider_list = list(providers) if providers else None
+        eff = (
+            routing
+            if routing in ("fair", "fast", "quality", "legacy", "model", "model-fast")
+            else self.routing
+        )
+        difficulty = prompt_difficulty(messages) if eff == "quality" else None
+        return self._order(
+            self._all_targets(include=provider_list, model=model),
+            difficulty=difficulty,
+            routing=routing,
+        )
+
     def _mark_cooldown(self, provider_id: str, now: float) -> None:
         until = now + self.cooldown_seconds
         with self._cooldown_lock:

--- a/src/freellmpool/savings.py
+++ b/src/freellmpool/savings.py
@@ -1,25 +1,30 @@
-"""Estimate the money you *didn't* pay OpenAI by routing through free tiers.
+"""Estimate the money you *didn't* spend by routing through free tiers.
 
-Numbers are deliberately conservative (GPT-4o list pricing as of 2026) and the
-label always says "avoided cost", never "earnings" — it's a fun, honest metric.
+The reference point is **Claude Opus 4.8** list pricing — a frontier-model rate — so
+the "avoided cost" reflects what these tokens would have cost on a top-tier paid model.
+The label always says "avoided cost", never "earnings" — it's a fun, honest metric
+(it states the baseline so the number is interpretable, not inflated by sleight of hand).
 """
 
 from __future__ import annotations
 
-# GPT-4o list price (USD per token). Conservative reference point.
-_GPT4O_INPUT = 2.50 / 1_000_000
-_GPT4O_OUTPUT = 10.00 / 1_000_000
+# Claude Opus 4.8 list price (USD per token). A frontier-model reference point.
+_OPUS_INPUT = 15.00 / 1_000_000
+_OPUS_OUTPUT = 75.00 / 1_000_000
+
+# Human-readable baseline, shown alongside the figure so the number is honest.
+BASELINE_LABEL = "Claude Opus 4.8 rates"
 
 
 def usd_saved(prompt_tokens: int | None, completion_tokens: int | None) -> float:
-    """USD this many tokens would have cost on GPT-4o."""
+    """USD this many tokens would have cost on Claude Opus 4.8."""
     pt = prompt_tokens or 0
     ct = completion_tokens or 0
-    return pt * _GPT4O_INPUT + ct * _GPT4O_OUTPUT
+    return pt * _OPUS_INPUT + ct * _OPUS_OUTPUT
 
 
 def format_saved(prompt_tokens: int | None, completion_tokens: int | None) -> str:
     amount = usd_saved(prompt_tokens, completion_tokens)
     if amount < 0.01:
-        return f"~${amount:.4f} not paid to OpenAI (gpt-4o rates)"
-    return f"~${amount:.2f} not paid to OpenAI (gpt-4o rates)"
+        return f"~${amount:.4f} not spent ({BASELINE_LABEL})"
+    return f"~${amount:,.2f} not spent ({BASELINE_LABEL})"

--- a/src/freellmpool/svg.py
+++ b/src/freellmpool/svg.py
@@ -123,7 +123,7 @@ def summary_svg(stats: dict, leaderboard: list[tuple[str, float]] | None = None)
         f"free LLMs, pooled</text>",
         f'<text x="20" y="84" fill="{_GREEN}" font-size="38" font-weight="bold">'
         f"{_esc(_money(_saved(stats)))}</text>",
-        f'<text x="20" y="104" fill="{_MUTED}" font-size="12">avoided cost (gpt-4o rates)</text>',
+        f'<text x="20" y="104" fill="{_MUTED}" font-size="12">avoided cost (Claude Opus 4.8 rates)</text>',
         f'<text x="20" y="132" fill="{_TEXT}" font-size="13">'
         f"{_esc(_compact(_tokens(stats)))} tokens served free  ·  "
         f"{_esc(_compact(stats.get('requests', 0)))} requests"

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -39,7 +39,15 @@ def test_tools_list(providers, env, quota):
     pool = _pool(providers, env, quota)
     resp = handle_message(pool, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
     names = {t["name"] for t in resp["result"]["tools"]}
-    assert names == {"free_llm_ask", "free_llm_models", "free_llm_quota"}
+    assert names == {
+        "free_llm_ask",
+        "free_llm_panel",
+        "tokenmax",
+        "free_llm_route",
+        "free_llm_models",
+        "free_llm_quota",
+        "free_llm_stats",
+    }
 
 
 def test_tools_call_quota(providers, env, quota):
@@ -65,8 +73,92 @@ def test_tools_call_ask(providers, env, quota):
             "params": {"name": "free_llm_ask", "arguments": {"prompt": "hi"}},
         },
     )
-    assert resp["result"]["content"][0]["text"] == "ok"
+    text = resp["result"]["content"][0]["text"]
+    assert text.startswith("ok")
+    assert "via alpha/" in text  # provenance footer names the serving model
     assert resp["result"]["isError"] is False
+
+
+def test_tools_call_panel(providers, env, quota):
+    pool = _pool(providers, env, quota)  # all providers return "ok"
+    resp = handle_message(
+        pool,
+        {
+            "jsonrpc": "2.0",
+            "id": 10,
+            "method": "tools/call",
+            "params": {"name": "free_llm_panel", "arguments": {"prompt": "hi", "n": 2}},
+        },
+    )
+    text = resp["result"]["content"][0]["text"]
+    assert "panel" in text.lower()
+    assert text.count("###") >= 2  # one section per model asked
+
+
+def test_tools_call_tokenmax(providers, env, quota):
+    pool = _pool(providers, env, quota)  # all providers return "ok"
+    resp = handle_message(
+        pool,
+        {
+            "jsonrpc": "2.0",
+            "id": 13,
+            "method": "tools/call",
+            "params": {"name": "tokenmax", "arguments": {"prompt": "hi", "max_models": 3}},
+        },
+    )
+    text = resp["result"]["content"][0]["text"]
+    assert "TOKENMAX" in text
+    assert "synthesize" in text.lower()  # the caller is told to synthesize
+    assert text.count("###") >= 1  # at least one model's answer included
+
+
+def test_tokenmax_default_respects_hard_cap(providers, env, quota, monkeypatch):
+    import freellmpool.mcp_server as M
+
+    monkeypatch.setattr(M, "_TOKENMAX_HARD_CAP", 2)  # even "all" must obey the ceiling
+    pool = _pool(providers, env, quota)
+    resp = handle_message(
+        pool,
+        {
+            "jsonrpc": "2.0",
+            "id": 14,
+            "method": "tools/call",
+            "params": {"name": "tokenmax", "arguments": {"prompt": "hi"}},  # no max_models -> ALL
+        },
+    )
+    assert "to 2 models" in resp["result"]["content"][0]["text"]
+
+
+def test_tools_call_route_is_zero_token(providers, env, quota):
+    pool = _pool(providers, env, quota)
+    resp = handle_message(
+        pool,
+        {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "tools/call",
+            "params": {
+                "name": "free_llm_route",
+                "arguments": {"prompt": "hi", "routing": "quality"},
+            },
+        },
+    )
+    text = resp["result"]["content"][0]["text"]
+    assert "difficulty" in text.lower()
+    assert "alpha/" in text  # a ranked candidate
+    assert pool.stats_snapshot()["requests"] == 0  # explained without spending a token
+
+
+def test_tools_call_stats(providers, env, quota):
+    pool = _pool(providers, env, quota)
+    pool.ask("hi")  # record some usage
+    resp = handle_message(
+        pool,
+        {"jsonrpc": "2.0", "id": 12, "method": "tools/call", "params": {"name": "free_llm_stats"}},
+    )
+    text = resp["result"]["content"][0]["text"]
+    assert "lifetime" in text.lower()
+    assert "Claude Opus 4.8" in text
 
 
 def test_tools_call_ask_missing_prompt(providers, env, quota):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -83,7 +83,7 @@ def test_dashboard(server):
         body = resp.read().decode()
     assert "freellmpool" in body
     assert "providers configured" in body
-    assert "not paid to OpenAI" in body
+    assert "not spent (Claude Opus 4.8)" in body
 
 
 def test_healthz(server):

--- a/tests/test_savings.py
+++ b/tests/test_savings.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 from freellmpool.savings import format_saved, usd_saved
 
 
-def test_usd_saved_gpt4o_rates():
-    # 1M input @ $2.50 + 1M output @ $10.00 = $12.50
-    assert usd_saved(1_000_000, 1_000_000) == 12.50
+def test_usd_saved_opus_rates():
+    # 1M input @ $15 + 1M output @ $75 = $90.00 (Claude Opus 4.8 list pricing)
+    assert usd_saved(1_000_000, 1_000_000) == 90.00
     assert usd_saved(0, 0) == 0.0
     assert usd_saved(None, None) == 0.0
 
 
 def test_format_saved():
-    assert "not paid to OpenAI" in format_saved(10, 10)
-    assert format_saved(1_000_000, 1_000_000).startswith("~$12.50")
+    assert "not spent" in format_saved(10, 10)
+    assert "Claude Opus 4.8" in format_saved(10, 10)
+    assert format_saved(1_000_000, 1_000_000).startswith("~$90.00")


### PR DESCRIPTION
## MCP toolbox + savings vs Claude Opus 4.8

Makes the MCP server something MCP power users will actually rave about, and rebases the
"avoided cost" metric onto a frontier baseline.

### New / upgraded MCP tools
- **`free_llm_panel`** — ask the same prompt to N *distinct* providers in parallel and compare;
  optional `synthesize` merges them. A free second opinion / ensemble.
- **`tokenmax`** 🌈 — gloriously excessive: fan the prompt to **every model across every provider**
  at once (round-robin interleave, default ALL, hard cap 256, 32-way parallel), then the *calling*
  model synthesizes them all. Rainbow `TOKENMAXXING` throb on a TTY stderr (never stdout). Live:
  168 models / 11 providers / 123 answered in 92s.
- **`free_llm_route`** — explain where a prompt *would* route (difficulty + ranked candidates by
  capability) at **zero token cost**.
- **`free_llm_stats`** — lifetime served-free totals.
- **`free_llm_ask`** — now takes `routing` (auto/fast/quality/fair) + `max_tokens` and reports the
  serving model in a provenance footer.
- **`Pool.rank_targets()`** — read-only candidate ordering helper powering the above.

### Savings → Claude Opus 4.8
`savings.py` rebased from gpt-4o to **Claude Opus 4.8** ($15/$75 per M; 1M+1M = $90); the
"avoided cost" labels updated across the dashboard, the SVG badge, and the MCP tools.

### Verification
All 7 MCP tools exercised live through the real stdio JSON-RPC protocol with keyed providers.
Reviewed by **Codex** (SHIP after fixing a `tokenmax` hard-cap bypass on the default path —
now regression-tested) and **freellmpool's own quality routing** (dogfooded). **316 tests, ruff clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Expand the MCP server toolbox with multi-model comparison, routing introspection, and lifetime stats while rebasing cost-savings metrics onto Claude Opus 4.8 pricing.

New Features:
- Expose a free_llm_panel MCP tool to query multiple free models in parallel with optional synthesis into a single answer.
- Add a tokenmax MCP tool that fans out a prompt to many models across providers with a progress indicator and returns all responses for caller-side synthesis.
- Introduce a free_llm_route MCP tool that explains how a prompt would be routed, including difficulty and ranked candidate models, without consuming tokens.
- Add a free_llm_stats MCP tool to report lifetime free usage, cache hits, and estimated cost avoided.
- Extend free_llm_ask to support routing modes, max_tokens limits, and provenance footers indicating the serving provider and model.

Enhancements:
- Add a Pool.rank_targets helper to expose the router’s ordered candidate list for reuse by tools without duplicating routing logic.
- Refine quota summaries, dashboard cards, and SVG labels to describe avoided cost relative to Claude Opus 4.8 rather than GPT-4o.
- Enhance MCP server messaging utilities and introduce a rainbow stderr banner for long-running tokenmax fan-outs.

Tests:
- Expand MCP tests to cover the new tools (panel, tokenmax, route, stats), provenance output, routing behavior, and the tokenmax hard cap.
- Update savings and dashboard tests to validate the new Claude Opus 4.8 pricing baseline and revised copy.