### PR TITLE
tokenmax full spectacle: live MCP progress + rainbow banner + CLI animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,18 @@ Only dependency is `httpx`. Python 3.11+.
 ```bash
 freellmpool ask "Write a haiku about sqlite"
 git diff | freellmpool ask "Write a commit message for this"
+freellmpool tokenmax "Hardest question you've got"  # 🌈 blast EVERY model, synthesize the swarm
 freellmpool providers        # which providers are configured
 freellmpool models           # every provider/model id
 freellmpool stats            # lifetime tokens served free + avoided cost
 freellmpool badge -o badge.svg   # a shareable SVG badge of that total
 ```
+
+`freellmpool tokenmax` is the tongue-in-cheek maximum-effort mode: it fans your
+prompt out to **every model across every provider** at once, prints each answer, and
+synthesizes one best verdict — flashing a rainbow `TOKENMAXXING` animation in your
+terminal while it runs. (Also available as the `tokenmax` MCP tool — see
+[docs/MCP.md](docs/MCP.md).)
 
 `freellmpool stats` is a running, **persistent** lifetime total (it survives restarts
 and upgrades). Embed `freellmpool badge` in a README, or serve it live from the proxy

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -14,7 +14,7 @@ and it works (keyless providers). Add keys to unlock more.
 |---|---|
 | `free_llm_ask` | Ask a free model (`prompt`, optional `system` / `model` / `provider` / `routing` / `max_tokens`). The reply names the serving model. |
 | `free_llm_panel` | Ask the **same** prompt to N different free models at once and compare — a free second opinion / ensemble. Optional `synthesize` merges them into one best answer. |
-| `tokenmax` | 🌈 Gloriously excessive: blast the prompt to a big swarm of free models, then the **calling** model synthesizes them all. Tongue-in-cheek, genuinely useful for hard questions (throbs a rainbow `TOKENMAXXING` banner while it runs). |
+| `tokenmax` | 🌈 Gloriously excessive: blast the prompt to **every** free model across **every** provider at once, then the **calling** model synthesizes them all. Emits live `notifications/progress` (`🌈 TOKENMAXXING ▸ 47/168 models…`) so hosts like Claude Code show it ticking up, and a colorful rainbow banner in the result. Tongue-in-cheek, genuinely useful for hard questions. |
 | `free_llm_route` | Explain where a prompt **would** route (estimated difficulty + ranked candidate models) **without spending a token**. |
 | `free_llm_models` | List available `provider/model` ids. |
 | `free_llm_quota` | Today's per-provider usage + daily-limit headroom, plus session totals and estimated cost avoided. |
@@ -77,3 +77,10 @@ Pass them through the MCP server's environment, e.g. in the config:
 - The server speaks newline-delimited JSON-RPC 2.0 over stdio (the standard MCP
   stdio transport) and is implemented on the Python standard library only.
 - `stdout` carries the protocol; freellmpool prints its banner to `stderr`.
+- **Live `tokenmax` progress:** when a client passes a `progressToken` (Claude
+  Code does), `tokenmax` streams `notifications/progress` as each model answers, so
+  you see the swarm tick up in real time. Raw ANSI can't animate inside an MCP
+  host's chat, so progress + a rainbow emoji banner are how the spectacle "comes
+  through" there. For the **genuine** flashing rainbow animation, run it in a real
+  terminal: `freellmpool tokenmax "your question"` (it also prints every answer and
+  a synthesized verdict).

