### PR TITLE
mcp: instructions telling agents to invoke tools directly (not via the CLI)

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -77,6 +77,11 @@ Pass them through the MCP server's environment, e.g. in the config:
 - The server speaks newline-delimited JSON-RPC 2.0 over stdio (the standard MCP
   stdio transport) and is implemented on the Python standard library only.
 - `stdout` carries the protocol; freellmpool prints its banner to `stderr`.
+- **Invoke the tools directly.** The `initialize` handshake returns an
+  `instructions` field telling the calling agent to call these as MCP tools — **not**
+  to shell out to the `freellmpool` CLI as a subprocess. Subprocessing captures the
+  output inside the agent's process and hides `tokenmax`'s live progress, the rainbow
+  banner, and the answers from the user.
 - **Live `tokenmax` progress:** when a client passes a `progressToken` (Claude
   Code does), `tokenmax` streams `notifications/progress` as each model answers, so
   you see the swarm tick up in real time. Raw ANSI can't animate inside an MCP

--- a/src/freellmpool/mcp_server.py
+++ b/src/freellmpool/mcp_server.py
@@ -39,6 +39,25 @@ _DEFAULT_PROTOCOL = "2025-06-18"
 _ROUTING_MODES = ("fair", "fast", "quality", "legacy", "model", "model-fast")
 _MAX_PANEL = 5
 
+# Returned in the `initialize` handshake (MCP's standard `instructions` field) so the
+# calling agent learns HOW to invoke these tools — chiefly: call them directly instead
+# of shelling out to the CLI, which is what hides the live progress + banner from the user.
+_SERVER_INSTRUCTIONS = (
+    "freellmpool pools many free-tier LLMs behind these tools. Offload self-contained "
+    "subtasks (drafting, summarizing, classifying, quick lookups) to free models instead "
+    "of spending your own context/quota.\n\n"
+    "INVOKE THESE AS MCP TOOLS DIRECTLY. Do NOT shell out to the `freellmpool` CLI (e.g. "
+    "spawning `freellmpool mcp` or `freellmpool tokenmax` as a subprocess) to reach them — "
+    "that captures the output in your subprocess and hides the live progress, the rainbow "
+    "banner, and the answers from the user.\n\n"
+    "`tokenmax` streams live `notifications/progress` as each model in the swarm answers "
+    "(e.g. `🌈 TOKENMAXXING ▸ 47/168 models…`); call it directly so the client shows that to "
+    "the user in real time, and the result carries a rainbow banner plus every answer for YOU "
+    "to synthesize. The flashing rainbow ANSI animation can only render on a real terminal "
+    "(not inside an MCP chat), so to let the HUMAN watch it pulse, tell them to run "
+    '`freellmpool tokenmax "<prompt>"` in their own terminal.'
+)
+
 TOOLS = [
     {
         "name": "free_llm_ask",
@@ -113,7 +132,11 @@ TOOLS = [
             "model across EVERY configured provider at once (a deliberate maximum-effort stress "
             "test), then YOU (the calling model) synthesize the single best answer from all of "
             "them. Maximum free tokens, maximum cross-checking. Tongue-in-cheek, but genuinely "
-            "useful for the hardest questions where you want every model's take."
+            "useful for the hardest questions where you want every model's take. "
+            "Call this tool DIRECTLY (your client receives live `🌈 TOKENMAXXING ▸ N/total` "
+            "progress as each model answers) — do NOT shell out to the CLI, which hides that "
+            "from the user. To let the human watch the flashing rainbow, suggest they run "
+            '`freellmpool tokenmax "<prompt>"` in their own terminal.'
         ),
         "inputSchema": {
             "type": "object",
@@ -499,6 +522,7 @@ def handle_message(
                     "protocolVersion": protocol,
                     "capabilities": {"tools": {}},
                     "serverInfo": {"name": "freellmpool", "version": version},
+                    "instructions": _SERVER_INSTRUCTIONS,
                 },
             )
         if method == "ping":

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -28,6 +28,12 @@ def test_initialize(providers, env, quota):
     assert resp["result"]["serverInfo"]["name"] == "freellmpool"
     assert resp["result"]["protocolVersion"] == "2025-06-18"
     assert "tools" in resp["result"]["capabilities"]
+    # The handshake teaches agents to invoke tools directly (not via the CLI), which is
+    # what lets tokenmax's live progress reach the user instead of a hidden subprocess.
+    instructions = resp["result"]["instructions"]
+    assert "tokenmax" in instructions
+    assert "directly" in instructions.lower()
+    assert "freellmpool tokenmax" in instructions  # how the human sees the flashing animation
 
 
 def test_notification_gets_no_reply(providers, env, quota):


### PR DESCRIPTION
## Make agents invoke the tools properly (so the spectacle reaches the user)

`tokenmax`'s live progress, rainbow banner, and answers only reach the user when the
**MCP client invokes the tool directly**. An agent that instead shells out to
`freellmpool mcp` / `freellmpool tokenmax` as a subprocess captures all of that inside
its own process — the user sees nothing. (Ask me how I know. 🌈)

### Fix
Return MCP's standard **`instructions`** field from the `initialize` handshake (and mirror
it in the `tokenmax` tool description), telling the calling agent to:

- **call these as MCP tools directly — never as a CLI subprocess;**
- expect `tokenmax` to stream live `notifications/progress` and surface it to the user;
- tell the **human** to run `freellmpool tokenmax "<prompt>"` in their own terminal to see
  the flashing rainbow ANSI animation (which can't render inside an MCP chat — only on a
  real TTY).

### Verified
Handshake now carries the instructions (confirmed live); `tokenmax` invoked directly streams
`🌈 TOKENMAXXING ▸ N/total` ticks over the wire. Test added on the handshake. **328 tests, ruff clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document and expose MCP server instructions so agents invoke freellmpool tools directly instead of shelling out to the CLI, ensuring tokenmax’s live progress and banner reach end users.

Enhancements:
- Add a server-level MCP instructions string returned in the initialize handshake to guide agents on proper tool invocation and tokenmax usage.
- Clarify the tokenmax tool description to emphasize direct MCP invocation, real-time progress streaming, and suggesting the CLI only for human-facing rainbow output.

Documentation:
- Update MCP documentation to describe the new initialize instructions and recommend invoking tools directly rather than via the freellmpool CLI to preserve live tokenmax feedback.

Tests:
- Extend MCP initialize handshake tests to assert presence and content of the instructions field guiding direct tool usage.