### PR TITLE
transcription: Voxtral-first default + multipart/empty/cap/format fixes

### DIFF
--- a/src/freellmpool/client.py
+++ b/src/freellmpool/client.py
@@ -612,16 +612,21 @@ def transcribe(
             result.status, _err_message(result), retryable=_retryable(result.status)
         )
     body = result.body if isinstance(result.body, dict) else {}
-    text = (body.get("text") if isinstance(body.get("text"), str) else None) or result.text or ""
-    text = text.strip()
-    if not text:
-        raise ProviderHTTPError(502, "empty transcription", retryable=True)
+    raw_text = body.get("text")
+    # `default_multipart_post` always lands the transcript under body["text"] (plain-text
+    # responses too), so a missing/non-string text field means a malformed response — retry
+    # another provider rather than passing a raw JSON blob through as the transcript.
+    if not isinstance(raw_text, str):
+        raise ProviderHTTPError(502, "malformed transcription response (no text)", retryable=True)
+    # A present `text` field is a successful result — an empty string means the clip was silent,
+    # NOT a failure. Returning "" avoids needless failover/exhaustion for legitimately silent audio.
+    text = raw_text.strip()
     usage = body.get("usage") or {}
     return TranscribeReply(
         text=text,
         provider_id=provider.id,
         model=model,
-        raw=body or {"text": text},
+        raw=body,
         prompt_tokens=usage.get("prompt_tokens"),
     )
 

--- a/src/freellmpool/providers.toml
+++ b/src/freellmpool/providers.toml
@@ -552,17 +552,9 @@ models = [
 ]
 
 # ── transcribers: audio→text (OpenAI /audio/transcriptions shape). Failover order. ──
-[[transcriber]]
-id = "groq"
-label = "Groq (Whisper)"
-adapter = "openai"
-base_url = "https://api.groq.com/openai/v1"
-key_env = "GROQ_API_KEY"
-models = [
-    { name = "whisper-large-v3-turbo", rpd = 0 },
-    { name = "whisper-large-v3", rpd = 0 },
-]
-
+# Quality-first order from a local WER smoke test (5 known-speech clips, 2026-06-08): Voxtral
+# was most accurate (WER 0.024), then whisper-large-v3 (0.070), then -turbo (0.062, fastest).
+# `auto` walks this list top-down, so the most accurate model is the default.
 [[transcriber]]
 id = "mistral"
 label = "Mistral (Voxtral)"
@@ -571,4 +563,15 @@ base_url = "https://api.mistral.ai/v1"
 key_env = "MISTRAL_API_KEY"
 models = [
     { name = "voxtral-mini-latest", rpd = 0 },
+]
+
+[[transcriber]]
+id = "groq"
+label = "Groq (Whisper)"
+adapter = "openai"
+base_url = "https://api.groq.com/openai/v1"
+key_env = "GROQ_API_KEY"
+models = [
+    { name = "whisper-large-v3", rpd = 0 },
+    { name = "whisper-large-v3-turbo", rpd = 0 },
 ]

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -44,6 +44,12 @@ from .router import Pool
 from .savings import usd_saved
 
 _MAX_BODY = 16 * 1024 * 1024  # 16 MB cap on request bodies
+# Audio uploads are larger than JSON; Groq's free tier accepts up to 25 MB, so cap audio
+# multipart bodies there rather than at the JSON limit (a valid 20 MB clip must not 413).
+_MAX_AUDIO_BODY = 25 * 1024 * 1024
+# response_format values we forward. srt/vtt aren't accepted by Groq/Mistral's transcription
+# endpoints (they'd fail upstream and surface as a confusing 502), so reject them up front.
+_TRANSCRIPTION_FORMATS = ("json", "text", "verbose_json")
 
 
 def _model_ids(pool: Pool) -> list[str]:
@@ -377,7 +383,8 @@ def make_handler(pool: Pool, api_key: str | None = None):
             if length < 0:
                 self._error(400, "invalid Content-Length header", "invalid_request_error")
                 return
-            if length > _MAX_BODY:
+            max_body = _MAX_AUDIO_BODY if is_transcription else _MAX_BODY
+            if length > max_body:
                 self._error(413, "request body too large", "invalid_request_error")
                 return
             try:
@@ -590,6 +597,14 @@ def make_handler(pool: Pool, api_key: str | None = None):
             language = form.get("language") if isinstance(form.get("language"), str) else None
             response_format = form.get("response_format")
             response_format = response_format if isinstance(response_format, str) else "json"
