### PR TITLE
routing: add `spread` mode (best for agentic) + make it the OpenCode default

### DIFF
--- a/integrations/opencode-jail/opencode-freellmpool-jailed.sh
+++ b/integrations/opencode-jail/opencode-freellmpool-jailed.sh
@@ -26,7 +26,7 @@
 #         opencode-freellmpool-jailed.sh --serve     # opencode serve (basic-auth)
 #         opencode-freellmpool-jailed.sh --selftest  # prove containment + stealth, exit
 #
-# ENV KNOBS: OPENCODE_FP_MODEL (default freellmpool/fair — spreads load across ALL providers;
+# ENV KNOBS: OPENCODE_FP_MODEL (default freellmpool/spread — full-pool breadth + fast; best agentic;
 #   models), OPENCODE_FP_PROJECT (in-jail project basename, default "project"),
 #   OPENCODE_FP_PROXY_URL, OPENCODE_FP_CPUS/MEM/DISK (default 1 / 6G / 12G),
 #   OPENCODE_FP_PORT (--serve), OPENCODE_FP_ALLOW_UNCAPPED=1 (run without the disk image —
@@ -46,9 +46,9 @@ esac
 
 # ── tunables ────────────────────────────────────────────────────────────────────────
 PROXY_URL="${OPENCODE_FP_PROXY_URL:-http://127.0.0.1:8765}"
-MODEL="${OPENCODE_FP_MODEL:-freellmpool/fair}"   # fair = least-used-first → spreads load across ALL
-                                                 # providers (best for sustained agentic loops; 'fast'
-                                                 # hammers the same few → 429 storms)
+MODEL="${OPENCODE_FP_MODEL:-freellmpool/spread}"  # spread = full-pool breadth (least-used tier first,
+                                                  # anti-429) WITH a latency/health tie-break — the best
+                                                  # mode for sustained agentic loops on free tiers
 PROJECT="${OPENCODE_FP_PROJECT:-project}"         # in-jail cwd basename — NOT "sandbox"
 PORT="${OPENCODE_FP_PORT:-4099}"
 HOSTBIND="127.0.0.1"
@@ -131,7 +131,10 @@ mkdir -p "$HOSTBASE"
 # the jail's whole life — the fd survives `exec` into bwrap, released only when the jail
 # exits. A second concurrent jail on the same image is refused.
 exec {LOCKFD}>"$HOSTBASE/.lock"
-flock -n "$LOCKFD" || { echo "ERROR: another jail is already using this sandbox image (set OPENCODE_FP_* for a separate one)." >&2; exit 6; }
+# Wait briefly (not -n/instant-fail): when a previous session is still tearing down, its
+# lock lingers for a moment — instant-fail made the jail "refuse to restart" right after
+# closing it. flock auto-releases on process death, so a real holder means a live jail.
+flock -w 15 "$LOCKFD" || { echo "ERROR: another jail is still using this sandbox image — close it first, or set OPENCODE_FP_* to run a separate one." >&2; exit 6; }
 
 if [ "$MODE" != "selftest" ]; then ensure_storage; else mkdir -p "$IMG_PROJECT" "$IMG_STATE" "$IMG_CFG" 2>/dev/null || { MNT="$HOSTBASE/uncapped"; IMG_PROJECT="$MNT/project"; IMG_STATE="$MNT/state"; IMG_CFG="$MNT/config"; mkdir -p "$IMG_PROJECT" "$IMG_STATE" "$IMG_CFG"; }; fi
 
