### PR TITLE
opencode-jail: disable OpenCode self-update inside the sandbox

### DIFF
--- a/integrations/opencode-jail/opencode-freellmpool-jailed.sh
+++ b/integrations/opencode-jail/opencode-freellmpool-jailed.sh
@@ -165,6 +165,9 @@ cat > "$IMG_CFG/opencode.jsonc" <<JSON
   "\$schema": "https://opencode.ai/config.json",
   "model": "$MODEL",
   "small_model": "$MODEL",
+  // never self-update inside the jail (binary lives on the read-only host mount; the host
+  // owns the version). Belt-and-suspenders with OPENCODE_DISABLE_AUTOUPDATE in the env.
+  "autoupdate": false,
   // allow-all: NO approval prompts of any kind (incl. external_directory). The sandbox is
   // the real containment, so blanket-allow inside is safe.
   "permission": {
@@ -224,6 +227,7 @@ BWRAP=(
   --setenv TERM "${TERM:-xterm-256color}"
   --setenv PATH "$NODE_BIN:$HOME/.npm-global/bin:$HOME/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
   --setenv FREELLMPOOL_PROXY_URL "$PROXY_URL"
+  --setenv OPENCODE_DISABLE_AUTOUPDATE "1"
   --setenv npm_config_prefix "$HOME/.npm-local"
   --setenv PIP_USER "1"
   --setenv PYTHONUSERBASE "$HOME/.local"


### PR DESCRIPTION
OpenCode's auto-updater tries to overwrite its own binary, which is on the read-only `~/.npm-global` host mount in the jail → the update fails. A sandboxed OpenCode should never self-update (the host owns the version). Disabled both ways the binary checks: `"autoupdate": false` in the generated config + `OPENCODE_DISABLE_AUTOUPDATE=1` in the jail env. Verified: jail still runs (`--run` returns), generated config shows `autoupdate:false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Disable OpenCode self-updates inside the jailed environment to avoid failed writes to the read-only host-mounted binary.

Enhancements:
- Set the generated OpenCode config to disable autoupdate when running inside the jail.
- Export an environment variable in the jail to belt-and-suspenders disable OpenCode auto-updates at runtime.