--- a/src/freellmpool/cli.py
+++ b/src/freellmpool/cli.py
@@ -1,6 +1,7 @@
 """Command-line interface for freellmpool.
 
 freellmpool ask "question"        one-shot completion (reads stdin too)
+freellmpool tokenmax "question"   🌈 blast every model, synthesize the swarm
 freellmpool providers            list configured / available providers
 freellmpool quota                show today's per-provider usage
 freellmpool proxy                run the OpenAI-compatible proxy server
@@ -80,6 +81,70 @@ def cmd_ask(args: argparse.Namespace) -> int:
             f"\n[served by {reply.provider_id}/{reply.model} · {saved}]",
             file=sys.stderr,
         )
+    return 0
+
+
+def cmd_tokenmax(args: argparse.Namespace) -> int:
+    """🌈 Blast one prompt to EVERY model across EVERY provider, then (by default)
+    synthesize the swarm into one answer. The genuine rainbow animation runs on a
+    real terminal."""
+    from .tokenmax import RAINBOW_BANNER, RainbowThrob, fan_out, select_targets
+
+    stdin = _read_stdin()
+    prompt = args.prompt or ""
+    if stdin:
+        prompt = f"{stdin}\n\n{prompt}".strip() if prompt else stdin
+    if not prompt.strip():
+        print("freellmpool: no prompt provided (pass text or pipe stdin)", file=sys.stderr)
+        return 3
+
+    pool = Pool.from_default_config()
+    if not pool.providers:
+        print(
+            "freellmpool: no providers configured; set at least one API key "
+            "(see .env.example) before tokenmaxxing.",
+            file=sys.stderr,
+        )
+        return 3
+
+    msgs: list[dict[str, str]] = []
+    if args.system:
+        msgs.append({"role": "system", "content": args.system})
+    msgs.append({"role": "user", "content": prompt})
+
+    picks, n_providers = select_targets(pool, msgs, args.max_models)
+    if not picks:
+        print("freellmpool: no models available to blast", file=sys.stderr)
+        return 3
+
+    label = f"TOKENMAXXING {len(picks)} models across {n_providers} providers"
+    with RainbowThrob(label):
+        answered, failed = fan_out(pool, msgs, picks, max_tokens=args.max_tokens)
+
+    print(
+        f"{RAINBOW_BANNER} TOKENMAX — {len(picks)} models / {n_providers} providers · "
+        f"{len(answered)} answered, {len(failed)} unavailable {RAINBOW_BANNER}\n"
+    )
+    for lbl, text in answered:
+        print(f"### {lbl}\n{text}\n")
+    if failed:
+        shown = ", ".join(failed[:30]) + ("…" if len(failed) > 30 else "")
+        print(f"({len(failed)} unavailable: {shown})\n", file=sys.stderr)
+
+    if not args.no_synthesize and answered:
+        blob = "\n\n".join(f"[{lbl}]\n{txt}" for lbl, txt in answered)
+        syn_prompt = (
+            "Below are many models' answers to the same question. Synthesize the single "
+            "best, correct, concise answer, weighing agreement and discarding outliers.\n\n"
+            f"Question: {prompt}\n\n{blob}"
+        )
+        try:
+            syn = pool.chat(
+                [{"role": "user", "content": syn_prompt}], routing="quality", max_tokens=1024
+            )
+            print(f"{RAINBOW_BANNER} SYNTHESIS — via {syn.provider_id}/{syn.model}\n{syn.text}")
+        except Exception as exc:  # noqa: BLE001 — synthesis is a bonus, never fatal
+            print(f"(synthesis failed: {type(exc).__name__}: {exc})", file=sys.stderr)
     return 0
 
 
@@ -740,6 +805,25 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_ask.add_argument("-v", "--verbose", action="store_true", help="report which provider served")
     p_ask.set_defaults(func=cmd_ask)
+
+    p_tokenmax = sub.add_parser(
+        "tokenmax",
+        help="🌈 blast a prompt to EVERY model across EVERY provider, then synthesize",
+    )
+    p_tokenmax.add_argument("prompt", nargs="?", default="", help="prompt text (stdin is appended)")
+    p_tokenmax.add_argument("-s", "--system", help="system prompt")
+    p_tokenmax.add_argument(
+        "--max-models", type=int, default=None, help="cap how many models to hit (default: ALL)"
+    )
+    p_tokenmax.add_argument(
+        "--max-tokens", type=int, default=400, help="max output tokens per model"
+    )
+    p_tokenmax.add_argument(
+        "--no-synthesize",
+        action="store_true",
+        help="just dump every answer; skip the synthesized verdict",
+    )
+    p_tokenmax.set_defaults(func=cmd_tokenmax)
 
     p_prov = sub.add_parser("providers", help="list providers and configuration status")
     prov_sub = p_prov.add_subparsers(dest="providers_command")

--- a/src/freellmpool/mcp_server.py
+++ b/src/freellmpool/mcp_server.py
@@ -26,7 +26,6 @@ Implemented on the standard library only — no MCP SDK required.
 from __future__ import annotations
 
 import concurrent.futures as _cf
-import itertools
 import json
 import sys
 import threading
@@ -34,14 +33,11 @@ import time
 
 from .config import resolve_alias
 from .router import Pool
+from .tokenmax import HARD_CAP, RAINBOW_BANNER, RainbowThrob, fan_out, select_targets
 
 _DEFAULT_PROTOCOL = "2025-06-18"
 _ROUTING_MODES = ("fair", "fast", "quality", "legacy", "model", "model-fast")
 _MAX_PANEL = 5
-# tokenmax fans out to EVERY model by default (the whole point). A high hard ceiling
-# only stops a pathological catalog from spawning thousands; workers stay bounded.
-_TOKENMAX_HARD_CAP = 256
-_TOKENMAX_WORKERS = 32
 
 TOOLS = [
     {
@@ -126,7 +122,7 @@ TOOLS = [
                 "system": {"type": "string", "description": "Optional system instruction."},
                 "max_models": {
                     "type": "integer",
-                    "description": f"Optional cap on how many models to hit (default: ALL of them; hard max {_TOKENMAX_HARD_CAP}).",
+                    "description": f"Optional cap on how many models to hit (default: ALL of them; hard max {HARD_CAP}).",
                 },
                 "max_tokens": {
                     "type": "integer",
@@ -229,7 +225,7 @@ def _resolve_model(model, env) -> tuple[list[str] | None, str | None]:
     return None, model
 
 
-def _call_tool(pool: Pool, params: dict) -> dict:
+def _call_tool(pool: Pool, params: dict, notify=None) -> dict:
     name = params.get("name")
     args = params.get("arguments") or {}
     if name == "free_llm_ask":
@@ -237,7 +233,7 @@ def _call_tool(pool: Pool, params: dict) -> dict:
     if name == "free_llm_panel":
         return _tool_panel(pool, args)
     if name == "tokenmax":
-        return _tool_tokenmax(pool, args)
+        return _tool_tokenmax(pool, args, notify=notify)
     if name == "free_llm_route":
         return _tool_route(pool, args)
     if name == "free_llm_models":
@@ -336,90 +332,29 @@ def _tool_panel(pool: Pool, args: dict) -> dict:
     return _text("\n".join(out))
 
 
-class _RainbowThrob:
-    """Tongue-in-cheek: pulse a rainbow 'TOKENMAXXING' banner while a long fan-out
-    runs, so the harness shows it working. Writes to STDERR only — never stdout,
-    which is the JSON-RPC channel. On a real TTY it animates in place; piped (the
-    usual MCP-client case) it prints one plain start line + a done line, so logs
-    don't fill with escape codes."""
-
-    _COLORS = (196, 208, 226, 46, 51, 21, 201)  # ANSI-256 rainbow
-    _PULSE = "▁▂▃▄▅▆▇█▇▆▅▄▃▂"
-
-    def __init__(self, label: str):
-        self.label = label
-        self._stop = threading.Event()
-        self._thread: threading.Thread | None = None
-        self._tty = bool(getattr(sys.stderr, "isatty", lambda: False)())
-
-    def __enter__(self) -> _RainbowThrob:
-        if self._tty:
-            self._thread = threading.Thread(target=self._run, daemon=True)
-            self._thread.start()
-        else:
-            sys.stderr.write(f"🌈 {self.label} …\n")
-            sys.stderr.flush()
-        return self
-
-    def _run(self) -> None:
-        for i in itertools.count():
-            if self._stop.wait(0.1):
-                break
-            c = self._COLORS[i % len(self._COLORS)]
-            p = self._PULSE[i % len(self._PULSE)]
-            sys.stderr.write(f"\r\033[38;5;{c}m{p} 🌈 {self.label} {p}\033[0m\033[K")
-            sys.stderr.flush()
-
-    def __exit__(self, *exc) -> None:
-        self._stop.set()
-        if self._thread is not None:
-            self._thread.join(timeout=1.0)
-            sys.stderr.write("\r\033[K")  # clear the animated line
-            sys.stderr.flush()
-        elif not self._tty:
-            sys.stderr.write(f"🌈 {self.label} — done\n")
-            sys.stderr.flush()
-
-
-def _tool_tokenmax(pool: Pool, args: dict) -> dict:
+def _tool_tokenmax(pool: Pool, args: dict, notify=None) -> dict:
     prompt = args.get("prompt")
     if not isinstance(prompt, str) or not prompt.strip():
         return _text("'prompt' is required", is_error=True)
     max_tokens = _max_tokens(args.get("max_tokens"), 350)
     msgs = _messages(args.get("system"), prompt)