@@ -185,6 +188,7 @@ cat > "$IMG_CFG/opencode.jsonc" <<JSON
       "name": "freellmpool (free pool)",
       "options": { "baseURL": "$PROXY_URL/v1", "apiKey": "unused" },
       "models": {
+        "spread":  { "name": "spread (all providers + fast)", "tool_call": true, "structured_output": true, "limit": { "context": 128000, "output": 8192 } },
         "auto":    { "name": "auto",    "tool_call": true, "structured_output": true, "limit": { "context": 128000, "output": 8192 } },
         "fast":    { "name": "fast",    "tool_call": true, "structured_output": true, "limit": { "context": 128000, "output": 8192 } },
         "quality": { "name": "quality", "tool_call": true, "structured_output": true, "limit": { "context": 128000, "output": 8192 } },

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -29,12 +29,17 @@ Routing is chosen by the **model name** in OpenCode's model picker — no extra 
 
 | Model | Routing |
 | --- | --- |
+| `freellmpool/spread` | **best for agentic work** — spread across the *whole* pool (least-used tier first → no provider hits its rate limit), with a latency/health tie-break so it stays fast. Use this for long, multi-step loops. |
 | `freellmpool/auto` | proxy default (whatever `FREELLMPOOL_ROUTING` is set to) |
-| `freellmpool/fast` | lowest-latency provider first |
+| `freellmpool/fast` | lowest-latency provider first (concentrates load → can rate-limit under sustained loops) |
 | `freellmpool/quality` | match the model's capability to the prompt's difficulty |
-| `freellmpool/fair` | spread load across providers (preserve quota) |
+| `freellmpool/fair` | spread load across providers (preserve quota), latency-blind |
 
-(Advanced: send an `X-Freellmpool-Routing: fast|quality|fair` header instead.)
+**For agentic coding, pick `freellmpool/spread`.** `fast` keeps hitting the same few fast providers
+every turn, so they exhaust their free-tier limits first and you get a 429 storm; `spread` rotates
+across all of them while still preferring the quick/healthy ones.
+
+(Advanced: send an `X-Freellmpool-Routing: spread|fast|quality|fair` header instead.)
 
 ## Install
 
@@ -64,6 +69,7 @@ routing aliases as models so you can pick them:
       "npm": "@ai-sdk/openai-compatible",
       "options": { "baseURL": "http://localhost:8765/v1" },
       "models": {
+        "spread": {},
         "auto": {},
         "fast": {},
         "quality": {},

--- a/src/freellmpool/agents.py
+++ b/src/freellmpool/agents.py
@@ -75,11 +75,12 @@ AGENTS: dict[str, dict] = {
             '      "npm": "@ai-sdk/openai-compatible",',
             f'      "options": {{ "baseURL": "{_PROXY}" }},',
             '      "models": {',
-            '        "auto": {}, "fast": {}, "quality": {}, "fair": {}',
+            '        "spread": {}, "auto": {}, "fast": {}, "quality": {}, "fair": {}',
             "      }",
             "    }",
             "  }",
-            "Pick freellmpool/{auto,fast,quality,fair} to control routing.",
+            "Pick freellmpool/{spread,auto,fast,quality,fair} to control routing.",
+            "For agentic work use freellmpool/spread — uses the whole pool, avoids 429 storms.",
         ],
         "note": (
             "Embedded dashboard + status/usage tools live in integrations/opencode "

--- a/src/freellmpool/mcp_server.py
+++ b/src/freellmpool/mcp_server.py
@@ -36,7 +36,7 @@ from .router import Pool
 from .tokenmax import HARD_CAP, RAINBOW_BANNER, fan_out, select_targets
 
 _DEFAULT_PROTOCOL = "2025-06-18"
-_ROUTING_MODES = ("fair", "fast", "quality", "legacy", "model", "model-fast")
+_ROUTING_MODES = ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
 _MAX_PANEL = 5
 
 # Returned in the `initialize` handshake (MCP's standard `instructions` field) so the
@@ -82,7 +82,7 @@ TOOLS = [
                 },
                 "routing": {
                     "type": "string",
-                    "enum": ["auto", "fast", "quality", "fair"],
+                    "enum": ["auto", "fast", "quality", "fair", "spread"],
                     "description": "How to pick the model: quality (best capable model for the prompt), fast (lowest latency), fair (spread quota), or auto (server default).",
                 },
                 "max_tokens": {
@@ -168,7 +168,7 @@ TOOLS = [
                 "prompt": {"type": "string", "description": "The prompt to analyze."},
                 "routing": {
                     "type": "string",
-                    "enum": ["auto", "fast", "quality", "fair"],
+                    "enum": ["auto", "fast", "quality", "fair", "spread"],
                     "description": "Routing mode to explain (default: the server's mode).",
                 },
             },

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -48,7 +48,7 @@ _MAX_BODY = 16 * 1024 * 1024  # 16 MB cap on request bodies
 def _model_ids(pool: Pool) -> list[str]:
     # "auto" + per-request routing aliases (mapped to a routing mode by the proxy),
     # then every enabled provider/model id.
-    ids = ["auto", "fast", "quality", "fair"]
+    ids = ["auto", "spread", "fast", "quality", "fair"]
     for provider in pool.providers:
         for m in provider.models:
             if m.enabled:
@@ -168,7 +168,7 @@ def _status_payload(pool: Pool, recent: Sequence[dict], tokenmax: dict | None = 
     }
 
 
-_ROUTING_MODES = frozenset({"fair", "fast", "quality", "legacy", "model", "model-fast"})
+_ROUTING_MODES = frozenset({"fair", "fast", "quality", "spread", "legacy", "model", "model-fast"})
 
 
 def _routing_and_model(headers, requested: str) -> tuple[str | None, str]:
@@ -178,9 +178,16 @@ def _routing_and_model(headers, requested: str) -> tuple[str | None, str]:
     model selection. Returns ``(routing_override, requested_model)``."""
     override = (headers.get("X-Freellmpool-Routing", "") or "").lower()
     override = override if override in _ROUTING_MODES else None
-    if isinstance(requested, str) and requested.lower() in _ROUTING_MODES:
-        override = override or requested.lower()
-        requested = "auto"
+    if isinstance(requested, str):
+        # accept bare or provider-qualified aliases: 'spread', 'freellmpool/spread',
+        # and 'freellmpool/auto' (opencode sends its provider name as the prefix). No real
+        # pool model is named after a routing keyword or 'auto', so the suffix check is safe.
+        alias = requested.rsplit("/", 1)[-1].lower()
+        if alias in _ROUTING_MODES:
+            override = override or alias
+            requested = "auto"
+        elif alias == "auto":
+            requested = "auto"  # 'auto' / 'freellmpool/auto' → default routing, no provider filter
     return override, requested
 
 

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -53,6 +53,12 @@ _CTX_LIMIT_TTL = 1800.0  # seconds (30 min)
 # breaks ties among models that already clear the difficulty bar.
 _QUALITY_SLOW_S = 8.0
 _QUALITY_UNKNOWN_LAT = 0.34
+# "spread" routing groups providers into coarse usage tiers of this many requests, so the
+# least-used tier is served first (spreading load across the WHOLE pool to avoid one
+# provider hitting its rate limit), while within a tier the fastest/healthiest is preferred.
+# Small bucket => stronger spread; large => more latency-greedy. 8 balances both for
+# sustained agentic loops on free tiers.
+_SPREAD_BUCKET = 8
 
 
 def _is_health_failure(exc: Exception) -> bool:
@@ -130,7 +136,7 @@ class Pool:
         # "legacy"/"model" keep the old per-(provider, model) balancing behavior.
         self.routing = (
             routing
-            if routing in ("fair", "fast", "quality", "legacy", "model", "model-fast")
+            if routing in ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
             else "fair"
         )
         self._on_event = on_event
@@ -192,7 +198,7 @@ class Pool:
         provider_list = list(providers) if providers else None
         eff = (
             routing
-            if routing in ("fair", "fast", "quality", "legacy", "model", "model-fast")
+            if routing in ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
             else self.routing
         )
         difficulty = prompt_difficulty(messages) if eff == "quality" else None
@@ -362,6 +368,11 @@ class Pool:
         ``fast``: lowest measured provider latency / failure penalty first, then
         least-used provider.
 
+        ``spread``: least-used *tier* first (usage bucketed by ``_SPREAD_BUCKET``) so load
+        spreads across the WHOLE pool — no single provider hits its rate limit first — then
+        fastest/healthiest within a tier. Best for sustained agentic loops on free tiers:
+        the breadth of ``fair`` with the speed of ``fast``.
+
         ``quality``: match the request's ``difficulty`` (0–1) to each model's
         benchmark-scored capability — strong models for hard prompts, light models
         for easy ones (rationing scarce strong-model quota). Ordered globally, not
@@ -376,7 +387,7 @@ class Pool:
         metrics = self.metrics
         mode = (
             routing
-            if routing in ("fair", "fast", "quality", "legacy", "model", "model-fast")
+            if routing in ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
             else self.routing
         )
 
@@ -447,6 +458,15 @@ class Pool:
         def target_fast_key(t: Target) -> tuple[int, float, int]:
             return (over_of(t), metrics.score(t.name), used_of(t))
 
+        def target_spread_key(t: Target) -> tuple[int, int, int, float]:
+            # least-used TIER first (spread across the whole pool), then fastest within tier.
+            return (
+                over_of(t),
+                1 if metrics.failing(t.name) else 0,
+                used_of(t) // _SPREAD_BUCKET,
+                metrics.score(t.name),
+            )
+
         if mode == "fast":
 
             def provider_fast_key(provider_id: str) -> tuple[int, float, int]:
@@ -455,6 +475,21 @@ class Pool:
 
             provider_order = sorted(by_provider, key=provider_fast_key)
             target_key = target_fast_key
+        elif mode == "spread":
+
+            def provider_spread_key(provider_id: str) -> tuple[int, int, int, float]:
+                # group providers into usage tiers (least-used tier first → load spreads
+                # across ALL providers), then prefer the fastest/healthiest within a tier.
+                stats = by_provider[provider_id]
+                return (
+                    1 if stats.all_over else 0,
+                    1 if stats.all_failing else 0,
+                    stats.used // _SPREAD_BUCKET,
+                    stats.best_score,
+                )
+
+            provider_order = sorted(by_provider, key=provider_spread_key)
+            target_key = target_spread_key
         else:
 
             def provider_fair_key(provider_id: str) -> tuple[int, int, int]:
@@ -534,7 +569,7 @@ class Pool:
         # never serves a reply produced under a different mode's intent.
         eff = (
             routing
-            if routing in ("fair", "fast", "quality", "legacy", "model", "model-fast")
+            if routing in ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
             else self.routing
         )
         cache_key = None
@@ -721,7 +756,7 @@ class Pool:
             raise NoProvidersConfigured("no provider has an API key set")
         eff = (
             routing
-            if routing in ("fair", "fast", "quality", "legacy", "model", "model-fast")
+            if routing in ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
             else self.routing
         )
         difficulty = prompt_difficulty(messages, max_tokens) if eff == "quality" else None

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -602,7 +602,20 @@ def test_status_records_served_target(server):
 def test_models_route_includes_routing_aliases(server):
     with urllib.request.urlopen(server + "/v1/models") as resp:  # noqa: S310
         ids = {m["id"] for m in json.load(resp)["data"]}
-    assert {"auto", "fast", "quality", "fair"} <= ids
+    assert {"auto", "fast", "quality", "fair", "spread"} <= ids  # spread discoverable
+
+
+def test_spread_alias_routes(server):
+    # bare + provider-qualified aliases all route and serve (incl. freellmpool/auto, which
+    # must NOT be treated as a literal provider filter → 503)
+    for name in ("spread", "freellmpool/spread", "freellmpool/auto", "auto"):
+        status, body = _post_json(
+            server + "/v1/chat/completions",
+            {"model": name, "messages": [{"role": "user", "content": "hi"}]},
+        )
+        assert status == 200, name
+        assert body["choices"][0]["message"]["content"] == "ok", name
+        assert "x_freellmpool" in body
 
 
 def test_model_name_is_treated_as_routing_keyword(server):

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -96,6 +96,30 @@ def test_fast_mode_prefers_low_latency(providers, env, quota):
     assert order.index("beta/beta-1") < order.index("alpha/alpha-small")
 
 
+def test_spread_serves_least_used_tier_first_over_faster_busy_provider(providers, env, quota):
+    # The anti-429 property fast lacks: a heavily-used provider drops to a higher usage tier,
+    # so spread serves the least-used one first EVEN IF the busy one is faster.
+    from freellmpool.router import _SPREAD_BUCKET
+
+    for _ in range(_SPREAD_BUCKET + 1):
+        quota.record("beta", "beta-1")  # beta into a higher usage tier
+    pool = Pool(providers, quota=quota, env=env, post=make_post({}), routing="spread")
+    pool.metrics.record_success("beta/beta-1", 50.0)  # busy provider is FAST
+    pool.metrics.record_success("alpha/alpha-small", 900.0)  # least-used is SLOW
+    order = _names(pool, include=["alpha", "beta"])
+    assert order.index("alpha/alpha-small") < order.index("beta/beta-1")
+
+
+def test_spread_breaks_ties_by_latency_within_a_usage_tier(providers, env, quota):
+    # Within the same usage tier (both unused), spread prefers the faster/healthier one —
+    # the speed of fast, on top of the breadth of fair.
+    pool = Pool(providers, quota=quota, env=env, post=make_post({}), routing="spread")
+    pool.metrics.record_success("beta/beta-1", 50.0)
+    pool.metrics.record_success("alpha/alpha-small", 900.0)
+    order = _names(pool, include=["alpha", "beta"])
+    assert order.index("beta/beta-1") < order.index("alpha/alpha-small")
+
+
 def test_invalid_routing_falls_back_to_fair(providers, env, quota):
     pool = Pool(providers, quota=quota, env=env, post=make_post({}), routing="nonsense")
     assert pool.routing == "fair"


### PR DESCRIPTION
## `spread` routing — the best mode for agentic loops, now the OpenCode default

`spread` = **breadth of `fair` + speed of `fast`.** It orders providers by **least-used tier first**
(usage bucketed by `_SPREAD_BUCKET`) so load spreads across the **whole pool** — no single provider
hits its free-tier rate limit first — then **tie-breaks by latency/health within a tier** so it stays
quick.

### Why
Sustained agentic coding (many rapid calls) was triggering **429 storms**: `fast` slams the same few
fast providers every request → they rate-limit first → each turn fails over through ~25 providers to a
slow survivor (14–68 s/step). `fair` spreads load but is latency-blind. `spread` does both: full-pool
rotation *and* prefers the quick/healthy providers.

### What's in here
- **`router._order`**: new `spread` branch (provider + target keys bucket usage, then sort by score).
- Wired through **every** routing-mode allowlist (router ×5, proxy `_ROUTING_MODES`, mcp
  `_ROUTING_MODES` + tool-schema enums), exposed in **`/v1/models`**, and the `freellmpool code opencode`
  setup output.
- **`proxy._routing_and_model`** now accepts provider-qualified aliases (`freellmpool/spread`,
  `freellmpool/auto`) as well as bare ones.
- **Set as the OpenCode default**: the jail (`OPENCODE_FP_MODEL=freellmpool/spread`), the host config,
  and the documented provider snippets all default to / offer `spread`.
- **Tests**: spread ordering (least-used tier first, latency tie-break within tier), `/v1/models`
  discoverability, and bare + provider-qualified alias routing.

### Review
**Codex, 4 rounds → `VERDICT: SHIP`** (caught: missing allowlist wiring, `/v1/models` discoverability,
provider-qualified `freellmpool/spread` + `freellmpool/auto` mapping — all fixed). Full suite + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new `spread` routing mode optimized for agentic workloads and make it the default for OpenCode integrations, while updating routing aliases, proxy handling, and documentation accordingly.

New Features:
- Add `spread` routing mode that balances load by least-used usage tier with latency/health tie-breaking for sustained agentic loops.
- Expose `spread` as a discoverable routing alias in the proxy, MCP server schemas, and OpenCode integrations, including model lists and configuration templates.

Enhancements:
- Extend proxy routing to accept provider-qualified routing aliases such as `freellmpool/spread` and `freellmpool/auto` without treating them as literal provider filters.
- Set `freellmpool/spread` as the default routing mode for OpenCode jail and host configurations, and adjust locking behavior to wait briefly for prior sessions before failing.
- Update OpenCode agent and documentation guidance to recommend `freellmpool/spread` for agentic work and clarify the behavior of other routing modes.

Tests:
- Add router tests covering `spread` ordering by usage tier and latency, and proxy tests ensuring `spread` alias discoverability and correct routing for bare and provider-qualified aliases.