### PR TITLE
opencode-jail: default to fair routing (use all providers, kill the 429 storm)

### DIFF
--- a/integrations/opencode-jail/opencode-freellmpool-jailed.sh
+++ b/integrations/opencode-jail/opencode-freellmpool-jailed.sh
@@ -26,7 +26,7 @@
 #         opencode-freellmpool-jailed.sh --serve     # opencode serve (basic-auth)
 #         opencode-freellmpool-jailed.sh --selftest  # prove containment + stealth, exit
 #
-# ENV KNOBS: OPENCODE_FP_MODEL (default freellmpool/fast — snappy; "quality" stalls on slow
+# ENV KNOBS: OPENCODE_FP_MODEL (default freellmpool/fair — spreads load across ALL providers;
 #   models), OPENCODE_FP_PROJECT (in-jail project basename, default "project"),
 #   OPENCODE_FP_PROXY_URL, OPENCODE_FP_CPUS/MEM/DISK (default 1 / 6G / 12G),
 #   OPENCODE_FP_PORT (--serve), OPENCODE_FP_ALLOW_UNCAPPED=1 (run without the disk image —
@@ -46,7 +46,9 @@ esac
 
 # ── tunables ────────────────────────────────────────────────────────────────────────
 PROXY_URL="${OPENCODE_FP_PROXY_URL:-http://127.0.0.1:8765}"
-MODEL="${OPENCODE_FP_MODEL:-freellmpool/fast}"   # fast = lowest-latency; quality is slow/stally
+MODEL="${OPENCODE_FP_MODEL:-freellmpool/fair}"   # fair = least-used-first → spreads load across ALL
+                                                 # providers (best for sustained agentic loops; 'fast'
+                                                 # hammers the same few → 429 storms)
 PROJECT="${OPENCODE_FP_PROJECT:-project}"         # in-jail cwd basename — NOT "sandbox"
 PORT="${OPENCODE_FP_PORT:-4099}"
 HOSTBIND="127.0.0.1"


### PR DESCRIPTION
The jail forced `freellmpool/fast`, which latency-orders providers → hammers the same few fast ones every request → they rate-limit first → each turn fails over through ~25 providers to a slow survivor (429 storm, 14–68s/step). `fair` is **least-used-first**: it rotates across the **whole** pool, using every provider's quota evenly, so no single one exhausts and sustained agentic loops stop storming. All modes still reach every provider on failover; fair just stops concentrating load. Override via `OPENCODE_FP_MODEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Default the opencode jail freellmpool integration to the fair routing model to distribute load evenly across providers and reduce rate-limit storms.

Enhancements:
- Update the default FP model from freellmpool/fast to freellmpool/fair for more balanced provider usage.
- Clarify environment variable documentation to describe the new fair routing behavior and its impact on sustained workloads.