-    # EVERY model across EVERY configured provider — round-robin interleaved so the swarm
-    # spans all providers (best-first within each) instead of pounding one provider's list.
-    by_provider: dict[str, list] = {}
-    for t in pool.rank_targets(msgs):
-        by_provider.setdefault(t.provider.id, []).append(t)
-    interleaved = [t for tier in itertools.zip_longest(*by_provider.values()) for t in tier if t]
-    # Default: ALL of them (the whole point), but never above the hard ceiling — that
-    # guards against a pathological catalog even on the default path. max_models only lowers it.
-    default_limit = min(len(interleaved), _TOKENMAX_HARD_CAP)
-    limit = _clamp_int(args.get("max_models"), default_limit, 1, _TOKENMAX_HARD_CAP)
-    picks = interleaved[:limit]
+    picks, n_providers = select_targets(pool, msgs, args.get("max_models"))
     if not picks:
         return _text("no providers configured", is_error=True)
-    n_providers = len({t.provider.id for t in picks})  # providers actually hit, not pool size
 
-    def ask_one(t):
-        try:
-            r = pool.chat(msgs, model=t.model, providers=[t.provider.id], max_tokens=max_tokens)
-            return (f"{r.provider_id}/{r.model}", r.text, None)
-        except Exception as exc:  # noqa: BLE001
-            return (f"{t.provider.id}/{t.model}", None, f"{type(exc).__name__}: {exc}")
+    # Live progress for hosts that support it (Claude Code shows the message ticking
+    # up). Raw ANSI can't animate inside an MCP chat, so this is the "it's alive" signal.
+    def progress(done: int, total: int, _label: str) -> None:
+        if notify is not None:
+            notify(done, total, f"🌈 TOKENMAXXING ▸ {done}/{total} models")
 
