### PR TITLE
OpenCode tokenmax rainbow animation + accurate aggregated stats

### DIFF
--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -82,6 +82,12 @@ Pass them through the MCP server's environment, e.g. in the config:
   to shell out to the `freellmpool` CLI as a subprocess. Subprocessing captures the
   output inside the agent's process and hides `tokenmax`'s live progress, the rainbow
   banner, and the answers from the user.
+- **Want the *visible* rainbow animation?** An MCP tool can't paint a live animation in
+  the host chat (stdout is the protocol, stderr is logged, results strip ANSI) — the
+  `tokenmax` `notifications/progress` status line is the ceiling here. For a genuine
+  in-harness graphic, use the **OpenCode embedded TUI plugin** (`integrations/opencode-tui`),
+  whose panel throbs a live rainbow `TOKENMAXXING` animation; or run `freellmpool tokenmax`
+  in a real terminal for the standalone flash.
 - **Live `tokenmax` progress:** when a client passes a `progressToken` (Claude
   Code does), `tokenmax` streams `notifications/progress` as each model answers, so
   you see the swarm tick up in real time. Raw ANSI can't animate inside an MCP

--- a/integrations/opencode-tui/README.md
+++ b/integrations/opencode-tui/README.md
@@ -18,12 +18,28 @@ session sidebar and on the home screen — showing, in real time, how much your 
 └───────────────────────────────────┘
 ```
 
-- **routing mode**, **$ saved**, **tokens served free**, and live **throughput (tok/s)**
+- **routing mode**, **$ saved**, **tokens served free**, and live **throughput (tok/s)** —
+  the totals are **lifetime aggregates** (persisted, summed across the proxy + CLI + MCP,
+  so they survive restarts and count *all* freellmpool usage, not just this OpenCode session)
 - a medal'd **provider race** — requests used today vs daily cap, with live cooldown timers
 - a **latency sparkline** (best provider EWMA over time)
 - the **most-recently-served** provider/model
-- updates every 1.5s by polling the proxy's `/status`; shows an offline banner if the
-  proxy is down
+- a **🌈 live TOKENMAXXING animation** — when a `tokenmax` swarm is in flight (see below),
+  the panel throbs a color-cycling `🌈 T O K E N M A X X I N G 🌈` banner with an
+  `N/total models` progress bar, then flashes a completion line. This is the genuine
+  in-harness graphic that MCP can't render — it works here because the plugin draws real
+  OpenTUI, not text in a tool result.
+- updates every 1.5s by polling the proxy's `/status` (every 0.3s while a swarm runs);
+  shows an offline banner if the proxy is down
+
+## 🌈 TOKENMAXXING — the live rainbow
+
+Install the companion tools plugin in `../opencode` and ask OpenCode to use the
+`freellmpool_tokenmax` tool (e.g. *"tokenmax: what's the best…"*). It blasts your prompt to
+**every** free model at once via the proxy's `/tokenmax` endpoint; while the swarm drains,
+**this dashboard throbs the rainbow animation live** and the model synthesizes every answer.
+The flashing is a real terminal animation — to also get it standalone, run
+`freellmpool tokenmax "…"` in any terminal.
 
 It's a real OpenTUI/SolidJS plugin (not text in a tool result), so it's themed to match
 your editor and lives alongside OpenCode's own Context / MCP / LSP panels.

--- a/integrations/opencode-tui/index.tsx
+++ b/integrations/opencode-tui/index.tsx
@@ -10,12 +10,14 @@
 // Install:  opencode plugin -g file:/path/to/integrations/opencode-tui
 // Config:   FREELLMPOOL_PROXY_URL (default http://localhost:8765)
 //
-import { createSignal, onCleanup, For, Show } from "solid-js"
+import { createEffect, createSignal, onCleanup, For, Show } from "solid-js"
 
 const PROXY = (process.env.FREELLMPOOL_PROXY_URL || "http://localhost:8765").replace(/\/+$/, "")
 const PROXY_KEY = process.env.FREELLMPOOL_PROXY_KEY || ""
 const AUTH = PROXY_KEY ? { Authorization: `Bearer ${PROXY_KEY}` } : {}
 const POLL_MS = 1500
+const POLL_MS_TOKENMAX = 300 // poll fast while a swarm is in flight, so the bar moves
+const RAINBOW = ["#ff0040", "#ff8800", "#ffdd00", "#22cc44", "#00ccff", "#3366ff", "#cc44ff"]
 
 // ── formatting helpers ───────────────────────────────────────────────────────
 const BAR = "█"
@@ -72,8 +74,11 @@ const plugin = async (api) => {
       setStatus(s)
       setDown(false)
 
-      // throughput: completion-token delta / elapsed since last sample
-      const tokens = Number(s?.pool?.completion_tokens) || 0
+      // throughput: completion-token delta / elapsed since last sample. Use the LIFETIME
+      // counter (persisted, shared across the proxy + CLI + MCP) so tok/s reflects ALL
+      // freellmpool activity, not just this proxy session — and so it's non-zero for
+      // streaming clients now that the stream path records tokens.
+      const tokens = Number(s?.lifetime?.completion_tokens) || 0
       const now = Date.now()
       if (prev && now > prev.t) {
         const dt = (now - prev.t) / 1000
@@ -97,9 +102,48 @@ const plugin = async (api) => {
       setDown(true)
     }
   }
-  poll()
-  const timer = setInterval(poll, POLL_MS)
-  onCleanup(() => clearInterval(timer))
+  // Self-scheduling poll: tick fast while a tokenmax swarm is active so the rainbow
+  // progress bar moves smoothly, otherwise fall back to the calm cadence. The `disposed`
+  // flag is essential: onCleanup can fire mid-`await poll()`, after which we must NOT
+  // reschedule (the timeout cleanup already ran) — otherwise the loop becomes a zombie
+  // poller that keeps hitting the proxy and updating disposed signals forever.
+  let pollTimer: ReturnType<typeof setTimeout>
+  let disposed = false
+  const loop = async () => {
+    await poll()
+    if (disposed) return
+    const delay = status()?.tokenmax?.active ? POLL_MS_TOKENMAX : POLL_MS
+    pollTimer = setTimeout(loop, delay)
+  }
+  loop()
+  onCleanup(() => {
+    disposed = true
+    clearTimeout(pollTimer)
+  })
+
+  // Rainbow throb: a frame counter the TOKENMAXXING banner reads to cycle colors. The
+  // banner is only mounted while a swarm is active, so this drives no renders when idle.
+  const [frame, setFrame] = createSignal(0)
+  const throb = setInterval(() => setFrame((f) => (f + 1) % 1000), 90)
+  onCleanup(() => clearInterval(throb))
+  const rainbow = () => RAINBOW[frame() % RAINBOW.length]
+
+  // Brief "✅ TOKENMAXXED" flash when a swarm finishes (active true → false).
+  const [flash, setFlash] = createSignal<string | null>(null)
+  let wasActive = false
+  let flashTimer: ReturnType<typeof setTimeout> | undefined
+  createEffect(() => {
+    const tm = status()?.tokenmax
+    const active = !!tm?.active
+    if (wasActive && !active) {
+      const n = tm?.answered ?? tm?.total ?? 0
+      setFlash(`✅ TOKENMAXXED — ${n} models answered`)
+      clearTimeout(flashTimer)
+      flashTimer = setTimeout(() => setFlash(null), 4000)
+    }
+    wasActive = active
+  })
+  onCleanup(() => clearTimeout(flashTimer))
 
   // top providers by requests-used-today (the "race")
   const topProviders = () => {
@@ -118,6 +162,36 @@ const plugin = async (api) => {
   }
   const maxUsed = () => Math.max(1, ...topProviders().map((p: any) => p.used))
 
+  // ── 🌈 the live TOKENMAXXING banner (color-cycles while a swarm runs) ────────
+  const TokenmaxBanner = () => {
+    const theme = api.theme.current
+    const tm = () => status()?.tokenmax || {}
+    const done = () => Number(tm().done) || 0
+    const total = () => Number(tm().total) || 0
+    return (
+      <Show when={tm().active || flash()}>
+        <Show
+          when={tm().active}
+          fallback={
+            <box border borderColor={theme.success} paddingLeft={1} paddingRight={1}>
+              <text fg={theme.success}>{flash()}</text>
+            </box>
+          }
+        >
+          <box border borderColor={rainbow()} paddingLeft={1} paddingRight={1} flexDirection="column">
+            <text fg={rainbow()}>🌈 T O K E N M A X X I N G 🌈</text>
+            <box flexDirection="row" gap={1}>
+              <text fg={rainbow()}>{bar(total() ? done() / total() : 0, 16)}</text>
+              <text fg={theme.textMuted}>
+                {done()}/{total()} models · {Number(tm().n_providers) || 0} providers
+              </text>
+            </box>
+          </box>
+        </Show>
+      </Show>
+    )
+  }
+
   // ── the panel component (used by both the sidebar and the home screen) ──────
   const Panel = () => {
     const theme = api.theme.current
@@ -132,19 +206,23 @@ const plugin = async (api) => {
         }
       >
         <box border borderColor={theme.success} title=" freellmpool " paddingLeft={1} paddingRight={1} flexDirection="column">
+          <TokenmaxBanner />
           <box flexDirection="row" gap={1}>
             <text fg={theme.textMuted}>routing</text>
             <text fg={theme.accent}>{status()?.routing ?? "?"}</text>
           </box>
 
           <box flexDirection="row" gap={1}>
-            <text fg={theme.success}>💸 {money(status()?.pool?.usd_saved ?? 0)}</text>
+            <text fg={theme.success}>💸 {money(status()?.lifetime?.usd_saved ?? 0)}</text>
             <text fg={theme.textMuted}>saved</text>
             <text fg={theme.info}>⚡ {tps()} tok/s</text>
           </box>
 
           <text fg={theme.textMuted}>
-            {compact(status()?.pool?.completion_tokens ?? 0)} tokens served free · {status()?.pool?.requests ?? 0} req
+            {compact(
+              (status()?.lifetime?.prompt_tokens ?? 0) + (status()?.lifetime?.completion_tokens ?? 0),
+            )}{" "}
+            tokens served free · {status()?.lifetime?.requests ?? 0} req
           </text>
 
           <text fg={theme.textMuted}>── provider race ──</text>
@@ -191,11 +269,14 @@ const plugin = async (api) => {
         const theme = api.theme.current
         return (
           <Show when={!down()} fallback={<text fg={theme.error}>● freellmpool proxy offline</text>}>
-            <box border borderColor={theme.success} paddingLeft={1} paddingRight={1} marginTop={1} flexDirection="row" gap={1}>
-              <text fg={theme.success}>● freellmpool</text>
-              <text fg={theme.text}>
-                {money(status()?.pool?.usd_saved ?? 0)} saved · {compact(status()?.pool?.completion_tokens ?? 0)} free tokens · {tps()} tok/s · {status()?.routing ?? "?"}
-              </text>
+            <box marginTop={1} flexDirection="column">
+              <TokenmaxBanner />
+              <box border borderColor={theme.success} paddingLeft={1} paddingRight={1} flexDirection="row" gap={1}>
+                <text fg={theme.success}>● freellmpool</text>
+                <text fg={theme.text}>
+                  {money(status()?.lifetime?.usd_saved ?? 0)} saved · {compact((status()?.lifetime?.prompt_tokens ?? 0) + (status()?.lifetime?.completion_tokens ?? 0))} free tokens · {tps()} tok/s · {status()?.routing ?? "?"}
+                </text>
+              </box>
             </box>
           </Show>
         )

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -14,6 +14,10 @@ It talks to a running [freellmpool](https://github.com/0xzr/freellmpool) proxy
   things like *"check freellmpool status"* or *"how much quota is left?"*.
 - **`freellmpool_models` tool** — lists the model ids the proxy exposes (including the
   routing aliases `auto` / `fast` / `quality` / `fair`).
+- **`freellmpool_tokenmax` tool** 🌈 — blast the same prompt to **every** free model at
+  once, then the agent synthesizes them all. Ask *"tokenmax: &lt;hard question&gt;"*. While
+  the swarm runs, the companion **embedded TUI dashboard** (`../opencode-tui`) throbs a live
+  rainbow `TOKENMAXXING` animation with `N/total` progress — install it too for the show.
 - **served-model toast** — after each reply, a small toast shows which provider+model
   actually answered. OpenCode itself only knows the alias you picked
   (`freellmpool/auto`), so the real target is read back from the proxy. Silence it with

--- a/integrations/opencode/freellmpool.js
+++ b/integrations/opencode/freellmpool.js
@@ -61,6 +61,38 @@ async function getJSON(path) {
   }
 }
 
+// POST <path> with a JSON body. Like getJSON, never throws. Takes its own timeout
+// because tokenmax fans out to many models and can run far longer than a status poll.
+async function postJSON(path, body, timeoutMs = TIMEOUT_MS) {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  try {
+    const res = await fetch(`${BASE_URL}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders() },
+      body: JSON.stringify(body),
+      signal: ac.signal,
+    });
+    const text = await res.text();
+    let data;
+    try {
+      data = text ? JSON.parse(text) : {};
+    } catch {
+      return { ok: false, error: `non-JSON response (HTTP ${res.status})` };
+    }
+    if (!res.ok) {
+      const msg = data?.error?.message || data?.error || `HTTP ${res.status}`;
+      return { ok: false, error: String(msg) };
+    }
+    return { ok: true, data };
+  } catch (err) {
+    const why = err?.name === "AbortError" ? `timed out after ${timeoutMs}ms` : err?.message || String(err);
+    return { ok: false, error: `cannot reach freellmpool proxy at ${BASE_URL} (${why})` };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 const num = (n) => (typeof n === "number" && isFinite(n) ? n : 0);
 const pad = (s, w) => String(s).padEnd(w);
 
@@ -165,6 +197,47 @@ export const FreellmpoolPlugin = async ({ client }) => {
           const ids = (data?.data || []).map((m) => m.id).filter(Boolean);
           if (!ids.length) return "freellmpool: no models reported.";
           return `freellmpool exposes ${ids.length} models:\n` + ids.map((id) => `  ${id}`).join("\n");
+        },
+      },
+
+      freellmpool_tokenmax: {
+        description:
+          "🌈 TOKENMAX: blast the SAME prompt to EVERY free model the proxy can reach at " +
+          "once, then YOU synthesize the single best answer from all of them. While it runs, " +
+          "the freellmpool panel throbs a live rainbow TOKENMAXXING animation with N/total " +
+          "progress. Tongue-in-cheek but genuinely useful for the hardest questions where you " +
+          "want every model's take.",
+        args: {
+          prompt: tool.schema.string().describe("The prompt to blast to every model."),
+          max_models: tool.schema
+            .number()
+            .optional()
+            .describe("Cap how many models to hit (default: ALL of them)."),
+        },
+        async execute(args) {
+          if (!args?.prompt || !String(args.prompt).trim()) {
+            return "freellmpool_tokenmax: 'prompt' is required";
+          }
+          const body = { prompt: String(args.prompt) };
+          if (typeof args.max_models === "number") body.max_models = args.max_models;
+          // Long timeout: the swarm can take a couple of minutes to drain every provider.
+          const { ok, data, error } = await postJSON("/tokenmax", body, 180000);
+          if (!ok) return `freellmpool tokenmax unavailable: ${error}`;
+          const answers = Array.isArray(data.answers) ? data.answers : [];
+          const lines = [
+            `🌈 TOKENMAX — ${answers.length}/${num(data.total) || answers.length} models answered ` +
+              `across ${num(data.n_providers) || "?"} providers (rainbow throbbing live in the freellmpool panel).`,
+            "Synthesize the single best, correct answer from every response below " +
+              "(weigh agreement, discard outliers):",
+            "",
+          ];
+          for (const a of answers) lines.push(`### ${a.model}\n${a.text}\n`);
+          const failed = Array.isArray(data.failed) ? data.failed : [];
+          if (failed.length) {
+            const shown = failed.slice(0, 30).join(", ") + (failed.length > 30 ? "…" : "");
+            lines.push(`_${failed.length} unavailable: ${shown}_`);
+          }
+          return lines.join("\n");
         },
       },
     },

