### PR TITLE
transcriber: add Mistral (Voxtral) as a free failover for Groq Whisper

### DIFF
--- a/docs/ACCOUNTS.md
+++ b/docs/ACCOUNTS.md
@@ -56,6 +56,9 @@ That's enough to start. Run `freellmpool ask "hello"`.
 1. <https://console.mistral.ai/api-keys> → **Create new key**.
 2. `export MISTRAL_API_KEY=...`
 
+   Also gives free **audio transcription** (Voxtral) — a failover for Groq's
+   Whisper on `/v1/audio/transcriptions`.
+
 ### Cohere — *free trial keys*
 1. <https://dashboard.cohere.com/api-keys> → copy your **Trial key**.
 2. `export COHERE_API_KEY=...`

--- a/src/freellmpool/providers.toml
+++ b/src/freellmpool/providers.toml
@@ -562,3 +562,13 @@ models = [
     { name = "whisper-large-v3-turbo", rpd = 0 },
     { name = "whisper-large-v3", rpd = 0 },
 ]
+
+[[transcriber]]
+id = "mistral"
+label = "Mistral (Voxtral)"
+adapter = "openai"
+base_url = "https://api.mistral.ai/v1"
+key_env = "MISTRAL_API_KEY"
+models = [
+    { name = "voxtral-mini-latest", rpd = 0 },
+]

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -24,8 +24,11 @@ def _transcriber(tid: str, key_env: str) -> Provider:
 
 def test_transcriber_catalog_loads():
     cat = load_transcribers()
-    ids = {t.id for t in cat}
-    assert "groq" in ids
+    ids = [t.id for t in cat]
+    # Groq (Whisper) + Mistral (Voxtral); catalog order IS failover order (Pool.transcribe
+    # iterates the list), so assert Groq precedes Mistral, not just membership.
+    assert "groq" in ids and "mistral" in ids
+    assert ids.index("groq") < ids.index("mistral")
     for t in cat:
         assert t.base_url.startswith("https://")
         assert t.models
@@ -34,7 +37,11 @@ def test_transcriber_catalog_loads():
 def test_configured_transcribers_filter():
     cat = load_transcribers()
     got = {t.id for t in configured_transcribers(cat, {"GROQ_API_KEY": "x"})}
-    assert got == {"groq"}
+    assert got == {"groq"}  # only providers whose key is set are configured
+    both = {
+        t.id for t in configured_transcribers(cat, {"GROQ_API_KEY": "x", "MISTRAL_API_KEY": "y"})
+    }
+    assert {"groq", "mistral"} <= both
     assert configured_transcribers(cat, {}) == []  # no key → nothing configured
 
 


### PR DESCRIPTION
## What

Groq was the only audio-transcription provider (#27). This adds **Mistral Voxtral** (`voxtral-mini-latest`) as a second `[[transcriber]]`, so `/v1/audio/transcriptions` now fails over across **two free, already-configured providers**.

Both speak the OpenAI `/audio/transcriptions` multipart shape, so there's **no new code** — just a catalog row + a test + a docs note.

## Verification (live, end-to-end through the proxy)

A real speech clip (JFK, 11s) transcribed correctly by **both**:
- `groq/whisper-large-v3-turbo` → ✅ HTTP 200, correct text
- `mistral/voxtral-mini-latest` → ✅ HTTP 200, correct text
- `auto` → routes Groq-first per catalog/failover order

## Provider survey

| Provider | OpenAI `/audio/transcriptions` | Free for us | Verdict |
|---|---|---|---|
| Groq (Whisper) | ✅ | ✅ | shipped (#27) |
| **Mistral (Voxtral)** | ✅ | ✅ (existing key) | **added here** |
| SambaNova (Whisper-large-v3) | ✅ | ❌ now `402 PAYMENT_METHOD_REQUIRED` | skipped |

Tests pass (`pytest -q`), `ruff` clean. Codex-reviewed (catalog loads correctly; test now asserts failover order, not just membership).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Mistral Voxtral as a secondary audio transcription provider and ensure catalog ordering reflects failover behavior.

New Features:
- Introduce Mistral (Voxtral) as an additional OpenAI-compatible audio transcription provider alongside Groq Whisper.

Enhancements:
- Enforce transcriber catalog ordering in tests so Groq is tried before Mistral for failover.
- Extend configured transcriber tests to cover multiple-provider configuration behavior.

Documentation:
- Document that Mistral now also provides free audio transcription as a failover for Groq in the accounts setup guide.