-    with (
-        _RainbowThrob(f"TOKENMAXXING {len(picks)} models across {n_providers} providers"),
-        _cf.ThreadPoolExecutor(max_workers=min(_TOKENMAX_WORKERS, len(picks))) as ex,
-    ):
-        results = list(ex.map(ask_one, picks))
+    with RainbowThrob(f"TOKENMAXXING {len(picks)} models across {n_providers} providers"):
+        answered, failed = fan_out(pool, msgs, picks, max_tokens=max_tokens, progress=progress)
 
-    answered = [(lbl, txt) for lbl, txt, err in results if not err]
-    failed = [lbl for lbl, _txt, err in results if err]
     head = [
-        f"🌈 TOKENMAX — blasted your prompt to {len(picks)} models across "
-        f"{n_providers} providers; {len(answered)} answered, {len(failed)} unavailable.",
+        f"{RAINBOW_BANNER} TOKENMAX — blasted your prompt to {len(picks)} models across "
+        f"{n_providers} providers; {len(answered)} answered, {len(failed)} unavailable. "
+        f"{RAINBOW_BANNER}",
         "Synthesize the single best, correct answer from every response below "
         "(weigh agreement, discard outliers):",
         "",
@@ -510,9 +445,40 @@ def _lifetime_summary(pool: Pool) -> str:
     return "\n".join(lines)
 
 
-def handle_message(pool: Pool, msg: dict, *, version: str = "0.0.0") -> dict | None:
+def _make_notify(params: dict, send_notification):
+    """Build a progress callback that emits MCP `notifications/progress`, but only
+    when the client supplied a progressToken (per the MCP spec) and we have a
+    channel to send on. Otherwise return None so the tool runs silently."""
+    if send_notification is None:
+        return None
+    token = (params.get("_meta") or {}).get("progressToken")
+    if token is None:
+        return None
+
+    def notify(progress: int, total: int, message: str) -> None:
+        send_notification(
+            {
+                "jsonrpc": "2.0",
+                "method": "notifications/progress",
+                "params": {
+                    "progressToken": token,
+                    "progress": progress,
+                    "total": total,
+                    "message": message,
+                },
+            }
+        )
+
+    return notify
+
+
+def handle_message(
+    pool: Pool, msg: dict, *, version: str = "0.0.0", send_notification=None
+) -> dict | None:
     """Handle one JSON-RPC message. Returns a response dict, or None for
-    notifications (which get no reply)."""
+    notifications (which get no reply). `send_notification`, if given, is a
+    callback the server can use to emit out-of-band notifications (e.g. progress)
+    while a tool is still running."""
     if not isinstance(msg, dict):
         return _error(None, -32600, "invalid request: not a JSON-RPC object")
     if "method" not in msg or not isinstance(msg["method"], str):
@@ -540,7 +506,9 @@ def handle_message(pool: Pool, msg: dict, *, version: str = "0.0.0") -> dict | N
         if method == "tools/list":
             return _result(mid, {"tools": TOOLS})
         if method == "tools/call":
-            return _result(mid, _call_tool(pool, msg.get("params") or {}))
+            params = msg.get("params") or {}
+            notify = _make_notify(params, send_notification)
+            return _result(mid, _call_tool(pool, params, notify=notify))
         return _error(mid, -32601, f"method not found: {method}")
     except Exception as exc:  # noqa: BLE001 — never crash the loop
         return _error(mid, -32603, f"{type(exc).__name__}: {exc}")
@@ -549,11 +517,31 @@ def handle_message(pool: Pool, msg: dict, *, version: str = "0.0.0") -> dict | N
 def serve_stdio(pool: Pool, version: str = "0.0.0") -> None:
     """Run the MCP server over stdio until stdin closes."""
     out = sys.stdout
+    # A lock guards every write so progress notifications emitted from tokenmax's
+    # worker threads can't interleave mid-line with the final response.
+    #
+    # Deadlock-safety invariant: the lock is only ever held for the duration of a
+    # single write_obj() call. handle_message() (which runs the tool's fan-out and
+    # all of its worker-thread progress notifications) is fully evaluated BEFORE
+    # emit()/write_obj() acquires the lock — so the main thread never holds the lock
+    # while workers are trying to acquire it. Do not move write_obj() to wrap a
+    # handle_message() call, or the workers' notifications would deadlock.
+    write_lock = threading.Lock()
+
+    def write_obj(obj) -> None:
+        with write_lock:
+            out.write(json.dumps(obj) + "\n")
+            out.flush()
 
     def emit(resp) -> None:
         if resp is not None:
-            out.write(json.dumps(resp) + "\n")
-            out.flush()
+            write_obj(resp)
+
+    def send_notification(obj) -> None:
+        try:  # best-effort; a failed progress ping must never abort the tool
+            write_obj(obj)
+        except Exception:  # noqa: BLE001
+            pass
 
     for line in sys.stdin:
         line = line.strip()
@@ -568,11 +556,17 @@ def serve_stdio(pool: Pool, version: str = "0.0.0") -> None:
             if not msg:
                 emit(_error(None, -32600, "invalid request: empty batch"))
                 continue
-            responses = [r for r in (handle_message(pool, m, version=version) for m in msg) if r]
+            responses = [
+                r
+                for r in (
+                    handle_message(pool, m, version=version, send_notification=send_notification)
+                    for m in msg
+                )
+                if r
+            ]
             # JSON-RPC 2.0: a batch gets a single response that is an array of the
             # individual responses (omitting notifications). All-notifications → no reply.
             if responses:
-                out.write(json.dumps(responses) + "\n")
-                out.flush()
+                write_obj(responses)
             continue
-        emit(handle_message(pool, msg, version=version))
+        emit(handle_message(pool, msg, version=version, send_notification=send_notification))

--- a/src/freellmpool/tokenmax.py
+++ b/src/freellmpool/tokenmax.py
@@ -1,0 +1,144 @@
+"""Shared TOKENMAX core — fan one prompt out to a whole swarm of free models.
+
+Used by both the MCP ``tokenmax`` tool and the ``freellmpool tokenmax`` CLI so
+the fan-out logic lives in exactly one place:
+
+* the **CLI** gets the genuine rainbow ANSI animation on a TTY (stderr), then
+  prints every answer (and, by default, a synthesized verdict);
+* the **MCP** tool emits live ``notifications/progress`` while it runs (so hosts
+  like Claude Code show ``🌈 TOKENMAXXING ▸ 47/168 models…`` ticking up) and a
+  colorful, markdown-safe rainbow banner in the result — because raw ANSI can't
+  animate inside an MCP host's chat, but progress + emoji color can.
+
+Nothing here imports the MCP or proxy layers, so it stays dependency-light.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures as _cf
+import itertools
+import sys
+import threading
+from collections.abc import Callable
+
+from .router import Pool
+
+# Even the default "ALL models" path is bounded — a pathological catalog should
+# never spawn thousands of in-flight requests. ``max_models`` only lowers this.
+HARD_CAP = 256
+WORKERS = 32
+
+# A markdown-safe rainbow banner: real color that lands in EVERY MCP host without
+# ANSI escape codes (which hosts strip from tool output).
+RAINBOW_BANNER = "🟥🟧🟨🟩🟦🟪"
+
+# ANSI-256 rainbow + a pulse ramp for the genuine TTY animation.
+_ANSI_COLORS = (196, 208, 226, 46, 51, 21, 201)
+_PULSE = "▁▂▃▄▅▆▇█▇▆▅▄▃▂"
+
+
+class RainbowThrob:
+    """Pulse a rainbow ``TOKENMAXXING`` banner while a long fan-out runs.
+
+    Writes to STDERR only — never stdout (which is the MCP JSON-RPC channel). On a
+    real TTY it animates in place; piped (the usual MCP-client case) it prints one
+    plain start line + a done line so logs don't fill with escape codes.
+    """
+
+    def __init__(self, label: str):
+        self.label = label
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._tty = bool(getattr(sys.stderr, "isatty", lambda: False)())
+
+    def __enter__(self) -> RainbowThrob:
+        if self._tty:
+            self._thread = threading.Thread(target=self._run, daemon=True)
+            self._thread.start()
+        else:
+            sys.stderr.write(f"🌈 {self.label} …\n")
+            sys.stderr.flush()
+        return self
+
+    def _run(self) -> None:
+        for i in itertools.count():
+            if self._stop.wait(0.1):
+                break
+            c = _ANSI_COLORS[i % len(_ANSI_COLORS)]
+            p = _PULSE[i % len(_PULSE)]
+            sys.stderr.write(f"\r\033[38;5;{c}m{p} 🌈 {self.label} {p}\033[0m\033[K")
+            sys.stderr.flush()
+
+    def __exit__(self, *exc) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+            sys.stderr.write("\r\033[K")  # clear the animated line
+            sys.stderr.flush()
+        elif not self._tty:
+            sys.stderr.write(f"🌈 {self.label} — done\n")
+            sys.stderr.flush()
+
+
+def select_targets(pool: Pool, messages: list[dict], max_models=None) -> tuple[list, int]:
+    """Pick which models to blast: EVERY model across EVERY provider, round-robin
+    interleaved by provider (best-first within each) so the swarm spans all
+    providers instead of pounding one provider's list.
+
+    Returns ``(picks, n_providers)``. ``max_models`` only lowers the count; the
+    default is ALL of them, capped at :data:`HARD_CAP`.
+    """
+    by_provider: dict[str, list] = {}
+    for t in pool.rank_targets(messages):
+        by_provider.setdefault(t.provider.id, []).append(t)
+    interleaved = [t for tier in itertools.zip_longest(*by_provider.values()) for t in tier if t]
+    default_limit = min(len(interleaved), HARD_CAP)
+    if max_models is None:
+        limit = default_limit
+    else:
+        try:
+            limit = max(1, min(HARD_CAP, int(max_models)))
+        except (TypeError, ValueError):
+            limit = default_limit
+    picks = interleaved[:limit]
+    n_providers = len({t.provider.id for t in picks})
+    return picks, n_providers
+
+
+def fan_out(
+    pool: Pool,
+    messages: list[dict],
+    picks: list,
+    *,
+    max_tokens: int,
+    progress: Callable[[int, int, str], None] | None = None,
+) -> tuple[list[tuple[str, str | None]], list[str]]:
+    """Blast ``messages`` to every target in ``picks`` concurrently.
+
+    Calls ``progress(done, total, label)`` after each model returns (thread-safe).
+    Returns ``(answered, failed)`` where ``answered`` is ``[(label, text)]`` and
+    ``failed`` is ``[label]``.
+    """
+    total = len(picks)
+    counter = itertools.count(1)
+    lock = threading.Lock()
+
+    def ask_one(t):
+        try:
+            r = pool.chat(messages, model=t.model, providers=[t.provider.id], max_tokens=max_tokens)
+            out = (f"{r.provider_id}/{r.model}", r.text, None)
+        except Exception as exc:  # noqa: BLE001 — one model failing must not abort the swarm
+            out = (f"{t.provider.id}/{t.model}", None, f"{type(exc).__name__}: {exc}")
+        if progress is not None:
+            with lock:
+                done = next(counter)
+            progress(done, total, out[0])
+        return out
+
+    if total == 0:
+        return [], []
+    with _cf.ThreadPoolExecutor(max_workers=min(WORKERS, total)) as ex:
+        results = list(ex.map(ask_one, picks))
+    answered = [(lbl, txt) for lbl, txt, err in results if not err]
+    failed = [lbl for lbl, _txt, err in results if err]
+    return answered, failed

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,38 @@ def test_strip_plain_json():
     assert _strip_fences('{"a": 1}') == '{"a": 1}'
 
 
+def test_cli_tokenmax_smoke(providers, env, quota, monkeypatch, capsys):
+    """`freellmpool tokenmax` blasts the fake pool and prints every answer."""
+    from helpers import make_post
+
+    from freellmpool.cli import main
+    from freellmpool.router import Pool
+
+    pool = Pool(providers, quota=quota, env=env, post=make_post({}))  # all return "ok"
+    monkeypatch.setattr(Pool, "from_default_config", classmethod(lambda cls: pool))
+    monkeypatch.setattr("freellmpool.cli._read_stdin", lambda: "")
+
+    assert main(["tokenmax", "capital of Australia?", "--no-synthesize"]) == 0
+    out = capsys.readouterr().out
+    assert "TOKENMAX" in out
+    assert "###" in out  # at least one model's answer
+
+
+def test_cli_tokenmax_synthesizes_by_default(providers, env, quota, monkeypatch, capsys):
+    from helpers import make_post
+
+    from freellmpool.cli import main
+    from freellmpool.router import Pool
+
+    pool = Pool(providers, quota=quota, env=env, post=make_post({}))
+    monkeypatch.setattr(Pool, "from_default_config", classmethod(lambda cls: pool))
+    monkeypatch.setattr("freellmpool.cli._read_stdin", lambda: "")
+
+    assert main(["tokenmax", "hi", "--max-models", "2"]) == 0
+    out = capsys.readouterr().out
+    assert "SYNTHESIS" in out  # the verdict is produced unless --no-synthesize
+
+
 def test_strip_fenced_json():
     assert _strip_fences('```json\n{"a": 1}\n```') == '{"a": 1}'
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -113,9 +113,9 @@ def test_tools_call_tokenmax(providers, env, quota):
 
 
 def test_tokenmax_default_respects_hard_cap(providers, env, quota, monkeypatch):
-    import freellmpool.mcp_server as M
+    import freellmpool.tokenmax as TM
 
-    monkeypatch.setattr(M, "_TOKENMAX_HARD_CAP", 2)  # even "all" must obey the ceiling
+    monkeypatch.setattr(TM, "HARD_CAP", 2)  # even "all" must obey the ceiling
     pool = _pool(providers, env, quota)
     resp = handle_message(
         pool,
@@ -127,6 +127,64 @@ def test_tokenmax_default_respects_hard_cap(providers, env, quota, monkeypatch):
         },
     )
     assert "to 2 models" in resp["result"]["content"][0]["text"]