--- a/src/freellmpool/mcp_server.py
+++ b/src/freellmpool/mcp_server.py
@@ -33,7 +33,7 @@ import time
 
 from .config import resolve_alias
 from .router import Pool
-from .tokenmax import HARD_CAP, RAINBOW_BANNER, RainbowThrob, fan_out, select_targets
+from .tokenmax import HARD_CAP, RAINBOW_BANNER, fan_out, select_targets
 
 _DEFAULT_PROTOCOL = "2025-06-18"
 _ROUTING_MODES = ("fair", "fast", "quality", "legacy", "model", "model-fast")
@@ -365,14 +365,16 @@ def _tool_tokenmax(pool: Pool, args: dict, notify=None) -> dict:
     if not picks:
         return _text("no providers configured", is_error=True)
 
-    # Live progress for hosts that support it (Claude Code shows the message ticking
-    # up). Raw ANSI can't animate inside an MCP chat, so this is the "it's alive" signal.
+    # Live progress for hosts that support it (Claude Code shows the message ticking up).
+    # This is the ONLY "it's alive" signal that reaches an MCP user: raw ANSI can't animate
+    # inside an MCP chat, so there is no rainbow throb here (it would only spew breadcrumbs
+    # into the host's stderr log). For the genuine flashing animation use the CLI
+    # (`freellmpool tokenmax`); for a live in-harness graphic use the OpenCode TUI plugin.
     def progress(done: int, total: int, _label: str) -> None:
         if notify is not None:
             notify(done, total, f"🌈 TOKENMAXXING ▸ {done}/{total} models")
 