+            if response_format not in _TRANSCRIPTION_FORMATS:
+                self._error(
+                    400,
+                    f"unsupported response_format '{response_format}'; use one of "
+                    f"{', '.join(_TRANSCRIPTION_FORMATS)}",
+                    "invalid_request_error",
+                )
+                return
             # Resolve "auto" / "provider" / "provider/model" against the transcriber providers.
             provider_filter = None
             model = None
@@ -610,7 +625,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
             except AllProvidersExhausted as exc:
                 self._error(502, str(exc), "all_providers_exhausted")
                 return
-            if response_format in ("text", "srt", "vtt"):
+            if response_format == "text":
                 payload = reply.text.encode("utf-8")
                 self.send_response(200)
                 self.send_header("Content-Type", "text/plain; charset=utf-8")
@@ -953,7 +968,10 @@ def _parse_multipart_form(content_type: str, body: bytes) -> dict:
         if not sep:
             continue
         headers = hdr.decode("latin-1", "replace")
-        name_m = re.search(r'name="([^"]*)"', headers, re.IGNORECASE)
+        # Negative lookbehind for a letter so this matches the `name=` parameter but NOT the
+        # `name` inside `filename=` — otherwise a part with only a filename would be accepted
+        # as a named field (and could masquerade as the required `file` field).
+        name_m = re.search(r'(?<![A-Za-z])name="([^"]*)"', headers, re.IGNORECASE)
         if not name_m:
             continue
         name = name_m.group(1)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -668,6 +668,22 @@ def test_parse_multipart_form_binary_safe_embedded_boundary():
     assert f["file"] == ("a.wav", audio)
 
 
+def test_parse_multipart_form_filename_not_mistaken_for_name():
+    # A part with ONLY filename= (no name=) must NOT be parsed as a named field — the `name`
+    # inside `filename=` must not match the name= parameter.
+    from freellmpool.proxy import _parse_multipart_form
+
+    ct = "multipart/form-data; boundary=XB"
+    body = (
+        b'--XB\r\nContent-Disposition: form-data; filename="file"\r\n\r\nDATA\r\n'
+        b'--XB\r\nContent-Disposition: form-data; name="file"; filename="a.wav"\r\n\r\nAUDIO\r\n'
+        b"--XB--\r\n"
+    )
+    f = _parse_multipart_form(ct, body)
+    # the real file part wins; the no-name part is skipped (not stored under "file")
+    assert f["file"] == ("a.wav", b"AUDIO")
+
+
 def test_parse_multipart_form_missing_closing_boundary_raises():
     from freellmpool.proxy import _parse_multipart_form
 
@@ -754,6 +770,32 @@ def test_audio_transcription_missing_file_400(providers, env, quota):
             base + "/v1/audio/transcriptions",
             data=body,
             headers={"Content-Type": "multipart/form-data; boundary=BOUND1"},
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            urllib.request.urlopen(req)  # noqa: S310
+        assert exc.value.code == 400
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def test_audio_transcription_unsupported_format_400(providers, env, quota):
+    # srt/vtt aren't accepted upstream — the proxy must reject them with 400, not 502.
+    httpd, base = _transcribe_server(providers, env, quota)
+    try:
+        b = "BOUND1"
+        body = (
+            f'--{b}\r\nContent-Disposition: form-data; name="model"\r\n\r\nwhisper-large-v3-turbo\r\n'
+            f'--{b}\r\nContent-Disposition: form-data; name="response_format"\r\n\r\nsrt\r\n'
+            f'--{b}\r\nContent-Disposition: form-data; name="file"; filename="a.wav"\r\n'
+            f"Content-Type: audio/wav\r\n\r\n".encode()
+            + b"RIFF\x00fake"
+            + f"\r\n--{b}--\r\n".encode()
+        )
+        req = urllib.request.Request(
+            base + "/v1/audio/transcriptions",
+            data=body,
+            headers={"Content-Type": f"multipart/form-data; boundary={b}"},
         )
         with pytest.raises(urllib.error.HTTPError) as exc:
             urllib.request.urlopen(req)  # noqa: S310

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -25,10 +25,14 @@ def _transcriber(tid: str, key_env: str) -> Provider:
 def test_transcriber_catalog_loads():
     cat = load_transcribers()
     ids = [t.id for t in cat]
-    # Groq (Whisper) + Mistral (Voxtral); catalog order IS failover order (Pool.transcribe
-    # iterates the list), so assert Groq precedes Mistral, not just membership.
     assert "groq" in ids and "mistral" in ids
-    assert ids.index("groq") < ids.index("mistral")
+    # Catalog order IS failover/`auto` order (Pool.transcribe iterates the list). Quality-first
+    # per the WER smoke test: Mistral Voxtral (most accurate) precedes Groq Whisper.
+    assert ids.index("mistral") < ids.index("groq")
+    # Within Groq, whisper-large-v3 precedes -turbo (quality-first).
+    groq = next(t for t in cat if t.id == "groq")
+    gm = [m.name for m in groq.models]
+    assert gm.index("whisper-large-v3") < gm.index("whisper-large-v3-turbo")
     for t in cat:
         assert t.base_url.startswith("https://")
         assert t.models
