### PR TITLE
router: pooled audio transcription (/v1/audio/transcriptions, Whisper)

### DIFF
--- a/src/freellmpool/client.py
+++ b/src/freellmpool/client.py
@@ -23,7 +23,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from .errors import ProviderHTTPError
-from .models import EmbedReply, Provider, Reply
+from .models import EmbedReply, Provider, Reply, TranscribeReply
 
 Message = dict[str, str]
 
@@ -531,6 +531,97 @@ def embed(
         vectors=vectors,
         provider_id=provider.id,
         model=model,
+        prompt_tokens=usage.get("prompt_tokens"),
+    )
+
+
+# A multipart transport: (url, headers, files, data, timeout) -> HTTPResult. Separate from
+# PostFn because audio uploads are multipart/form-data, not a JSON body. Injectable for tests.
+MultipartPostFn = Callable[[str, dict, dict, dict, float], HTTPResult]
+
+
+def default_multipart_post(
+    url: str, headers: dict, files: dict, data: dict, timeout: float
+) -> HTTPResult:
+    """Real network multipart POST (file upload) via the pooled httpx client. httpx sets the
+    multipart Content-Type + boundary from ``files`` itself. Inherits ``follow_redirects=False``
+    so a redirect can't exfiltrate the API key (SSRF). Streams + caps the response like
+    ``default_post`` so a broken provider can't OOM the proxy and a slow-drip upstream can't
+    pin a worker past the deadline."""
+    deadline = time.monotonic() + timeout
+    with _client().stream(
+        "POST", url, headers=headers, files=files, data=data, timeout=_timeout(timeout)
+    ) as resp:
+        chunks: list[bytes] = []
+        total = 0
+        for chunk in resp.iter_bytes():
+            total += len(chunk)
+            if total > _MAX_RESPONSE_BYTES:
+                raise ProviderHTTPError(
+                    502, f"upstream response exceeded {_MAX_RESPONSE_BYTES} bytes", retryable=True
+                )
+            if time.monotonic() > deadline:
+                raise ProviderHTTPError(
+                    504, f"upstream exceeded {timeout:.0f}s deadline", retryable=True
+                )
+            chunks.append(chunk)
+        status = resp.status_code
+        ctype = resp.headers.get("content-type", "")
+    raw = b"".join(chunks)
+    text = raw.decode("utf-8", "replace")
+    if "application/json" in ctype:
+        try:
+            body = json.loads(raw) if raw else {}
+        except (json.JSONDecodeError, ValueError):
+            body = {"text": text}  # non-JSON despite the header → treat text as the result
+        if not isinstance(body, dict):  # provider returned a JSON list/scalar
+            body = {}  # keep _err_message safe; transcribe() falls back to result.text
+    else:
+        body = {"text": text}  # response_format=text returns the transcription as plain text
+    return HTTPResult(status=status, body=body, text=text)
+
+
+def transcribe(
+    provider: Provider,
+    model: str,
+    audio: bytes,
+    filename: str,
+    *,
+    api_key: str | None,
+    env: dict[str, str],
+    language: str | None = None,
+    response_format: str = "json",
+    timeout: float = 90.0,
+    post: MultipartPostFn = default_multipart_post,
+) -> TranscribeReply:
+    """Dispatch an audio-transcription request (OpenAI ``/audio/transcriptions`` shape)."""
+    base_url = provider.base_url
+    if provider.adapter == "cloudflare" or "{account_id}" in base_url:
+        base_url = base_url.replace("{account_id}", env.get("CLOUDFLARE_ACCOUNT_ID", ""))
+    url = f"{base_url}/audio/transcriptions"
+    headers = {}  # NOTE: no Content-Type — the transport sets the multipart boundary
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    files = {"file": (filename or "audio", audio, "application/octet-stream")}
+    data = {"model": model, "response_format": response_format}
+    if language:
+        data["language"] = language
+    result = post(url, headers, files, data, timeout)
+    if result.status != 200:
+        raise ProviderHTTPError(
+            result.status, _err_message(result), retryable=_retryable(result.status)
+        )
+    body = result.body if isinstance(result.body, dict) else {}
+    text = (body.get("text") if isinstance(body.get("text"), str) else None) or result.text or ""
+    text = text.strip()
+    if not text:
+        raise ProviderHTTPError(502, "empty transcription", retryable=True)
+    usage = body.get("usage") or {}
+    return TranscribeReply(
+        text=text,
+        provider_id=provider.id,
+        model=model,
+        raw=body or {"text": text},
         prompt_tokens=usage.get("prompt_tokens"),
     )
 

