### PR TITLE
opencode-jail: install /goal long-horizon plugin (persistent auto-continue)

### DIFF
--- a/integrations/opencode-jail/opencode-freellmpool-jailed.sh
+++ b/integrations/opencode-jail/opencode-freellmpool-jailed.sh
@@ -164,6 +164,20 @@ if [ -d "$INTEG/opencode-tui" ]; then
   cp -rf "$INTEG/opencode-tui/." "$IMG_CFG/tui-plugin/"
 fi
 
+# ── /goal long-horizon plugin (auto-continues toward an objective on session.idle) ─────
+# Installed as an npm spec opencode fetches into the capped image state (persists). It must
+# be in BOTH the server (opencode.jsonc) and tui (tui.json) plugin lists. Set OPENCODE_FP_GOAL
+# to a different package, or empty, to change/disable.
+GOAL="${OPENCODE_FP_GOAL-@prevalentware/opencode-goal-plugin}"
+case "$GOAL" in *[!A-Za-z0-9@/._-]*) echo "ERROR: OPENCODE_FP_GOAL has invalid chars" >&2; exit 2 ;; esac
+if [ -n "$GOAL" ]; then
+  PLUGIN_LIST="\"$J_CFG/plugin/freellmpool.js\", [\"$GOAL\", { \"auto_continue\": true, \"min_continue_interval_seconds\": 3 }]"
+  TUI_PLUGIN_LIST="\"file:$J_CFG/tui-plugin\", \"$GOAL\""
+else
+  PLUGIN_LIST="\"$J_CFG/plugin/freellmpool.js\""
+  TUI_PLUGIN_LIST="\"file:$J_CFG/tui-plugin\""
+fi
+
 # ── jail-only OpenCode config (regenerated each run; lives in the capped image) ────────
 cat > "$IMG_CFG/opencode.jsonc" <<JSON
 {
@@ -181,7 +195,7 @@ cat > "$IMG_CFG/opencode.jsonc" <<JSON
     "external_directory": "allow",
     "webfetch": "allow", "websearch": "allow"
   },
-  "plugin": ["$J_CFG/plugin/freellmpool.js"],
+  "plugin": [ $PLUGIN_LIST ],
   "provider": {
     "freellmpool": {
       "npm": "@ai-sdk/openai-compatible",
@@ -198,7 +212,7 @@ cat > "$IMG_CFG/opencode.jsonc" <<JSON
   }
 }
 JSON
-printf '{\n  "plugin": ["file:%s/tui-plugin"]\n}\n' "$J_CFG" > "$IMG_CFG/tui.json"
+printf '{\n  "plugin": [ %s ]\n}\n' "$TUI_PLUGIN_LIST" > "$IMG_CFG/tui.json"
 
 # ── preflight: host proxy reachable (shared net) ──────────────────────────────────────
 if [ "$MODE" != "selftest" ] && ! curl -fsS --max-time 3 "$PROXY_URL/healthz" >/dev/null 2>&1; then


### PR DESCRIPTION
`/goal` wasn't installed in the jail (and the per-launch config regen would wipe a hand-added plugin), so it never made OpenCode keep working toward a goal. Wires **@prevalentware/opencode-goal-plugin** into both `opencode.jsonc` and `tui.json` with `auto_continue: true` — it drives continuation off the stable `session.idle` event and targets `@opencode-ai/plugin ^1.14.39` (compatible). OpenCode auto-installs the npm spec into the capped image (persists). **Verified**: its goal tools register on launch. Toggle/replace with `OPENCODE_FP_GOAL`. Pairs with the `spread` default so auto-continue doesn't 429-storm the pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Integrate a configurable long-horizon goal plugin into the OpenCode jail configuration to enable persistent auto-continue behavior.

New Features:
- Add support for a goal plugin (defaulting to @prevalentware/opencode-goal-plugin) in both server and TUI OpenCode configs with auto-continue enabled and a minimum continuation interval.
- Allow overriding or disabling the goal plugin via the OPENCODE_FP_GOAL environment variable.

Enhancements:
- Centralize construction of server and TUI plugin lists in the jailed OpenCode startup script and validate the goal plugin package name for safe characters.