-    with RainbowThrob(f"TOKENMAXXING {len(picks)} models across {n_providers} providers"):
-        answered, failed = fan_out(pool, msgs, picks, max_tokens=max_tokens, progress=progress)
+    answered, failed = fan_out(pool, msgs, picks, max_tokens=max_tokens, progress=progress)
 
     head = [
         f"{RAINBOW_BANNER} TOKENMAX — blasted your prompt to {len(picks)} models across "

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -94,11 +94,13 @@ def _provider_leaderboard(pool: Pool, limit: int = 5) -> list[tuple[str, float]]
     return [(pid, count / top) for pid, count in ranked if count > 0]
 
 
-def _status_payload(pool: Pool, recent: Sequence[dict]) -> dict:
+def _status_payload(pool: Pool, recent: Sequence[dict], tokenmax: dict | None = None) -> dict:
     """Return a JSON-able status payload for the /status endpoint.
 
     ``recent`` is a snapshot (most-recent-first) of the served-target ring buffer,
-    taken under its lock by the caller so iteration here is race-free.
+    taken under its lock by the caller so iteration here is race-free. ``tokenmax`` is
+    an optional snapshot of the live tokenmax-swarm progress (the OpenCode TUI animates
+    its rainbow throb while ``active`` is true).
     """
     now = pool._clock()
     quota_snap = pool.quota.snapshot()
@@ -162,6 +164,7 @@ def _status_payload(pool: Pool, recent: Sequence[dict]) -> dict:
         },
         "providers": providers_list,
         "recent": list(recent),