--- a/src/freellmpool/config.py
+++ b/src/freellmpool/config.py
@@ -331,6 +331,22 @@ def configured_embedders(
     return [p for p in catalog if p.is_configured(env)]
 
 
+def load_transcribers(path: Path | None = None) -> list[Provider]:
+    """Load the transcriber catalog ([[transcriber]] rows). Same shape as providers —
+    audio→text (Whisper) endpoints on the OpenAI /audio/transcriptions surface."""
+    base_path = path or _PACKAGED_CATALOG
+    with base_path.open("rb") as fh:
+        return _parse_rows(tomllib.load(fh).get("transcriber", []))
+
+
+def configured_transcribers(
+    catalog: list[Provider] | None = None, env: dict[str, str] | None = None
+) -> list[Provider]:
+    catalog = catalog if catalog is not None else load_transcribers()
+    env = env if env is not None else dict(os.environ)
+    return [p for p in catalog if p.is_configured(env)]
+
+
 def load_catalog(path: Path | None = None) -> list[Provider]:
     """Load the full provider catalog (built-ins + user overrides)."""
     base_path = path or _PACKAGED_CATALOG

--- a/src/freellmpool/models.py
+++ b/src/freellmpool/models.py
@@ -89,3 +89,14 @@ class EmbedReply:
     provider_id: str
     model: str
     prompt_tokens: int | None = None
+
+
+@dataclass
+class TranscribeReply:
+    """A normalized audio-transcription (speech→text) result from some provider."""
+
+    text: str
+    provider_id: str
+    model: str
+    raw: dict
+    prompt_tokens: int | None = None

--- a/src/freellmpool/providers.toml
+++ b/src/freellmpool/providers.toml
@@ -550,3 +550,15 @@ models = [
     { name = "nvidia/nv-embedqa-mistral-7b-v2", rpd = 0 },
     { name = "snowflake/arctic-embed-l", rpd = 0 },
 ]
+
+# ── transcribers: audio→text (OpenAI /audio/transcriptions shape). Failover order. ──
+[[transcriber]]
+id = "groq"
+label = "Groq (Whisper)"
+adapter = "openai"
+base_url = "https://api.groq.com/openai/v1"
+key_env = "GROQ_API_KEY"
+models = [
+    { name = "whisper-large-v3-turbo", rpd = 0 },
+    { name = "whisper-large-v3", rpd = 0 },
+]

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -14,6 +14,7 @@ Supported routes:
     GET  /v1/models                 list available (provider/model) ids
     POST /v1/chat/completions       route a chat completion (true token streaming)
     POST /v1/embeddings             pooled free embeddings
+    POST /v1/audio/transcriptions   pooled free audio transcription (Whisper, multipart)
     POST /v1/responses              Responses API shim (Codex CLI / agents)
     POST /v1/messages               Anthropic Messages shim (Claude Code / agents)
     GET  /healthz                   liveness probe
@@ -350,8 +351,17 @@ def make_handler(pool: Pool, api_key: str | None = None):
             is_count = route.endswith("/v1/messages/count_tokens")
             is_messages = not is_count and (route.endswith("/v1/messages") or route == "/messages")
             is_tokenmax = route.endswith("/tokenmax") or route == "/tokenmax"
+            is_transcription = (
+                route.endswith("/v1/audio/transcriptions") or route == "/audio/transcriptions"
+            )
             if not (
-                is_chat or is_responses or is_embeddings or is_messages or is_count or is_tokenmax
+                is_chat
+                or is_responses
+                or is_embeddings
+                or is_messages
+                or is_count
+                or is_tokenmax
+                or is_transcription
             ):
                 self._error(404, f"unknown route {self.path}", "not_found")
                 return
@@ -371,10 +381,20 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 self._error(413, "request body too large", "invalid_request_error")
                 return
             try:
-                raw = self.rfile.read(length) if length else b"{}"
+                raw = self.rfile.read(length) if length else b""
                 if length and len(raw) < length:  # client aborted / truncated body
                     self._error(400, "incomplete request body", "invalid_request_error")
                     return
+            except (OSError, ValueError):
+                self._error(400, "could not read request body", "invalid_request_error")
+                return
+
+            # Audio uploads are multipart/form-data, not JSON — handle before parsing JSON.
+            if is_transcription:
+                self._handle_transcription(raw, self.headers.get("Content-Type", ""))
+                return
+
+            try:
                 req = json.loads(raw or b"{}")
             except (json.JSONDecodeError, ValueError):
                 self._error(400, "invalid JSON body", "invalid_request_error")
@@ -545,6 +565,60 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 self._error(502, str(exc), "all_providers_exhausted")
                 return
             self._send(200, _to_embeddings_response(reply))
+
+        def _handle_transcription(self, raw: bytes, content_type: str) -> None:
+            """OpenAI /audio/transcriptions (multipart): file + model → {text}."""
+            if "multipart/form-data" not in content_type.lower():
+                self._error(
+                    400, "audio transcription requires multipart/form-data", "invalid_request_error"
+                )
+                return
+            try:
+                form = _parse_multipart_form(content_type, raw)
+            except ValueError as exc:
+                self._error(400, f"malformed multipart body: {exc}", "invalid_request_error")
+                return
+            filepart = form.get("file")
+            if not isinstance(filepart, tuple):
+                self._error(400, "'file' part is required", "invalid_request_error")
+                return
+            filename, audio = filepart
+            if not audio:
+                self._error(400, "'file' is empty", "invalid_request_error")
+                return
+            requested = form.get("model") if isinstance(form.get("model"), str) else None
+            language = form.get("language") if isinstance(form.get("language"), str) else None
+            response_format = form.get("response_format")
+            response_format = response_format if isinstance(response_format, str) else "json"
+            # Resolve "auto" / "provider" / "provider/model" against the transcriber providers.
+            provider_filter = None
+            model = None
+            if requested and requested not in ("", "auto"):
+                provider_filter, model = _parse_model(requested, {p.id for p in pool.transcribers})
+            try:
+                reply = pool.transcribe(
+                    audio,
+                    filename,
+                    model=model,
+                    providers=provider_filter,
+                    language=language,
+                    response_format=response_format,
+                )
+            except NoProvidersConfigured as exc:
+                self._error(503, str(exc), "no_providers")
+                return
+            except AllProvidersExhausted as exc:
+                self._error(502, str(exc), "all_providers_exhausted")
+                return
+            if response_format in ("text", "srt", "vtt"):
+                payload = reply.text.encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+            else:
+                self._send(200, _to_transcription_response(reply))
 
         def _resolve(self, req: dict, messages: list[dict], *, tools=None, tool_choice=None):
             """Shared: resolve model/params and call the pool. Returns a Reply or
@@ -845,6 +919,50 @@ def _to_embeddings_response(reply) -> dict:
         },
         "x_freellmpool": {"provider": reply.provider_id, "model": reply.model},
     }
+
+
+def _to_transcription_response(reply) -> dict:
+    return {
+        "text": reply.text,
+        "x_freellmpool": {"provider": reply.provider_id, "model": reply.model},
+    }
+
+
+def _parse_multipart_form(content_type: str, body: bytes) -> dict:
+    """Minimal multipart/form-data parser (stdlib only — ``cgi`` is gone in 3.13).
+
+    Returns ``{name: str}`` for text fields and ``{name: (filename, bytes)}`` for file
+    parts. Raises ``ValueError`` on a missing/garbled boundary."""
+    m = re.search(r'boundary="?([^";]+)"?', content_type, re.IGNORECASE)
+    if not m:
+        raise ValueError("no boundary in Content-Type")
+    boundary = m.group(1).strip().encode("latin-1")
+    # The RFC-2046 inter-part delimiter is CRLF + "--boundary". Anchor on it (rather than a
+    # bare "--boundary") so binary audio bytes that happen to contain "--boundary" can't be
+    # mistaken for a delimiter and silently truncate the upload. Prepend a CRLF so the very
+    # first delimiter (which has no preceding CRLF in the body) matches uniformly.
+    segments = (b"\r\n" + body).split(b"\r\n--" + boundary)
+    # segments[0] is the preamble (normally empty); a well-formed body ends with the closing
+    # "--boundary--", so the LAST segment must begin with "--". Reject truncated/garbled bodies.
+    if len(segments) < 2 or not segments[-1].startswith(b"--"):
+        raise ValueError("missing closing multipart boundary")
+    out: dict = {}
+    for seg in segments[1:-1]:  # drop the preamble and the trailing closing segment
+        seg = seg[2:] if seg.startswith(b"\r\n") else seg  # CRLF terminating the boundary line
+        hdr, sep, payload = seg.partition(b"\r\n\r\n")
+        if not sep:
+            continue
+        headers = hdr.decode("latin-1", "replace")
+        name_m = re.search(r'name="([^"]*)"', headers, re.IGNORECASE)
+        if not name_m:
+            continue
+        name = name_m.group(1)
+        fn_m = re.search(r'filename="([^"]*)"', headers, re.IGNORECASE)
+        if fn_m is not None:
+            out[name] = (fn_m.group(1), payload)  # file part → raw bytes
+        else:
+            out[name] = payload.decode("utf-8", "replace")  # text field
+    return out
 
 
 def _to_openai_response(reply) -> dict:

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -17,13 +17,22 @@ from dataclasses import dataclass
 from . import client as _client
 from .cache import Cache
 from .capability import capability_table, fit_penalty, model_capability, prompt_difficulty
-from .client import PostFn, StreamPostFn, default_post, default_stream_post
+from .client import (
+    MultipartPostFn,
+    PostFn,
+    StreamPostFn,
+    default_multipart_post,
+    default_post,
+    default_stream_post,
+)
 from .config import (
     configured_embedders,
     configured_providers,
+    configured_transcribers,
     effective_env,
     load_catalog,
     load_embedders,
+    load_transcribers,
     settings,
 )
 from .context import context_limit_from_error, estimate_input_tokens
@@ -34,7 +43,7 @@ from .errors import (
     ProviderHTTPError,
 )
 from .metrics import Metrics
-from .models import EmbedReply, Provider, Reply
+from .models import EmbedReply, Provider, Reply, TranscribeReply
 from .observe import EventHook, emit
 from .quota import QuotaStore
 from .stats import StatsStore
@@ -112,7 +121,9 @@ class Pool:
         cooldown_seconds: float = 60.0,
         clock: Callable[[], float] | None = None,
         embedders: list[Provider] | None = None,
+        transcribers: list[Provider] | None = None,
         stream_post: StreamPostFn = default_stream_post,
+        transcribe_post: MultipartPostFn = default_multipart_post,
         cache: Cache | None = None,
         metrics: Metrics | None = None,
         routing: str = "fair",
@@ -121,6 +132,8 @@ class Pool:
     ):
         self.providers = providers
         self.embedders = embedders or []
+        self.transcribers = transcribers or []
+        self._transcribe_post = transcribe_post
         self.quota = quota or QuotaStore()
         self.env = env if env is not None else dict(os.environ)
         self._post = post
@@ -273,6 +286,7 @@ class Pool:
         catalog = list(by_id.values())
         providers = configured_providers(catalog, env)
         embedders = configured_embedders(load_embedders(), env)
+        transcribers = configured_transcribers(load_transcribers(), env)
         cfg = settings(env)
         cooldown = float(cfg.get("cooldown_seconds", 60.0))
         ttl = float(env.get("FREELLMPOOL_CACHE_TTL") or cfg.get("cache_ttl", 0) or 0)
@@ -285,6 +299,7 @@ class Pool:
             post=post,
             cooldown_seconds=cooldown,
             embedders=embedders,
+            transcribers=transcribers,
             cache=cache,
             routing=routing,
             on_event=on_event,
@@ -332,6 +347,53 @@ class Pool:
                 self.quota.record(emb.id, m.name)
                 self._bump_stats(requests=1, prompt_tokens=reply.prompt_tokens or 0)
                 return reply
+        raise AllProvidersExhausted(attempts)
+
+    def transcribe(
+        self,
+        audio: bytes,
+        filename: str,
+        *,
+        model: str | None = None,
+        providers: Iterable[str] | None = None,
+        language: str | None = None,
+        response_format: str = "json",
+        timeout: float = 90.0,
+    ) -> TranscribeReply:
+        """Transcribe audio→text, failing over across configured transcribers (Whisper)."""
+        if not self.transcribers:
+            raise NoProvidersConfigured(
+                "no transcriber configured; set a key for one of: groq (see docs/ACCOUNTS.md)"
+            )
+        include = {p.strip() for p in providers} if providers else None
+        attempts: list[tuple[str, str]] = []
+        for tr in self.transcribers:
+            if include is not None and tr.id not in include:
+                continue
+            for m in tr.models:
+                if model is not None and m.name != model:
+                    continue
+                try:
+                    reply = _client.transcribe(
+                        tr,
+                        m.name,
+                        audio,
+                        filename,
+                        api_key=tr.api_key(self.env),
+                        env=self.env,
+                        language=language,
+                        response_format=response_format,
+                        timeout=timeout,
+                        post=self._transcribe_post,
+                    )
+                except Exception as exc:  # noqa: BLE001 — try the next transcriber
+                    attempts.append((f"{tr.id}/{m.name}", f"{type(exc).__name__}: {exc}"))
+                    continue
+                self.quota.record(tr.id, m.name)
+                self._bump_stats(requests=1, prompt_tokens=reply.prompt_tokens or 0)
+                return reply
+        if not attempts:  # provider/model pins matched no configured transcriber
+            raise NoProvidersConfigured("no candidate transcriber/model matched the given filters")
         raise AllProvidersExhausted(attempts)
 
     # ---- candidate ordering -------------------------------------------

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -638,6 +638,131 @@ def test_header_routing_override_accepted(server):
     assert "x_freellmpool" in body
 
 
+def test_parse_multipart_form_unit():
+    from freellmpool.proxy import _parse_multipart_form
+
+    ct = "multipart/form-data; boundary=XB"
+    body = (
+        b'--XB\r\nContent-Disposition: form-data; name="model"\r\n\r\nm1\r\n'
+        b'--XB\r\nContent-Disposition: form-data; name="file"; filename="a.wav"\r\n'
+        b"Content-Type: audio/wav\r\n\r\nAUDIO\x00\x01\r\n--XB--\r\n"
+    )
+    f = _parse_multipart_form(ct, body)
+    assert f["model"] == "m1"
+    assert f["file"] == ("a.wav", b"AUDIO\x00\x01")  # binary bytes preserved
+
+
+def test_parse_multipart_form_binary_safe_embedded_boundary():
+    # Audio bytes that contain "--XB" (NOT preceded by CRLF) must NOT be treated as a
+    # delimiter — the payload must survive intact.
+    from freellmpool.proxy import _parse_multipart_form
+
+    audio = b"PRE--XB-and-more\x00\xff"
+    ct = "multipart/form-data; boundary=XB"
+    body = (
+        b'--XB\r\nContent-Disposition: form-data; name="file"; filename="a.wav"\r\n\r\n'
+        + audio
+        + b"\r\n--XB--\r\n"
+    )
+    f = _parse_multipart_form(ct, body)
+    assert f["file"] == ("a.wav", audio)
+
+
+def test_parse_multipart_form_missing_closing_boundary_raises():
+    from freellmpool.proxy import _parse_multipart_form
+
+    ct = "multipart/form-data; boundary=XB"
+    # no trailing "--XB--"
+    body = b'--XB\r\nContent-Disposition: form-data; name="file"; filename="a.wav"\r\n\r\nAUDIO'
+    with pytest.raises(ValueError, match="closing"):
+        _parse_multipart_form(ct, body)
+
+
+def _multipart_audio(boundary, audio, model="whisper-large-v3-turbo", with_file=True):
+    parts = [
+        f'--{boundary}\r\nContent-Disposition: form-data; name="model"\r\n\r\n{model}\r\n'.encode()
+    ]
+    if with_file:
+        parts.append(
+            f'--{boundary}\r\nContent-Disposition: form-data; name="file"; filename="a.wav"\r\n'
+            f"Content-Type: audio/wav\r\n\r\n".encode()
+            + audio
+            + b"\r\n"
+        )
+    parts.append(f"--{boundary}--\r\n".encode())
+    return b"".join(parts)
+
+
+def _transcribe_server(providers, env, quota, text="the transcript"):
+    from freellmpool.client import HTTPResult
+    from freellmpool.models import Model, Provider
+
+    tr = [
+        Provider(
+            id="groq",
+            label="Groq",
+            adapter="openai",
+            base_url="https://api.groq.com/openai/v1",
+            key_env="GROQ_API_KEY",
+            models=(Model("whisper-large-v3-turbo"),),
+        )
+    ]
+
+    def fake_mp(url, headers, files, data, timeout):
+        assert url.endswith("/audio/transcriptions")
+        assert files["file"][0] == "a.wav"
+        return HTTPResult(status=200, body={"text": text}, text=text)
+
+    pool = Pool(
+        providers,
+        quota=quota,
+        env={**env, "GROQ_API_KEY": "x"},
+        post=make_post({}),
+        stream_post=make_stream_post({}),
+        transcribers=tr,
+        transcribe_post=fake_mp,
+    )
+    httpd = serve(pool, host="127.0.0.1", port=0)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    return httpd, f"http://127.0.0.1:{httpd.server_address[1]}"
+
+
+def test_audio_transcription_route(providers, env, quota):
+    httpd, base = _transcribe_server(providers, env, quota)
+    try:
+        body = _multipart_audio("BOUND1", b"RIFF\x00fakeaudio")
+        req = urllib.request.Request(
+            base + "/v1/audio/transcriptions",
+            data=body,
+            headers={"Content-Type": "multipart/form-data; boundary=BOUND1"},
+        )
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            d = json.load(resp)
+        assert d["text"] == "the transcript"
+        assert d["x_freellmpool"]["provider"] == "groq"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def test_audio_transcription_missing_file_400(providers, env, quota):
+    httpd, base = _transcribe_server(providers, env, quota)
+    try:
+        body = _multipart_audio("BOUND1", b"", with_file=False)
+        req = urllib.request.Request(
+            base + "/v1/audio/transcriptions",
+            data=body,
+            headers={"Content-Type": "multipart/form-data; boundary=BOUND1"},
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            urllib.request.urlopen(req)  # noqa: S310
+        assert exc.value.code == 400
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
 def _post_json_with_headers(url, payload, headers):
     req = urllib.request.Request(
         url,

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,0 +1,134 @@
+"""Pooled audio transcription: catalog, client.transcribe, Pool.transcribe, failover."""
+
+from __future__ import annotations
+
+import pytest
+
+from freellmpool import client as C
+from freellmpool.config import configured_transcribers, load_transcribers
+from freellmpool.errors import AllProvidersExhausted, NoProvidersConfigured
+from freellmpool.models import Model, Provider
+from freellmpool.router import Pool
+
+
+def _transcriber(tid: str, key_env: str) -> Provider:
+    return Provider(
+        id=tid,
+        label=tid,
+        adapter="openai",
+        base_url=f"https://{tid}.test/v1",
+        key_env=key_env,
+        models=(Model("whisper-large-v3-turbo"),),
+    )
+
+
+def test_transcriber_catalog_loads():
+    cat = load_transcribers()
+    ids = {t.id for t in cat}
+    assert "groq" in ids
+    for t in cat:
+        assert t.base_url.startswith("https://")
+        assert t.models
+
+
+def test_configured_transcribers_filter():
+    cat = load_transcribers()
+    got = {t.id for t in configured_transcribers(cat, {"GROQ_API_KEY": "x"})}
+    assert got == {"groq"}
+    assert configured_transcribers(cat, {}) == []  # no key → nothing configured
+
+
+def test_client_transcribe_shape():
+    def post(url, headers, files, data, timeout):
+        assert url.endswith("/audio/transcriptions")
+        assert files["file"][0] == "a.wav"
+        assert files["file"][1] == b"AUDIO"
+        assert data["model"] == "whisper-large-v3-turbo"
+        assert headers["Authorization"] == "Bearer k"
+        return C.HTTPResult(200, {"text": "hello world"}, "")
+
+    t = _transcriber("groq", "GROQ_API_KEY")
+    reply = C.transcribe(
+        t, "whisper-large-v3-turbo", b"AUDIO", "a.wav", api_key="k", env={}, post=post
+    )
+    assert reply.text == "hello world"
+    assert reply.provider_id == "groq"
+
+
+def test_client_transcribe_text_format_plain_body():
+    def post(url, headers, files, data, timeout):
+        # response_format=text → transport returns plain text body
+        return C.HTTPResult(200, {"text": "plain transcript"}, "plain transcript")
+
+    t = _transcriber("groq", "GROQ_API_KEY")
+    reply = C.transcribe(
+        t,
+        "whisper-large-v3-turbo",
+        b"A",
+        "a.wav",
+        api_key="k",
+        env={},
+        response_format="text",
+        post=post,
+    )
+    assert reply.text == "plain transcript"
+
+
+def test_pool_transcribe_failover():
+    def post(url, headers, files, data, timeout):
+        if "alpha.test" in url:
+            return C.HTTPResult(429, {"error": {"message": "rl"}}, "")
+        return C.HTTPResult(200, {"text": "ok"}, "")
+
+    transcribers = [_transcriber("alpha", "A_KEY"), _transcriber("beta", "B_KEY")]
+    pool = Pool(
+        [], env={"A_KEY": "a", "B_KEY": "b"}, transcribers=transcribers, transcribe_post=post
+    )
+    reply = pool.transcribe(b"AUDIO", "a.wav")
+    assert reply.provider_id == "beta"  # alpha 429 → failover
+    assert reply.text == "ok"
+
+
+def test_pool_transcribe_provider_pin():
+    def post(url, headers, files, data, timeout):
+        return C.HTTPResult(200, {"text": url}, "")
+
+    transcribers = [_transcriber("alpha", "A_KEY"), _transcriber("beta", "B_KEY")]
+    pool = Pool(
+        [], env={"A_KEY": "a", "B_KEY": "b"}, transcribers=transcribers, transcribe_post=post
+    )
+    reply = pool.transcribe(b"AUDIO", "a.wav", providers=["beta"])
+    assert reply.provider_id == "beta"
+    assert "beta.test" in reply.text
+
+
+def test_pool_transcribe_no_transcribers_raises():
+    pool = Pool([], env={}, transcribers=[])
+    with pytest.raises(NoProvidersConfigured):
+        pool.transcribe(b"AUDIO", "a.wav")
+
+
+def test_pool_transcribe_unknown_pin_raises_no_providers():
+    # pinning a provider/model that matches nothing must be NoProvidersConfigured (→ 503),
+    # not AllProvidersExhausted([]) (→ 502).
+    def post(url, headers, files, data, timeout):
+        return C.HTTPResult(200, {"text": "ok"}, "")
+
+    pool = Pool(
+        [], env={"A_KEY": "a"}, transcribers=[_transcriber("alpha", "A_KEY")], transcribe_post=post
+    )
+    with pytest.raises(NoProvidersConfigured):
+        pool.transcribe(b"AUDIO", "a.wav", providers=["nonexistent"])
+    with pytest.raises(NoProvidersConfigured):
+        pool.transcribe(b"AUDIO", "a.wav", model="no-such-model")
+
+
+def test_pool_transcribe_all_fail_raises():
+    def post(url, headers, files, data, timeout):
+        return C.HTTPResult(500, {}, "")
+
+    pool = Pool(
+        [], env={"A_KEY": "a"}, transcribers=[_transcriber("alpha", "A_KEY")], transcribe_post=post
+    )
+    with pytest.raises(AllProvidersExhausted):
+        pool.transcribe(b"AUDIO", "a.wav")


### PR DESCRIPTION
## What

Adds pooled **audio transcription** (speech→text) to freellmpool via an OpenAI-compatible
`POST /v1/audio/transcriptions` endpoint, failing over across transcription providers.
First provider: **Groq Whisper** (`whisper-large-v3-turbo`, `whisper-large-v3`).

The design mirrors the existing **embeddings** architecture end-to-end. The one new wrinkle
is the request is `multipart/form-data` (a file upload), so the stdlib proxy parses it itself
(`cgi` is gone in Python 3.13).

## Changes

- **catalog/config** — `[[transcriber]]` rows in `providers.toml` + `load_transcribers` /
  `configured_transcribers`.
- **model/client** — `TranscribeReply`; `client.transcribe` + `default_multipart_post`
  (multipart upload; **streams + caps the response** like `default_post` so a broken/slow-drip
  provider can't OOM or pin a worker).
- **router** — `Pool.transcribe` + `.transcribers` + injectable `transcribe_post`;
  `from_default_config` wires `configured_transcribers`.
- **proxy** — `POST /v1/audio/transcriptions` (+ `/audio/transcriptions`), auth-gated, with a
  stdlib `_parse_multipart_form`; binary body branches **before** `json.loads`; returns
  `{"text": …}` JSON or `text/plain` for `response_format=text`.

## Correctness / safety

- Multipart parser is **binary-safe** — anchors delimiters on `CRLF + --boundary` so audio
  bytes that happen to contain the boundary can't truncate the upload — and **requires a
  closing delimiter** (else 400).
- Non-dict JSON error bodies coerced so error mapping can't crash.
- Unmatched provider/model pins → `NoProvidersConfigured` (503), not
  `AllProvidersExhausted` (502).

## Tests

13 new tests: parser unit (incl. binary-safety + missing-boundary), proxy endpoint +
missing-file 400, client/router failover + pinning + none-configured. Full suite green
(`pytest -q`), `ruff` clean.

Codex-reviewed over 2 rounds — all 5 findings resolved (binary-safe parser, closing-delimiter
requirement, response cap/deadline, non-dict body coercion, pin→`NoProvidersConfigured`).

## Out of scope (v1)

`/v1/audio/translations`, `srt`/`vtt`/`verbose_json` formats, streaming transcription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add pooled audio transcription support with an OpenAI-compatible /v1/audio/transcriptions endpoint, including catalog wiring, router integration, and safe multipart handling.

New Features:
- Introduce audio transcription pooling over Whisper-compatible providers via a new /v1/audio/transcriptions HTTP endpoint.
- Add a client-side transcribe API and multipart POST transport for audio uploads.
- Extend configuration to support a dedicated transcriber catalog with Groq Whisper as the initial backend.

Bug Fixes:
- Ensure provider/model pins that match no transcriber raise NoProvidersConfigured (503) instead of AllProvidersExhausted (502).

Enhancements:
- Implement a binary-safe, stdlib-only multipart/form-data parser for handling uploaded audio files.
- Wire transcriber providers into the Pool router with failover, provider pinning, and usage accounting for transcription requests.
- Normalize transcription responses into a TranscribeReply model and a consistent proxy JSON/text response shape.
- Harden HTTP response handling for transcription by capping streamed response size and enforcing a deadline, while tolerating non-dict JSON bodies.

Tests:
- Add unit tests for multipart parsing correctness, including binary safety and missing closing boundary handling.
- Add proxy-level tests for the /v1/audio/transcriptions route, including missing file validation.
- Add client and router tests covering transcriber catalog loading, configuration filtering, transcribe shape, failover, provider pinning, and error paths for no/failed transcribers.