+
+
+def test_tokenmax_result_has_rainbow_banner(providers, env, quota):
+    from freellmpool.tokenmax import RAINBOW_BANNER
+
+    pool = _pool(providers, env, quota)
+    resp = handle_message(
+        pool,
+        {
+            "jsonrpc": "2.0",
+            "id": 15,
+            "method": "tools/call",
+            "params": {"name": "tokenmax", "arguments": {"prompt": "hi"}},
+        },
+    )
+    assert RAINBOW_BANNER in resp["result"]["content"][0]["text"]  # color lands in every host
+
+
+def test_tokenmax_emits_progress_when_token_present(providers, env, quota):
+    pool = _pool(providers, env, quota)
+    sent: list = []
+    resp = handle_message(
+        pool,
+        {
+            "jsonrpc": "2.0",
+            "id": 16,
+            "method": "tools/call",
+            "params": {
+                "name": "tokenmax",
+                "arguments": {"prompt": "hi"},
+                "_meta": {"progressToken": "tok-1"},
+            },
+        },
+        send_notification=sent.append,
+    )
+    assert resp["result"]["isError"] is False
+    progs = [m for m in sent if m.get("method") == "notifications/progress"]
+    assert progs, "expected progress notifications when a progressToken is supplied"
+    last = progs[-1]["params"]
+    assert last["progressToken"] == "tok-1"
+    assert last["progress"] == last["total"]  # the final tick reaches 100%
+    assert "TOKENMAXXING" in last["message"]
+
+
+def test_tokenmax_silent_without_progress_token(providers, env, quota):
+    pool = _pool(providers, env, quota)
+    sent: list = []
+    handle_message(
+        pool,
+        {
+            "jsonrpc": "2.0",
+            "id": 17,
+            "method": "tools/call",
+            "params": {"name": "tokenmax", "arguments": {"prompt": "hi"}},  # no _meta
+        },
+        send_notification=sent.append,
+    )
+    assert not [m for m in sent if m.get("method") == "notifications/progress"]
 
 
 def test_tools_call_route_is_zero_token(providers, env, quota):

