### PR TITLE
docs: document audio transcription endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ print(client.chat.completions.create(
     model="auto",
     messages=[{"role": "user", "content": "hi"}],
 ).choices[0].message.content)
+
+# audio → text (Whisper), same client:
+print(client.audio.transcriptions.create(
+    model="auto", file=open("audio.mp3", "rb"),
+).text)
+```
+
+Or with `curl` (multipart upload):
+
+```bash
+curl -s http://localhost:8080/v1/audio/transcriptions \
+  -F file=@audio.mp3 -F model=auto
 ```
 
 The proxy also implements the OpenAI Responses API (for the Codex CLI) and the
@@ -138,7 +150,8 @@ freellmpool code aider       # also: claude, codex, cline, continue, cursor, ope
 ```
 
 Endpoints: `/v1/chat/completions` (token streaming, tool calling), `/v1/embeddings`,
-`/v1/responses`, `/v1/messages`, `/v1/models`, and a `/dashboard` page showing usage.
+`/v1/audio/transcriptions` (Whisper, multipart upload), `/v1/responses`, `/v1/messages`,
+`/v1/models`, and a `/dashboard` page showing usage.
 Setup snippets for specific tools are in [docs/INTEGRATIONS.md](docs/INTEGRATIONS.md)
 and [docs/AGENTS.md](docs/AGENTS.md).
 
@@ -152,6 +165,9 @@ reply = pool.ask("Summarize the plot of Hamlet in 20 words.")
 print(reply.text, "—", reply.provider_id)
 
 vectors = pool.embed(["first document", "second document"]).vectors
+
+with open("audio.mp3", "rb") as f:
+    text = pool.transcribe(f.read(), "audio.mp3").text   # Whisper, failover across providers
 ```
 
 Async is the same API with `await`:

--- a/docs/ACCOUNTS.md
+++ b/docs/ACCOUNTS.md
@@ -24,6 +24,9 @@ shell or put it in a `.env` file (copy [`.env.example`](../.env.example)).
 2. Click **Create API Key**, name it anything, copy the value (`gsk_...`).
 3. `export GROQ_API_KEY=gsk_...`
 
+   The same key also powers free **audio transcription** (Whisper) via
+   `/v1/audio/transcriptions`.
+
 ### Cerebras — *~1 min, no card*
 1. Go to <https://cloud.cerebras.ai> and sign in.
 2. Open **API Keys** → **Generate key**, copy it (`csk-...`).

--- a/docs/index.html
+++ b/docs/index.html
@@ -129,7 +129,7 @@ immediately. Add free keys for the other 14 providers to unlock more models and 
 <h3>Which free LLM providers does it support?</h3>
 <p>16 providers: Pollinations, OVHcloud, LLM7, Groq, Cerebras, NVIDIA NIM, OpenRouter, Google Gemini,
 GitHub Models, Cloudflare Workers AI, Mistral, Cohere, SambaNova, Z.ai/Zhipu, Ollama Cloud, and
-LongCat — 235 live-validated chat models, plus free embeddings.</p>
+LongCat — 235 live-validated chat models, plus free embeddings and audio transcription (Whisper).</p>
 
 <h3>How do I know which free providers are usable right now?</h3>
 <p>Run <code>freellmpool capacity status</code>: it labels each provider <code>healthy</code>,


### PR DESCRIPTION
Follow-up to #27. Documents the new `/v1/audio/transcriptions` (Whisper) endpoint where embeddings is documented.

- **README**: endpoints list, library example (`pool.transcribe`), proxy example (OpenAI SDK `audio.transcriptions` + `curl` multipart).
- **docs/ACCOUNTS.md**: note the Groq key also powers free Whisper transcription.
- **docs/index.html**: mention transcription in the capabilities FAQ.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the new /v1/audio/transcriptions (Whisper) endpoint across user-facing docs and examples.

Documentation:
- Add README examples for audio-to-text transcription using the OpenAI SDK client and curl multipart uploads.
- List the /v1/audio/transcriptions Whisper endpoint in the documented proxy endpoints.
- Note in ACCOUNTS docs that the Groq API key also enables free Whisper audio transcription via /v1/audio/transcriptions.
- Update the docs index FAQ to mention audio transcription (Whisper) alongside free embeddings in supported capabilities.