+        "tokenmax": tokenmax or {"active": False},
     }
 
 
@@ -191,6 +194,19 @@ def make_handler(pool: Pool, api_key: str | None = None):
     def record_recent(entry: dict) -> None:
         with recent_lock:
             recent.appendleft(entry)
+
+    # Live tokenmax-swarm progress, surfaced via /status so the OpenCode TUI can throb
+    # its rainbow banner while a swarm is in flight. Mutated from a request thread (and
+    # its fan-out workers via the progress callback); guard every read/write with the lock.
+    tokenmax_state: dict = {"active": False}
+    tokenmax_lock = threading.Lock()
+
+    def tokenmax_snapshot() -> dict:
+        with tokenmax_lock:
+            snap = dict(tokenmax_state)
+        if snap.get("active") and snap.get("started_at") is not None:
+            snap["elapsed_s"] = round(max(0.0, pool._clock() - snap["started_at"]), 1)
+        return snap
 
     class Handler(BaseHTTPRequestHandler):
         server_version = "freellmpool/0.10"
@@ -315,7 +331,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
             if path in ("/status", "/v1/status"):
                 with recent_lock:
                     recent_snapshot = list(recent)
-                self._send(200, _status_payload(pool, recent_snapshot))
+                self._send(200, _status_payload(pool, recent_snapshot, tokenmax_snapshot()))
                 return
             self._error(404, f"unknown route {self.path}", "not_found")
 