--- a/tests/test_tokenmax.py
+++ b/tests/test_tokenmax.py
@@ -1,0 +1,75 @@
+"""The shared TOKENMAX core: target selection, fan-out, progress, throb."""
+
+from __future__ import annotations
+
+from helpers import make_post
+
+from freellmpool import tokenmax
+from freellmpool.router import Pool
+
+MSGS = [{"role": "user", "content": "hi"}]
+
+
+def _pool(providers, env, quota, post=None):
+    return Pool(providers, quota=quota, env=env, post=post or make_post({}))
+
+
+def test_select_targets_defaults_to_all(providers, env, quota):
+    pool = _pool(providers, env, quota)
+    picks, n_providers = tokenmax.select_targets(pool, MSGS)
+    assert len(picks) >= 1
+    assert n_providers == len({t.provider.id for t in picks})
+
+
+def test_select_targets_respects_hard_cap(providers, env, quota, monkeypatch):
+    monkeypatch.setattr(tokenmax, "HARD_CAP", 2)
+    pool = _pool(providers, env, quota)
+    picks, _ = tokenmax.select_targets(pool, MSGS)  # no max_models -> ALL, but capped
+    assert len(picks) == 2
+
+
+def test_select_targets_max_models_lowers(providers, env, quota):
+    pool = _pool(providers, env, quota)
+    picks, _ = tokenmax.select_targets(pool, MSGS, max_models=1)
+    assert len(picks) == 1
+
+
+def test_select_targets_interleaves_across_providers(providers, env, quota):
+    """The first picks should span distinct providers, not pound one provider's list."""
+    pool = _pool(providers, env, quota)
+    picks, n_providers = tokenmax.select_targets(pool, MSGS)
+    if n_providers >= 2:
+        assert picks[0].provider.id != picks[1].provider.id
+
+
+def test_fan_out_collects_answers_and_reports_progress(providers, env, quota):
+    pool = _pool(providers, env, quota)
+    picks, _ = tokenmax.select_targets(pool, MSGS)
+    seen: list[tuple[int, int]] = []
+    answered, failed = tokenmax.fan_out(
+        pool, MSGS, picks, max_tokens=50, progress=lambda d, t, _l: seen.append((d, t))
+    )
+    assert answered  # the openai-adapter fakes return "ok"
+    assert len(answered) + len(failed) == len(picks)  # every model accounted for
+    assert len(seen) == len(picks)  # one progress tick per model (success or failure)
+    assert max(done for done, _total in seen) == len(picks)  # final tick reaches the total
+    assert all(total == len(picks) for _done, total in seen)
+
+
+def test_fan_out_surfaces_failures(providers, env, quota):
+    # alpha 500s; the swarm keeps going and records it as unavailable, not a crash.
+    post = make_post({"alpha.test": (500, {})})
+    pool = _pool(providers, env, quota, post=post)
+    picks, _ = tokenmax.select_targets(pool, MSGS)
+    answered, failed = tokenmax.fan_out(pool, MSGS, picks, max_tokens=50)
+    assert any(lbl.startswith("alpha/") for lbl in failed)
+
+
+def test_rainbow_throb_non_tty_is_plain(capsys):
+    # Under capture, stderr isn't a TTY, so the throb prints plain start/done lines
+    # (no animation thread, no escape-code spew).
+    with tokenmax.RainbowThrob("X"):
+        pass
+    err = capsys.readouterr().err
+    assert "X" in err
+    assert "\033[" not in err  # no ANSI color codes when piped