@@ -79,6 +83,31 @@ def test_client_transcribe_text_format_plain_body():
         post=post,
     )
     assert reply.text == "plain transcript"
+
+
+def test_client_transcribe_empty_text_is_success_not_failover():
+    # Silent audio → {"text": ""} on HTTP 200 is a VALID (empty) transcription, not an error.
+    # It must return "" rather than raise (which would force needless failover/exhaustion).
+    def post(url, headers, files, data, timeout):
+        return C.HTTPResult(200, {"text": ""}, "")
+
+    t = _transcriber("groq", "GROQ_API_KEY")
+    reply = C.transcribe(t, "whisper-large-v3", b"AUDIO", "a.wav", api_key="k", env={}, post=post)
+    assert reply.text == ""
+    assert reply.provider_id == "groq"
+
+
+def test_client_transcribe_no_text_field_raises():
+    # A 200 JSON dict with no text field is malformed → retryable error (drives failover),
+    # even when the raw response body text is non-empty (must NOT pass raw JSON as a transcript).
+    from freellmpool.errors import ProviderHTTPError
+
+    def post(url, headers, files, data, timeout):
+        return C.HTTPResult(200, {"unexpected": "shape"}, '{"unexpected":"shape"}')
+
+    t = _transcriber("groq", "GROQ_API_KEY")
+    with pytest.raises(ProviderHTTPError):
+        C.transcribe(t, "whisper-large-v3", b"AUDIO", "a.wav", api_key="k", env={}, post=post)
 
 
 def test_pool_transcribe_failover():


### PR DESCRIPTION
Default-order + correctness pass over the transcription feature (#27/#29), informed by the podcast backend's local WER smoke test (2026-06-08) and a Codex bug sweep.

## Reorder — default to the most accurate model first
The podcast backend's WER probe (5 known-speech clips) ranked Voxtral most accurate. The catalog `auto`/failover order now matches:

| Model | WER | latency |
|---|---:|---:|
| `mistral/voxtral-mini-latest` | 0.024 | 0.493s |
| `groq/whisper-large-v3` | 0.070 | 0.283s |
| `groq/whisper-large-v3-turbo` | 0.062 | 0.255s |

Previously Groq/turbo was first; `auto` now resolves to Voxtral.

## Bug fixes (Codex sweep)
- **Multipart parser**: `name=` regex used a negative lookbehind so it no longer matches inside `filename=` — a filename-only part can't masquerade as the required `file` field.
- **Silent audio**: empty `text` on HTTP 200 is now a success (valid silent transcription), not a retryable error that exhausts every provider. A *missing* text field still raises malformed (no longer leaks raw JSON as a transcript).
- **Body cap**: audio multipart bodies cap at 25 MB (Groq free-tier limit) instead of the 16 MB JSON cap — a valid large clip isn't 413'd.
- **response_format**: validated against `{json,text,verbose_json}`; `srt`/`vtt` now return a clear **400** instead of a confusing upstream-driven 502.

## Verification
Live end-to-end: `auto`→Voxtral, pins resolve, `response_format=srt`→400. Full suite green, ruff clean. **Codex-reviewed 2 rounds** — initial sweep (13 findings; fixed the 3 real bugs + format validation), then a re-review caught a malformed-response edge case in the empty-text fix (now resolved).

Out of scope (documented follow-ups): verbose_json segment passthrough, LF-only bodies, chunked uploads, forwarding prompt/temperature/timestamp params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reorder transcription providers for quality-first defaults and harden the audio transcription pipeline around multipart parsing, body limits, and response format handling.

Bug Fixes:
- Prevent multipart filename-only parts from being misinterpreted as named form fields such as the required file field.
- Treat an empty text field in successful transcription responses as a valid silent transcript while rejecting malformed responses that omit the text field.

Enhancements:
- Make Voxtral the default audio transcription provider ahead of Groq Whisper and prioritize whisper-large-v3 ahead of the turbo variant within Groq.
- Raise the maximum accepted size for audio multipart uploads to 25 MB to align with provider limits.
- Validate transcription response_format against supported values and reject unsupported formats like srt and vtt with clear 400 errors instead of propagating upstream 5xx failures.

Tests:
- Add tests for multipart parsing of filename-only parts to ensure they do not masquerade as named fields.
- Add tests covering unsupported transcription response_format handling returning 400.
- Add tests for client transcription behavior on empty text and missing text field responses.