@@ -326,7 +342,10 @@ def make_handler(pool: Pool, api_key: str | None = None):
             is_embeddings = route.endswith("/v1/embeddings") or route == "/embeddings"
             is_count = route.endswith("/v1/messages/count_tokens")
             is_messages = not is_count and (route.endswith("/v1/messages") or route == "/messages")
-            if not (is_chat or is_responses or is_embeddings or is_messages or is_count):
+            is_tokenmax = route.endswith("/tokenmax") or route == "/tokenmax"
+            if not (
+                is_chat or is_responses or is_embeddings or is_messages or is_count or is_tokenmax
+            ):
                 self._error(404, f"unknown route {self.path}", "not_found")
                 return
             if not self._authorized():
@@ -365,8 +384,87 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 self._send(200, {"input_tokens": estimate_tokens(req)})
             elif is_messages:
                 self._handle_messages(req)
+            elif is_tokenmax:
+                self._handle_tokenmax(req)
             else:
                 self._handle_chat(req)
+
+        def _handle_tokenmax(self, req: dict) -> None:
+            """🌈 Fan a prompt out to EVERY model and report live progress via /status so
+            the OpenCode TUI can throb its rainbow banner. Returns every answer for the
+            caller to synthesize."""
+            from . import tokenmax as _tm
+
+            prompt = req.get("prompt")
+            if not isinstance(prompt, str) or not prompt.strip():
+                self._error(400, "'prompt' is required", "invalid_request_error")
+                return
+            msgs: list[dict[str, str]] = []
+            system = req.get("system")
+            if isinstance(system, str) and system.strip():
+                msgs.append({"role": "system", "content": system})
+            msgs.append({"role": "user", "content": prompt})
+            try:
+                max_tokens = max(1, min(8192, int(req.get("max_tokens", 350))))
+            except (TypeError, ValueError):
+                max_tokens = 350
+
+            picks, n_providers = _tm.select_targets(pool, msgs, req.get("max_models"))
+            if not picks:
+                self._error(503, "no providers configured", "no_providers")
+                return
+            total = len(picks)
+
+            def on_progress(done: int, _total: int, _label: str) -> None:
+                with tokenmax_lock:
+                    if tokenmax_state.get("active"):  # don't resurrect a finished/cleared run
+                        # fan_out releases its counter lock before invoking this callback, so
+                        # worker callbacks can arrive out of order — clamp to keep the bar
+                        # monotonic (never jump backwards).
+                        tokenmax_state["done"] = max(int(tokenmax_state.get("done", 0)), done)
+
+            # Claim the single shared display slot atomically: only one swarm "owns" the
+            # /status banner at a time, so a second concurrent run can't clobber the first's
+            # progress. (tokenmax is a max-effort blast; serializing the display is fine.)
+            with tokenmax_lock:
+                busy = bool(tokenmax_state.get("active"))
+                if not busy:
+                    tokenmax_state.clear()
+                    tokenmax_state.update(
+                        {
+                            "active": True,
+                            "prompt": prompt[:120],
+                            "done": 0,
+                            "total": total,
+                            "n_providers": n_providers,
+                            "started_at": pool._clock(),
+                        }
+                    )
+            if busy:
+                self._error(409, "a tokenmax swarm is already in flight", "tokenmax_busy")
+                return
+            try:
+                answered, failed = _tm.fan_out(
+                    pool, msgs, picks, max_tokens=max_tokens, progress=on_progress
+                )
+                with tokenmax_lock:  # success: reflect the final, complete counts
+                    tokenmax_state["done"] = total
+                    tokenmax_state["answered"] = len(answered)
+            finally:
+                # Always release the slot so the TUI stops throbbing — even if the swarm
+                # errored (then `done` keeps its last real value rather than overstating).
+                with tokenmax_lock:
+                    tokenmax_state["active"] = False
+            self._send(
+                200,
+                {
+                    "answers": [{"model": lbl, "text": txt} for lbl, txt in answered],
+                    "failed": failed,
+                    "answered": len(answered),
+                    "total": total,
+                    "n_providers": n_providers,
+                },
+            )
 
         def _handle_messages(self, req: dict) -> None:
             """Anthropic Messages API shim — lets Claude Code & friends use free models."""

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -824,8 +824,34 @@ class Pool:
             self.quota.record(target.provider.id, target.model)
             self._bump_stats(requests=1)
             yield {"provider": target.provider.id, "model": target.model}
