### PR TITLE
integrations: sandboxed OpenCode-on-freellmpool jail (bubblewrap)

### DIFF
--- a/integrations/opencode-jail/README.md
+++ b/integrations/opencode-jail/README.md
@@ -1,0 +1,56 @@
+# Sandboxed OpenCode on freellmpool (bubblewrap jail)
+
+`opencode-freellmpool-jailed.sh` runs [OpenCode](https://opencode.ai) on the **freellmpool**
+free-model pool inside a [bubblewrap](https://github.com/containers/bubblewrap) sandbox, so you
+can let a model do **long agentic coding hands-off** without it touching anything outside a
+throwaway project — while it *believes* it's on a normal full Linux box.
+
+```sh
+freellmpool-proxy                         # start the proxy first (or `freellmpool proxy --port 8765`)
+integrations/opencode-jail/opencode-freellmpool-jailed.sh            # interactive TUI in ~/project
+integrations/opencode-jail/opencode-freellmpool-jailed.sh --run "…"  # headless single turn
+integrations/opencode-jail/opencode-freellmpool-jailed.sh --serve     # opencode serve (basic-auth)
+integrations/opencode-jail/opencode-freellmpool-jailed.sh --selftest  # prove the containment, exit
+```
+
+## The illusion (what the model sees)
+A complete, normal Linux box it owns: real read-only `/usr /lib /bin /etc /proc /dev`, a home
+it can write anywhere in, a working `/tmp`, and a real git project at `~/project`. OpenCode
+permissions are **allow-all** (no approval prompts), and pip/npm installs succeed (into writable
+tmpfs prefixes). Nothing is labelled "sandbox"/"jail" — no obvious tell.
+
+## The reality (what's actually true)
+- **Only the project persists.** The project, OpenCode's state, and its config all live inside a
+  single fixed-size **ext4 loopback image** (default **12 GB**); a runaway agent fills at most that
+  image, never the host disk.
+- **All host secrets are gone.** `$HOME` is a fresh tmpfs, so `~/.ssh`, API keys under `~/.config`,
+  cloud creds, the real OpenCode auth, and the freellmpool source tree are all `ENOENT`.
+  `--clearenv` keeps the host environment (and any exported keys) out.
+- **Resources are capped** via a cgroup-v2 scope: **1 CPU core**, **6 GB RAM** (hard cap, no swap),
+  **12 GB disk**. Tunable via `OPENCODE_FP_CPUS` / `OPENCODE_FP_MEM` / `OPENCODE_FP_DISK`.
+- `--unshare-pid/uts/ipc`, fail-closed storage, an exclusive flock against concurrent jails, and
+  symlink/TOCTOU-hardened host-side setup (reviewed across 10 adversarial Codex passes).
+
+## Routing
+Defaults to `freellmpool/fast` (lowest-latency provider first) — best for interactive agentic
+loops. `quality` routing picks the most *capable* models, which are often slow and can stall a turn.
+Override with `OPENCODE_FP_MODEL=freellmpool/quality` (etc.).
+
+## Known residuals (by design)
+- **Network egress is open.** Free models + webfetch need the internet, and `--unshare-net` would
+  also cut off the host proxy on `127.0.0.1`. Containment here is filesystem + secret-hiding, not
+  network (there are no on-disk secrets to exfiltrate).
+- **`/etc` is bound read-only** for a convincing, functional box.
+- **No writable `/usr`** (this bubblewrap build lacks overlay), so a *system* `apt install` fails;
+  project-local pip/npm works.
+
+## Requirements
+bubblewrap, OpenCode, a running freellmpool proxy, cgroup-v2 with a systemd `--user` session
+(falls back to `taskset` CPU-pinning otherwise), `sudo` for the one-time loopback mount, and
+`dev.tty.legacy_tiocsti=0` (the Linux ≥6.2 default) for the interactive TUI.
+
+## Env knobs
+`OPENCODE_FP_MODEL`, `OPENCODE_FP_PROJECT` (in-jail project basename), `OPENCODE_FP_PROXY_URL`,
+`OPENCODE_FP_CPUS` / `OPENCODE_FP_MEM` / `OPENCODE_FP_DISK`, `OPENCODE_FP_PORT` (`--serve`),
+`OPENCODE_FP_INTEG` (plugin source), `OPENCODE_FP_ALLOW_UNCAPPED=1` (run without the disk image —
+discouraged).

--- a/integrations/opencode-jail/opencode-freellmpool-jailed.sh
+++ b/integrations/opencode-jail/opencode-freellmpool-jailed.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+# opencode-freellmpool-jailed.sh — sandboxed OpenCode on the freellmpool free pool,
+# for long agentic coding you can let run hands-off.
+#
+# THE ILLUSION (what the model believes): a normal, complete Linux box it owns — real
+# read-only /usr /lib /bin /etc /proc /dev, a home it can write anywhere in, a working
+# /tmp, and a real git project at ~/project. OpenCode permissions are allow-all (no
+# approval prompts), pip/npm installs succeed (into writable tmpfs prefixes). Nothing is
+# named "sandbox"/"jail" inside; the agent has no obvious tell.
+#
+# THE REALITY: the ONLY persistent, writable storage is a single fixed-size ext4 image
+# (default 12G). The project, OpenCode's state, and its config all live INSIDE that image,
+# so a runaway agent can fill at most that image — never the host disk. $HOME is a fresh
+# tmpfs, so every host secret is gone (ENOENT): ~/.ssh, ~/.polybot (POLY_PRIVATE_KEY),
+# ~/.config/* keys, ~/.codex, ~/.aws, the real opencode auth, and the llmbuffet source.
+# --clearenv keeps the host environment (and any exported keys) out. CPU/RAM are capped
+# via a cgroup-v2 scope. PID/UTS/IPC namespaces are unshared.
+#
+# NETWORK (known residual): egress is OPEN — free models + webfetch need the internet, and
+# --unshare-net would also cut off the host proxy on 127.0.0.1. So the jail CAN reach other
+# host localhost services and the internet. Containment here is filesystem + secret-hiding,
+# NOT network. (A net-isolated variant with a proxy-only forwarder is a future option.)
+#
+# USAGE:  opencode-freellmpool-jailed.sh            # interactive TUI in ~/project
+#         opencode-freellmpool-jailed.sh --run "…"  # headless single turn (cron-friendly)
+#         opencode-freellmpool-jailed.sh --serve     # opencode serve (basic-auth)
+#         opencode-freellmpool-jailed.sh --selftest  # prove containment + stealth, exit
+#
+# ENV KNOBS: OPENCODE_FP_MODEL (default freellmpool/fast — snappy; "quality" stalls on slow
+#   models), OPENCODE_FP_PROJECT (in-jail project basename, default "project"),
+#   OPENCODE_FP_PROXY_URL, OPENCODE_FP_CPUS/MEM/DISK (default 1 / 6G / 12G),
+#   OPENCODE_FP_PORT (--serve), OPENCODE_FP_ALLOW_UNCAPPED=1 (run without the disk image —
+#   discouraged), OPENCODE_FP_INTEG (source of the freellmpool plugins on the host).
+
+set -euo pipefail
+
+MODE="tui"
+RUN_ARGS=()
+case "${1:-}" in
+  --serve) MODE="serve" ;;
+  --selftest) MODE="selftest" ;;
+  --run) MODE="run"; shift; RUN_ARGS=("$@") ;;
+  "" ) ;;
+  *) echo "usage: $(basename "$0") [--serve|--selftest|--run <prompt...>]" >&2; exit 2 ;;
+esac
+
+# ── tunables ────────────────────────────────────────────────────────────────────────
+PROXY_URL="${OPENCODE_FP_PROXY_URL:-http://127.0.0.1:8765}"
+MODEL="${OPENCODE_FP_MODEL:-freellmpool/fast}"   # fast = lowest-latency; quality is slow/stally
+PROJECT="${OPENCODE_FP_PROJECT:-project}"         # in-jail cwd basename — NOT "sandbox"
+PORT="${OPENCODE_FP_PORT:-4099}"
+HOSTBIND="127.0.0.1"
+CPUS="${OPENCODE_FP_CPUS:-1}"
+MEM="${OPENCODE_FP_MEM:-6G}"
+DISK="${OPENCODE_FP_DISK:-12G}"
+# Source of the freellmpool plugins (host, read-only). If this script lives in the repo's
+# integrations/ tree (…/integrations/opencode-jail/), derive it from the script location;
+# otherwise fall back. OPENCODE_FP_INTEG always overrides.
+_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd || true)"
+if [ -n "${_self_dir:-}" ] && [ -d "$_self_dir/../opencode" ] && [ -d "$_self_dir/../opencode-tui" ]; then
+  _integ_default="$(cd "$_self_dir/.." && pwd)"
+else
+  _integ_default="/home/ubuntu/llmbuffet/integrations"
+fi
+INTEG="${OPENCODE_FP_INTEG:-$_integ_default}"  # plugin source (host, read-only)
+
+# PROJECT must be a bare directory name (no traversal / absolute path).
+case "$PROJECT" in */*|..|.|"") echo "ERROR: OPENCODE_FP_PROJECT must be a bare name" >&2; exit 2 ;; esac
+# MODEL and PROXY_URL get written verbatim into the JSON config — reject anything that could
+# break/inject JSON (quotes, newlines, etc.). These are operator-set, so fail rather than escape.
+case "$MODEL" in ""|*[!A-Za-z0-9._/-]*) echo "ERROR: OPENCODE_FP_MODEL: only [A-Za-z0-9._/-] allowed" >&2; exit 2 ;; esac
+case "$PROXY_URL" in http://*|https://*) ;; *) echo "ERROR: OPENCODE_FP_PROXY_URL must start with http:// or https://" >&2; exit 2 ;; esac
+case "$PROXY_URL" in *[!A-Za-z0-9._:/-]*) echo "ERROR: OPENCODE_FP_PROXY_URL has invalid characters" >&2; exit 2 ;; esac
+
+# ── host-side state (hidden from the jail; everything persistent lives in ONE image) ──
+HOSTBASE="$HOME/.local/state/oc-fp-jail"
+DISK_IMG="$HOSTBASE/disk.img"
+MNT="$HOSTBASE/mnt"                 # the 12G image is mounted here on the host
+IMG_PROJECT="$MNT/project"          # → ~/$PROJECT  (the project; cwd)
+IMG_STATE="$MNT/state"             # → ~/.local/share/opencode  (opencode DB)
+IMG_CFG="$MNT/config"             # → ~/.config/opencode       (config + plugins)
+
+# in-jail paths the model sees:
+J_PROJECT="$HOME/$PROJECT"
+J_CFG="$HOME/.config/opencode"
+J_STATE="$HOME/.local/share/opencode"
+NODE_BIN="$(dirname "$(command -v node 2>/dev/null || echo /usr/bin/node)")"
+
+command -v bwrap >/dev/null 2>&1 || { echo "ERROR: bwrap not found (sudo apt-get install -y bubblewrap)" >&2; exit 1; }
+command -v opencode >/dev/null 2>&1 || { echo "ERROR: opencode not found on PATH" >&2; exit 1; }
+
+# ── capped storage: one fixed-size ext4 image holds project + state + config ──────────
+# Fail CLOSED: if we can't provide the cap, refuse — unless explicitly overridden.
+ensure_storage() {
+  mkdir -p "$HOSTBASE" "$MNT"
+  if ! mountpoint -q "$MNT"; then
+    if ! command -v mkfs.ext4 >/dev/null 2>&1; then
+      uncapped_or_die "mkfs.ext4 missing"; return
+    fi
+    if [ ! -f "$DISK_IMG" ]; then
+      echo "[jail] creating ${DISK} sandbox disk image ..." >&2
+      fallocate -l "$DISK" "$DISK_IMG" 2>/dev/null || dd if=/dev/zero of="$DISK_IMG" bs=1M count="$(( ${DISK%G} * 1024 ))" status=none
+      mkfs.ext4 -q -F "$DISK_IMG"
+    fi
+    if ! sudo -n mount -o loop "$DISK_IMG" "$MNT" 2>/dev/null; then
+      uncapped_or_die "could not loop-mount $DISK_IMG (needs sudo)"; return
+    fi
+    sudo -n chown "$(id -un):$(id -gn)" "$MNT" 2>/dev/null || true
+    echo "[jail] mounted ${DISK}-capped storage" >&2
+  fi
+  mkdir -p "$IMG_PROJECT" "$IMG_STATE" "$IMG_CFG"
+}
+# Fallback when the disk cap can't be applied: only if the operator opted in.
+uncapped_or_die() {
+  if [ "${OPENCODE_FP_ALLOW_UNCAPPED:-0}" = "1" ]; then
+    echo "[jail] WARNING: $1 — running WITHOUT the ${DISK} disk cap (OPENCODE_FP_ALLOW_UNCAPPED=1)" >&2
+    MNT="$HOSTBASE/uncapped"; IMG_PROJECT="$MNT/project"; IMG_STATE="$MNT/state"; IMG_CFG="$MNT/config"
+    mkdir -p "$IMG_PROJECT" "$IMG_STATE" "$IMG_CFG"
+  else
+    echo "ERROR: $1. Refusing to run without the disk cap. Set OPENCODE_FP_ALLOW_UNCAPPED=1 to override." >&2
+    exit 4
+  fi
+}
+
+mkdir -p "$HOSTBASE"
+# Serialize ALL access to the shared image (image create/mkfs/mount AND the symlink-safe
+# regen): a concurrent jail could otherwise race image setup or plant a symlink between our
+# cleanup and our writes (TOCTOU). Take the lock BEFORE ensure_storage and hold it through
+# the jail's whole life — the fd survives `exec` into bwrap, released only when the jail
+# exits. A second concurrent jail on the same image is refused.
+exec {LOCKFD}>"$HOSTBASE/.lock"
+flock -n "$LOCKFD" || { echo "ERROR: another jail is already using this sandbox image (set OPENCODE_FP_* for a separate one)." >&2; exit 6; }
+
+if [ "$MODE" != "selftest" ]; then ensure_storage; else mkdir -p "$IMG_PROJECT" "$IMG_STATE" "$IMG_CFG" 2>/dev/null || { MNT="$HOSTBASE/uncapped"; IMG_PROJECT="$MNT/project"; IMG_STATE="$MNT/state"; IMG_CFG="$MNT/config"; mkdir -p "$IMG_PROJECT" "$IMG_STATE" "$IMG_CFG"; }; fi
+
+# The project + config + state dirs are model-writable (across runs), so the model could
+# plant SYMLINKS at the names the host writes on the NEXT run, making `cat >`/`cp`/`git`
+# follow them to clobber host files or read host secrets. Defuse by removing any existing
+# file/symlink/dir at each target first (under the lock above, so no concurrent jail races
+# us), then recreating fresh regular files/dirs.
+# .git may be a real dir (keep the project's repo), or a model-planted symlink/gitfile that
+# would redirect git into a host path. `[ -d ]` FOLLOWS a symlink, so test `-L` too: treat
+# any symlink OR non-directory as hostile — remove it (rm -rf on a symlink removes the link,
+# not its target) and re-init clean.
+if [ -L "$IMG_PROJECT/.git" ] || [ ! -d "$IMG_PROJECT/.git" ]; then
+  rm -rf "$IMG_PROJECT/.git" 2>/dev/null || true
+  git -C "$IMG_PROJECT" init -q 2>/dev/null || true
+fi
+
+# ── refresh the freellmpool plugins INTO the config (so llmbuffet is never bind-mounted) ──
+# rm -rf (no trailing slash) clears a planted file, symlink, OR directory at each name — and
+# only AFTER this do we recreate plugin/tui-plugin, so no stale symlink is followed by mkdir.
+rm -rf "$IMG_CFG/opencode.jsonc" "$IMG_CFG/tui.json" "$IMG_CFG/plugin" "$IMG_CFG/tui-plugin"
+mkdir -p "$IMG_CFG/plugin" "$IMG_CFG/tui-plugin"
+if [ -f "$INTEG/opencode/freellmpool.js" ]; then
+  cp -f "$INTEG/opencode/freellmpool.js" "$IMG_CFG/plugin/freellmpool.js"
+fi
+if [ -d "$INTEG/opencode-tui" ]; then
+  cp -rf "$INTEG/opencode-tui/." "$IMG_CFG/tui-plugin/"
+fi
+
+# ── jail-only OpenCode config (regenerated each run; lives in the capped image) ────────
+cat > "$IMG_CFG/opencode.jsonc" <<JSON
+{
+  "\$schema": "https://opencode.ai/config.json",
+  "model": "$MODEL",
+  "small_model": "$MODEL",
+  // allow-all: NO approval prompts of any kind (incl. external_directory). The sandbox is
+  // the real containment, so blanket-allow inside is safe.
+  "permission": {
+    "read": "allow", "list": "allow", "glob": "allow", "grep": "allow", "lsp": "allow",
+    "edit": "allow", "bash": "allow", "task": "allow", "skill": "allow",
+    "external_directory": "allow",
+    "webfetch": "allow", "websearch": "allow"
+  },
+  "plugin": ["$J_CFG/plugin/freellmpool.js"],
+  "provider": {
+    "freellmpool": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "freellmpool (free pool)",
+      "options": { "baseURL": "$PROXY_URL/v1", "apiKey": "unused" },
+      "models": {
+        "auto":    { "name": "auto",    "tool_call": true, "structured_output": true, "limit": { "context": 128000, "output": 8192 } },
+        "fast":    { "name": "fast",    "tool_call": true, "structured_output": true, "limit": { "context": 128000, "output": 8192 } },
+        "quality": { "name": "quality", "tool_call": true, "structured_output": true, "limit": { "context": 128000, "output": 8192 } },
+        "fair":    { "name": "fair",    "tool_call": true, "structured_output": true, "limit": { "context": 128000, "output": 8192 } }
+      }
+    }
+  }
+}
+JSON
+printf '{\n  "plugin": ["file:%s/tui-plugin"]\n}\n' "$J_CFG" > "$IMG_CFG/tui.json"
+
+# ── preflight: host proxy reachable (shared net) ──────────────────────────────────────
+if [ "$MODE" != "selftest" ] && ! curl -fsS --max-time 3 "$PROXY_URL/healthz" >/dev/null 2>&1; then
+  echo "ERROR: freellmpool proxy not reachable at $PROXY_URL — start it on the host:" >&2
+  echo "         freellmpool proxy --port 8765   (or set OPENCODE_FP_PROXY_URL)" >&2
+  exit 3
+fi
+
+# ── the sandbox ───────────────────────────────────────────────────────────────────────
+BWRAP=(
+  bwrap
+  --clearenv
+  --ro-bind /usr /usr
+  --ro-bind-try /lib /lib
+  --ro-bind-try /lib64 /lib64
+  --ro-bind /bin /bin
+  --ro-bind /sbin /sbin
+  --ro-bind /etc /etc
+  --proc /proc
+  --dev /dev
+  --size 2147483648 --tmpfs /tmp
+  --size 67108864 --tmpfs /run
+  --ro-bind-try /run/systemd/resolve/stub-resolv.conf /run/systemd/resolve/stub-resolv.conf
+  --size 4294967296 --tmpfs "$HOME"
+  --ro-bind-try "$HOME/.npm-global" "$HOME/.npm-global"
+  --ro-bind-try "$HOME/.nvm" "$HOME/.nvm"
+  --bind "$IMG_CFG" "$J_CFG"
+  --bind "$IMG_STATE" "$J_STATE"
+  --bind "$IMG_PROJECT" "$J_PROJECT"
+  --setenv HOME "$HOME"
+  --setenv USER "$(id -un)"
+  --setenv TERM "${TERM:-xterm-256color}"
+  --setenv PATH "$NODE_BIN:$HOME/.npm-global/bin:$HOME/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+  --setenv FREELLMPOOL_PROXY_URL "$PROXY_URL"
+  --setenv npm_config_prefix "$HOME/.npm-local"
+  --setenv PIP_USER "1"
+  --setenv PYTHONUSERBASE "$HOME/.local"
+  --setenv GIT_AUTHOR_NAME "dev"
+  --setenv GIT_AUTHOR_EMAIL "dev@localhost"
+  --setenv GIT_COMMITTER_NAME "dev"
+  --setenv GIT_COMMITTER_EMAIL "dev@localhost"
+  --unshare-pid
+  --unshare-uts
+  --unshare-ipc
+  --die-with-parent
+  --chdir "$J_PROJECT"
+)
+
+# ── CPU + RAM caps via a transient cgroup-v2 scope ────────────────────────────────────
+LIMIT=()
+if [ "$MODE" != "selftest" ]; then
+  if systemctl --user show-environment >/dev/null 2>&1; then
+    LIMIT=( systemd-run --user --scope --quiet --collect
+            -p CPUQuota="$(( CPUS * 100 ))%" -p MemoryMax="$MEM" -p MemorySwapMax=0 )
+    echo "[jail] caps: CPU=${CPUS} core(s) · RAM=${MEM} · disk=${DISK} · model=${MODEL}" >&2
+  elif command -v taskset >/dev/null 2>&1; then
+    echo "[jail] systemd --user unavailable; CPU-pinning via taskset (no hard RAM cap)" >&2
+    LIMIT=( taskset -c "0-$(( CPUS - 1 ))" )
+  fi
+fi
+
+case "$MODE" in
+  tui)
+    # Interactive TUI needs the controlling terminal, so --new-session isn't usable here.
+    # The TIOCSTI keystroke-injection escape (queue input into the host shell) is instead
+    # blocked kernel-wide by dev.tty.legacy_tiocsti=0 (the Linux >=6.2 default). Fail closed
+    # if that protection isn't in effect — use --run/--serve (which detach the tty) instead.
+    # Fail CLOSED: require the sysctl to be readable AND 0. An unreadable/missing knob
+    # (older kernel) is NOT assumed safe — refuse the interactive TUI and point at --run/--serve.
+    ti="$(cat /proc/sys/dev/tty/legacy_tiocsti 2>/dev/null || true)"
+    if [ "$ti" != "0" ]; then
+      echo "ERROR: TIOCSTI injection protection not confirmed (dev.tty.legacy_tiocsti='$ti')." >&2
+      echo "       Use --run/--serve (tty detached), or: sudo sysctl -w dev.tty.legacy_tiocsti=0" >&2
+      exit 5
+    fi
+    echo "[jail] OpenCode on freellmpool — project: ~/$PROJECT" >&2
+    exec ${LIMIT[@]+"${LIMIT[@]}"} "${BWRAP[@]}" -- opencode
+    ;;
+  run)
+    # Headless: --new-session detaches the controlling tty so nothing can inject keystrokes.
+    exec ${LIMIT[@]+"${LIMIT[@]}"} "${BWRAP[@]}" --new-session -- opencode run "${RUN_ARGS[@]}"
+    ;;
+  serve)
+    # Keep the server password in the HOST-only base — never in model-writable state, so a
+    # planted symlink can't read-through it.
+    PW_FILE="$HOSTBASE/server.password"
+    [ -L "$PW_FILE" ] && rm -f "$PW_FILE"
+    [ -f "$PW_FILE" ] || (umask 077; head -c 24 /dev/urandom | base64 | tr -d '/+= ' > "$PW_FILE")
+    echo "[jail] serve on $HOSTBIND:$PORT (basic-auth password at host: $PW_FILE)" >&2
+    # Pass the secret via a bound file the entrypoint reads — NOT via --setenv/argv (which
+    # `ps`/`/proc/<pid>/cmdline` would expose to other host processes).
+    exec ${LIMIT[@]+"${LIMIT[@]}"} "${BWRAP[@]}" \
+      --ro-bind "$PW_FILE" /run/oc_pw \
+      --new-session \
+      -- /bin/bash -c 'export OPENCODE_SERVER_PASSWORD="$(cat /run/oc_pw)"; exec opencode serve --port "$1" --hostname "$2" --print-logs --log-level INFO' _ "$PORT" "$HOSTBIND"
+    ;;
+  selftest)
+    echo "[jail] containment + stealth self-test:" >&2
+    exec "${BWRAP[@]}" -- bash -c '
+      fail=0
+      absent() { if [ -e "$1" ]; then echo "  FAIL leaked: $1"; fail=1; else echo "  ok   hidden: $1"; fi; }
+      absent "$HOME/.ssh"; absent "$HOME/.polybot"; absent "$HOME/.config/minimax"
+      absent "$HOME/.codex"; absent "$HOME/.aws"; absent "$HOME/llmbuffet"
+      [ -e /home/ubuntu/llmbuffet ] && { echo "  FAIL leaked: /home/ubuntu/llmbuffet"; fail=1; } || echo "  ok   hidden: llmbuffet source"
+      case "$PWD" in *sandbox*|*jail*) echo "  FAIL cwd not stealthy: $PWD"; fail=1;; *) echo "  ok   stealthy cwd: $PWD";; esac
+      echo hi > "$HOME/__probe" 2>/dev/null && echo "  ok   home writable (ephemeral)" || { echo "  FAIL home not writable"; fail=1; }
+      echo p > "$PWD/.__probe" 2>/dev/null && { echo "  ok   project writable (persists)"; rm -f "$PWD/.__probe"; } || { echo "  FAIL project not writable"; fail=1; }
+      touch /usr/__x 2>/dev/null && { echo "  FAIL /usr writable"; rm -f /usr/__x; fail=1; } || echo "  ok   /usr read-only"
+      [ -e /etc/passwd ] && echo "  ok   system looks real" || { echo "  FAIL no /etc/passwd"; fail=1; }
+      echo
+      [ "$fail" = 0 ] && echo "SELFTEST: PASS — secrets+llmbuffet hidden, stealthy cwd, only the project persists" || echo "SELFTEST: FAIL"
+      exit "$fail"
+    '
+    ;;
+esac


### PR DESCRIPTION
## Sandboxed OpenCode on freellmpool (bubblewrap jail)

`integrations/opencode-jail/opencode-freellmpool-jailed.sh` — run OpenCode on the freellmpool free
pool inside a bubblewrap sandbox for **long, hands-off agentic coding**. The model believes it's on
a normal full Linux box with full permissions; in reality it's tightly boxed.

### Reality vs. illusion
- **Only a throwaway project persists** — project + OpenCode state + config all live inside one
  fixed-size **ext4 loopback image** (default **12 GB**); a runaway agent fills at most that image.
- **All host secrets are gone** — fresh tmpfs `$HOME` ⇒ `~/.ssh`, `~/.config` keys, cloud creds,
  the real OpenCode auth, and the freellmpool source are all `ENOENT`; `--clearenv` keeps host env out.
- **Resources capped** via a cgroup-v2 scope: **1 core / 6 GB RAM (no swap) / 12 GB disk** (tunable).
- `--unshare-pid/uts/ipc`, fail-closed storage, an exclusive flock vs concurrent jails, and
  symlink/TOCTOU-hardened host-side setup.

### Stealth + routing
Cwd is a neutral `~/project` with a generic git identity (no "sandbox"/"jail" tell). Plugins (the
freellmpool tools + TUI dashboard) are **copied into the in-image config**, so the `llmbuffet` source
tree is never bind-mounted/visible. Defaults to `freellmpool/fast` routing (interactive-friendly;
`quality` picks slow models and can stall a turn).

### Modes
`tui` (default, interactive) · `--run "…"` (headless) · `--serve` (basic-auth) · `--selftest` (proves
containment + stealth, exits).

### Known residuals (by design)
Open network egress (free models + the proxy need it), `/etc` RO-bind, no writable `/usr` (no overlay
in this bubblewrap build → project-local pip/npm only).

### Review
Hardened across **10 adversarial Codex passes** to `VERDICT: SHIP` (capping, namespaces, symlink/
TOCTOU, password-in-argv, TIOCSTI injection, JSON injection, …). `--selftest` PASSes. Pure shell —
no Python/test-matrix impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a sandboxed bubblewrap-based environment to run OpenCode against the freellmpool proxy with capped resources and isolated, image-backed storage.

New Features:
- Introduce opencode-freellmpool-jailed.sh to run OpenCode in a bubblewrap jail with an ext4 image for project, config, and state persistence, supporting interactive, headless, serve, and self-test modes.

Enhancements:
- Apply cgroup-v2 or taskset-based CPU and memory limits, plus disk caps, to constrain jailed OpenCode sessions and guard against runaway agents.
- Harden the jail setup against symlink/TOCTOU issues, concurrent access via file locking, and TTY injection for interactive sessions.

Documentation:
- Document the sandboxed OpenCode-on-freellmpool setup, usage modes, security model, requirements, and environment configuration in a new README under integrations/opencode-jail.