### PR DESCRIPTION
## 🌈 tokenmax full spectacle — make TOKENMAXXING come through everywhere

Inline ANSI animation **can't** render in an MCP host's chat (the tool's stdout is the
JSON-RPC channel, stderr is logged rather than live-painted, and results are markdown
with ANSI stripped). So this makes the spectacle land three ways instead:

- **Live MCP progress** — when the client passes a `progressToken` (Claude Code does),
  `tokenmax` streams `notifications/progress` as each model answers
  (`🌈 TOKENMAXXING ▸ 47/168 models…`), so hosts show the swarm ticking up in real time.
- **Rainbow result banner** — a markdown-safe `🟥🟧🟨🟩🟦🟪` banner so the color lands in
  **every** client, no ANSI required.
- **Real animation** — a new `freellmpool tokenmax` CLI runs the genuine rainbow ANSI
  throb on a TTY, prints every answer, and synthesizes one verdict.

### Implementation
- **New shared core** `src/freellmpool/tokenmax.py` (`select_targets` + `fan_out` +
  `RainbowThrob`) used by **both** the MCP tool and the CLI — one fan-out, one hard cap.
- **mcp_server** threads a `progressToken`-gated `notify()` callback from a thread-safe
  `serve_stdio` writer down into the fan-out; emits progress per completion. The
  deadlock-safety invariant is documented (the write lock is never held across
  `handle_message`, so worker-thread notifications can't deadlock).
- **cli** `freellmpool tokenmax` (`--max-models`, `--max-tokens`, `--system`,
  `--no-synthesize`).

### Safety / correctness
`Pool.chat` is thread-safe by design (stats/cooldown/metrics under locks, quota via
flock + atomic replace) — the same path the threaded proxy already drives concurrently.
The 256 hard cap holds even on the default ALL-models path.

### Verified
- Uncapped tokenmax fanned to **168 models / 11 providers** live.
- MCP `notifications/progress` confirmed **over the wire** (8/8 ticks reaching `total`).
- CLI prints every answer + a synthesized verdict with the rainbow throb.
- Reviewed by **Codex** (`VERDICT: SHIP`) and **freellmpool's own quality routing**
  (the one flagged concern — a *conditional* deadlock — was verified not to apply and
  hardened with an explicit invariant). **327 tests, ruff clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a shared TOKENMAX core used by both the MCP tokenmax tool and a new CLI command, adding live progress notifications, a rainbow banner, and a reusable fan-out implementation.

New Features:
- Add a freellmpool tokenmax CLI command that blasts prompts to all models, prints every answer, and optionally synthesizes a verdict.
- Expose live MCP progress notifications for tokenmax calls when clients supply a progressToken, including a rainbow banner in the result.

Enhancements:
- Refactor tokenmax fan-out, target selection, animation, and hard-cap logic into a shared src/freellmpool/tokenmax.py module reused by MCP and CLI.
- Guard MCP stdio writes with a lock and structured helpers to safely interleave responses with background progress notifications without deadlocks.

Documentation:
- Document the enhanced tokenmax MCP tool behavior, including progress notifications, rainbow banner, and the new freellmpool tokenmax CLI usage in MCP.md and README.md.

Tests:
- Add unit tests for the shared tokenmax core (target selection, fan-out, progress reporting, and rainbow throb behavior).
- Extend MCP tests to cover the rainbow banner in tokenmax results and progress notification behavior with and without progress tokens.
- Add CLI tests to verify freellmpool tokenmax output and default synthesis behavior.