-            yield first
-            yield from gen
+            # Accumulate the streamed text so we can record token usage when the stream
+            # ends. Providers rarely send a usage block on a stream, so without this the
+            # session + lifetime token / savings totals — and the dashboard's tok/s — never
+            # move for streaming clients (e.g. OpenCode). chars/4 ≈ tokens, matching
+            # estimate_tokens; prompt size reuses est_tokens computed above.
+            streamed: list[str] = [first] if isinstance(first, str) else []
+            drained = False
+            try:
+                yield first
+                for chunk in gen:
+                    if isinstance(chunk, str):
+                        streamed.append(chunk)
+                    yield chunk
+                drained = True
+            finally:
+                # The manual loop (vs `yield from`) doesn't auto-delegate close(), so on an
+                # early consumer disconnect we must close the upstream stream ourselves to
+                # release the provider HTTP connection promptly. Guard for iterators that
+                # aren't generators. Only count a fully-drained stream — a disconnected/
+                # truncated one isn't a completed response.
+                closer = getattr(gen, "close", None)
+                if callable(closer):
+                    closer()
+                if drained:
+                    self._bump_stats(
+                        prompt_tokens=max(0, est_tokens),
+                        completion_tokens=max(0, sum(len(s) for s in streamed) // 4),
+                    )
             return
 
         emit(self._on_event, "exhausted", attempts=len(attempts))

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -91,6 +91,74 @@ def test_healthz(server):
         assert resp.status == 200
 
 
+def test_tokenmax_route(server):
+    status, body = _post_json(server + "/tokenmax", {"prompt": "hi", "max_models": 3})
+    assert status == 200
+    assert body["total"] >= 1
+    assert isinstance(body["answers"], list)
+    assert any(a["text"] == "ok" for a in body["answers"])  # openai-adapter fakes answer "ok"
+
+
+def test_tokenmax_requires_prompt(server):
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _post_json(server + "/tokenmax", {})
+    assert exc.value.code == 400
+
+
+def test_status_has_tokenmax_field_idle(server):
+    with urllib.request.urlopen(server + "/status") as resp:  # noqa: S310
+        s = json.load(resp)
+    assert s["tokenmax"]["active"] is False  # default snapshot before any run
+
+
+def test_status_tokenmax_active_during_run(providers, env, quota):
+    """A barrier-blocked swarm lets /status observe tokenmax.active live (the signal the
+    OpenCode TUI throbs on), then settle to done==total when it finishes."""
+    import time
+
+    from helpers import openai_body
+
+    from freellmpool.client import HTTPResult
+
+    release = threading.Event()
+
+    def slow_post(url, headers, json_body, timeout):
+        release.wait(2.0)  # hold every fan-out call open until the test releases it
+        return HTTPResult(status=200, body=openai_body("ok"), text="ok")
+
+    pool = Pool(providers, quota=quota, env=env, post=slow_post, stream_post=make_stream_post({}))
+    httpd = serve(pool, host="127.0.0.1", port=0)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    try:
+        runner = threading.Thread(
+            target=lambda: _post_json(base + "/tokenmax", {"prompt": "hi", "max_models": 3}),
+            daemon=True,
+        )
+        runner.start()
+        active_seen = False
+        for _ in range(100):  # poll until the swarm is in flight
+            with urllib.request.urlopen(base + "/status") as resp:  # noqa: S310
+                tm = json.load(resp)["tokenmax"]
+            if tm.get("active"):
+                active_seen = True
+                assert tm["total"] == 3
+                break
+            time.sleep(0.02)
+        release.set()
+        runner.join(timeout=3)
+        assert active_seen, "tokenmax.active was never observable during the run"
+        with urllib.request.urlopen(base + "/status") as resp:  # noqa: S310
+            tm2 = json.load(resp)["tokenmax"]
+        assert tm2["active"] is False
+        assert tm2["done"] == tm2["total"] == 3
+    finally:
+        release.set()
+        httpd.shutdown()
+        httpd.server_close()
+
+
 def test_content_parts_flattened(server):
     status, body = _post_json(
         server + "/v1/chat/completions",
@@ -129,6 +197,39 @@ def test_streaming_sse(server):
     assert chunks[-1]["choices"][0]["finish_reason"] == "stop"  # stop chunk last
     content = "".join(c["choices"][0]["delta"].get("content", "") for c in chunks)
     assert content == "ok"
+
+
+def test_streaming_counts_tokens(providers, env, quota):
+    """Streamed responses must accrue token usage (else $ saved / tokens / tok/s never
+    move for streaming clients like OpenCode). Tokens are estimated from the streamed
+    text, so /status reflects the stream after it drains."""
+    stream = make_stream_post({"alpha": ["Hello there, ", "this is a ", "streamed answer."]})
+    pool = Pool(providers, quota=quota, env=env, post=make_post({}), stream_post=stream)
+    httpd = serve(pool, host="127.0.0.1", port=0)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    try:
+        req = urllib.request.Request(
+            base + "/v1/chat/completions",
+            data=json.dumps(
+                {
+                    "model": "alpha/alpha-small",  # pin the openai-adapter provider
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "hello there"}],
+                }
+            ).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            resp.read()  # drain the whole stream so end-of-stream accounting runs
+        with urllib.request.urlopen(base + "/status") as resp:  # noqa: S310
+            pool_stats = json.load(resp)["pool"]
+        assert pool_stats["completion_tokens"] > 0  # streamed output is now counted
+        assert pool_stats["prompt_tokens"] > 0
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
 
 
 def _expect_status(url, payload, headers=None):


### PR DESCRIPTION
## 🌈 See tokenmax happen — live rainbow animation in OpenCode + accurate stats

Makes the `tokenmax` spectacle actually visible inside a harness (OpenCode), and fixes the
dashboard numbers that surface it.

### 🌈 Live animation (OpenCode)
- New **`freellmpool_tokenmax`** tool → new proxy **`POST /tokenmax`** endpoint that fans the
  prompt to every model and tracks live progress; **`/status`** gains a `tokenmax` field.
- The embedded **TUI panel throbs a color-cycling `🌈 T O K E N M A X X I N G 🌈` banner** with
  an `N/total models` progress bar while the swarm runs, then a `✅ TOKENMAXXED` flash.
- This is the in-harness graphic MCP fundamentally can't render (stdout=protocol, stderr=log,
  results strip ANSI) — OpenCode plugins draw real OpenTUI, so it works here.

### 🧮 Streaming token accounting (root-cause bugfix)
The stream path only counted `requests`, never tokens — so **`$ saved` / tokens-served / tok/s
were dead for streaming clients like OpenCode.** `stream_chat` now accumulates the streamed
text and records estimated prompt+completion tokens at end-of-drain, closes the upstream stream
on early disconnect, and only counts a fully-drained stream.

### 📊 Dashboard → lifetime aggregates
`$ saved`, tokens served free, and tok/s now sum **all** freellmpool usage (proxy + CLI + MCP,
persisted across restarts), not just the current proxy session.

### 🧹 MCP cleanup
Removed the no-op ANSI throb from the MCP tokenmax path (it only logged breadcrumbs); kept the
tool, `notifications/progress`, and the banner.

### Safety
Concurrency-hardened across **three Codex rounds**, each catching a real bug now fixed:
monotonic progress clamp (out-of-order worker callbacks), a `disposed` flag on the
self-scheduling TUI poll (no zombie poller after unmount), guarded upstream stream `close()`,
and an atomic single-swarm guard on the shared `tokenmax_state`.

### Verified
Reviewed by **Codex** (`VERDICT: SHIP`) + **freellmpool's own quality routing**. Tests added for
`/tokenmax`, live `tokenmax.active`, and streaming-counts-tokens. **Full suite + ruff green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a live TOKENMAXXING rainbow dashboard animation in the OpenCode TUI, expose a new /tokenmax fan‑out endpoint with status tracking, and fix streaming and aggregated stats so lifetime token and savings metrics are accurate across all clients.

New Features:
- Expose a freellmpool_tokenmax tool in the OpenCode integration that calls a new /tokenmax endpoint to fan prompts out to all models and return their answers.
- Add a live rainbow TOKENMAXXING banner with progress and completion flash to the OpenCode TUI panel and status bar, driven by tokenmax activity surfaced via /status.
- Extend the /status payload with a tokenmax progress snapshot so clients can display live swarm state.

Bug Fixes:
- Ensure streamed chat responses accrue prompt and completion token counts so $ saved, tokens served, and tok/s metrics update correctly for streaming clients.
- Fix tok/s and dashboard counters in the OpenCode TUI by basing them on lifetime token and savings aggregates instead of per-session pool stats.

Enhancements:
- Track live tokenmax swarm state in the proxy with concurrency-safe shared state and expose elapsed time and completion counts.
- Adjust OpenCode TUI polling cadence to refresh faster while a tokenmax swarm is active and prevent polling after unmount with a disposal guard.
- Update OpenCode TUI displays to use lifetime aggregated usd_saved, token, and request counts that include proxy, CLI, and MCP usage.
- Simplify MCP tokenmax to rely on notifications/progress only, removing unused ANSI rainbow throb behavior.

Documentation:
- Document lifetime aggregate metrics, the TOKENMAXXING animation, and the new /tokenmax-powered workflow in the OpenCode TUI README.
- Clarify MCP limitations around live rainbow animation and point users to the OpenCode TUI or CLI for visible tokenmax graphics in MCP.md.
- Describe the freellmpool_tokenmax tool and its animated dashboard behavior in the OpenCode integration README.

Tests:
- Add tests for the /tokenmax route, including prompt validation and tokenmax presence in /status.
- Add an integration test to verify tokenmax.active and completion fields are observable via /status during and after a swarm run.
- Add a test to confirm streaming chat responses correctly increment prompt and completion token counters in pool stats.