### PR TITLE
provider: add Kilo Gateway (keyless free-model aggregator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # freellmpool
 
-Pool the free tiers of 16 LLM providers (200+ live-validated models) behind one
+Pool the free tiers of 17 LLM providers (200+ live-validated models) behind one
 OpenAI-compatible endpoint — as a CLI, a Python library, or a local proxy.
 Works with no API keys.
 
@@ -17,8 +17,8 @@ rate limits, and daily cap. freellmpool puts them in one pool: it sends each
 request to a provider you have access to, fails over to the next when one is rate
 limited or down, and tracks per-day usage so you get the most out of every tier.
 
-Two providers (Pollinations and OVHcloud) need no API key, so a fresh install
-answers immediately:
+Several providers (Pollinations, OVHcloud, and Kilo Gateway) need no API key, so
+a fresh install answers immediately:
 
 ```console
 $ pip install freellmpool
@@ -333,7 +333,7 @@ hosted free tiers — not a server you deploy, and not a paid aggregator.
 
 **Is there a free, OpenAI-compatible LLM API gateway?** Yes — freellmpool is a free,
 MIT-licensed gateway that exposes one OpenAI-compatible endpoint backed by the free
-tiers of 16 providers. `pip install freellmpool` and point any OpenAI client at the
+tiers of 17 providers. `pip install freellmpool` and point any OpenAI client at the
 local proxy.
 
 **How do I use multiple free LLM APIs at once?** freellmpool pools them: each request

--- a/docs/ACCOUNTS.md
+++ b/docs/ACCOUNTS.md
@@ -5,10 +5,10 @@
 all of them — even **one** key gets you going. Start with Groq + Cerebras (the
 two fastest, most generous, and quickest to sign up for), then add more later.
 
-> **No keys at all?** freellmpool still works: **OVHcloud** is keyless (anonymous)
-> and **LLM7** works without a key. So `freellmpool ask "hi"` runs the moment you
-> install. The keys below just add more models, higher limits, and better
-> failover.
+> **No keys at all?** freellmpool still works: **OVHcloud**, **Kilo Gateway**, and
+> **Pollinations** are keyless (anonymous) and **LLM7** works without a key. So
+> `freellmpool ask "hi"` runs the moment you install. The keys below just add more
+> models, higher limits, and better failover.
 
 Each key takes about a minute. Once you have one, either `export` it in your
 shell or put it in a `.env` file (copy [`.env.example`](../.env.example)).
@@ -83,10 +83,14 @@ That's enough to start. Run `freellmpool ask "hello"`.
 1. <https://longcat.chat> → developer/API keys.
 2. `export LONGCAT_API_KEY=...`
 
-### OVHcloud & LLM7 — *no signup needed*
-Nothing to do — OVHcloud is anonymous and LLM7 works without a key. For higher
-LLM7 limits you can optionally grab a token at <https://token.llm7.io> and
-`export LLM7_API_KEY=...`.
+### OVHcloud, Kilo Gateway & LLM7 — *no signup needed*
+Nothing to do — OVHcloud and Kilo Gateway are anonymous, and LLM7 works without a
+key. For higher LLM7 limits you can optionally grab a token at
+<https://token.llm7.io> and `export LLM7_API_KEY=...`.
+
+**Kilo Gateway** is a keyless OpenAI-compatible aggregator of free models
+(~200 req/hour per IP). Heads up: its free routes may log prompts — don't send
+confidential data through Kilo models (`kilo/…`).
 
 ### Cloudflare Workers AI — *needs two values*
 1. Account ID: Cloudflare dashboard → **Workers & Pages** (right sidebar shows

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,11 +3,11 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>freellmpool — free OpenAI-compatible LLM API gateway (pool 16 free tiers, no key)</title>
-<meta name="description" content="freellmpool pools the free tiers of 16 LLM providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere and more) behind one OpenAI-compatible endpoint. Free, open-source, pip-installable; works with no API key. CLI, Python library, local proxy, and MCP server with automatic failover.">
+<title>freellmpool — free OpenAI-compatible LLM API gateway (pool 17 free tiers, no key)</title>
+<meta name="description" content="freellmpool pools the free tiers of 17 LLM providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere and more) behind one OpenAI-compatible endpoint. Free, open-source, pip-installable; works with no API key. CLI, Python library, local proxy, and MCP server with automatic failover.">
 <link rel="canonical" href="https://0xzr.github.io/freellmpool/">
 <meta property="og:title" content="freellmpool — free OpenAI-compatible LLM API gateway">
-<meta property="og:description" content="Pool the free tiers of 16 LLM providers behind one OpenAI-compatible endpoint. Free, open-source, keyless to start.">
+<meta property="og:description" content="Pool the free tiers of 17 LLM providers behind one OpenAI-compatible endpoint. Free, open-source, keyless to start.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://0xzr.github.io/freellmpool/">
 <style>
@@ -39,14 +39,14 @@
 <div class="wrap">
 
 <h1>freellmpool</h1>
-<p class="tag">A free, open-source, OpenAI-compatible gateway that pools the free tiers of 16 LLM providers.</p>
+<p class="tag">A free, open-source, OpenAI-compatible gateway that pools the free tiers of 17 LLM providers.</p>
 
-<p class="lead"><strong>freellmpool is a free, open-source Python tool that pools the free tiers of 16 LLM
+<p class="lead"><strong>freellmpool is a free, open-source Python tool that pools the free tiers of 17 LLM
 providers — Groq, Cerebras, NVIDIA, Google Gemini, OpenRouter, Cloudflare, Mistral, Cohere and more —
 behind one OpenAI-compatible endpoint.</strong> It runs as a command-line tool, a Python library, a
 local proxy, and an <a href="https://modelcontextprotocol.io">MCP</a> server, with automatic failover
-when a provider is rate-limited and per-day quota tracking across tiers. Two providers (Pollinations
-and OVHcloud) need no API key, so <code>pip install freellmpool</code> answers immediately — no signup.
+when a provider is rate-limited and per-day quota tracking across tiers. Several providers (Pollinations,
+OVHcloud, and Kilo Gateway) need no API key, so <code>pip install freellmpool</code> answers immediately — no signup.
 The proxy speaks both the OpenAI and the Anthropic API, so existing apps and coding agents such as
 Codex, Claude Code, and aider run on pooled free models with no code changes.</p>
 
@@ -106,7 +106,7 @@ tiers — not a server you deploy and not a paid aggregator.</p>
 
 <h3>Is there a free, OpenAI-compatible LLM API gateway?</h3>
 <p>Yes — freellmpool is a free, open-source, MIT-licensed gateway that exposes one OpenAI-compatible
-endpoint backed by the free tiers of 16 providers. Install it with <code>pip install freellmpool</code>
+endpoint backed by the free tiers of 17 providers. Install it with <code>pip install freellmpool</code>
 and point any OpenAI client at the local proxy.</p>
 
 <h3>How do I use multiple free LLM APIs at once?</h3>
@@ -123,13 +123,13 @@ Run <code>freellmpool code claude</code> for the exact setup. (The Claude Code p
 text and tool use, no vision yet.)</p>
 
 <h3>Do I need an API key?</h3>
-<p>No key is required to start: Pollinations and OVHcloud work anonymously, so a fresh install answers
-immediately. Add free keys for the other 14 providers to unlock more models and higher limits.</p>
+<p>No key is required to start: Pollinations, OVHcloud, and Kilo Gateway work anonymously, so a fresh
+install answers immediately. Add free keys for the other providers to unlock more models and higher limits.</p>
 
 <h3>Which free LLM providers does it support?</h3>
-<p>16 providers: Pollinations, OVHcloud, LLM7, Groq, Cerebras, NVIDIA NIM, OpenRouter, Google Gemini,
-GitHub Models, Cloudflare Workers AI, Mistral, Cohere, SambaNova, Z.ai/Zhipu, Ollama Cloud, and
-LongCat — 235 live-validated chat models, plus free embeddings and audio transcription (Whisper).</p>
+<p>17 providers: Pollinations, OVHcloud, LLM7, Groq, Cerebras, NVIDIA NIM, OpenRouter, Google Gemini,
+GitHub Models, Cloudflare Workers AI, Mistral, Cohere, SambaNova, Z.ai/Zhipu, Ollama Cloud,
+LongCat, and Kilo Gateway (keyless) — 240+ live-validated chat models, plus free embeddings and audio transcription (Whisper).</p>
 
 <h3>How do I know which free providers are usable right now?</h3>
 <p>Run <code>freellmpool capacity status</code>: it labels each provider <code>healthy</code>,
@@ -169,7 +169,7 @@ Project: <a href="https://github.com/0xzr/freellmpool">github.com/0xzr/freellmpo
   "name": "freellmpool",
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Linux, macOS, Windows",
-  "description": "Free, open-source OpenAI-compatible gateway that pools the free tiers of 16 LLM providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere and more) behind one endpoint, with automatic failover. CLI, Python library, local proxy, and MCP server. Keyless to start.",
+  "description": "Free, open-source OpenAI-compatible gateway that pools the free tiers of 17 LLM providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere and more) behind one endpoint, with automatic failover. CLI, Python library, local proxy, and MCP server. Keyless to start.",
   "url": "https://0xzr.github.io/freellmpool/",
   "downloadUrl": "https://pypi.org/project/freellmpool/",
   "softwareVersion": "0.11.0",

--- a/src/freellmpool/providers.toml
+++ b/src/freellmpool/providers.toml
@@ -57,6 +57,26 @@ models = [
     { name = "Qwen3-Coder-30B-A3B-Instruct", rpd = 0 },
 ]
 
+# Kilo Gateway: keyless OpenAI-compatible aggregator of FREE models (200 req/hr per IP,
+# no key). Models carry a provider/ prefix (handled by _parse_model's first-slash split,
+# same as openrouter). Note: free routes may log prompts — don't send confidential data.
+# Model set live-validated 2026-06-08; the 550B nemotron (~128s) and nex-n2-pro (no choices)
+# were dropped as too-slow / broken.
+[[provider]]
+id = "kilo"
+label = "Kilo Gateway (keyless)"
+adapter = "openai"
+base_url = "https://api.kilo.ai/api/gateway"
+auth = "none"
+models = [
+    { name = "openrouter/free", rpd = 0 },
+    { name = "kilo-auto/free", rpd = 0 },
+    { name = "poolside/laguna-m.1:free", rpd = 0 },
+    { name = "poolside/laguna-xs.2:free", rpd = 0 },
+    { name = "stepfun/step-3.7-flash:free", rpd = 0 },
+    { name = "nvidia/nemotron-3-super-120b-a12b:free", rpd = 0 },
+]
+
 [[provider]]
 id = "groq"
 label = "Groq"


### PR DESCRIPTION
Adds **Kilo Gateway** as freellmpool's 17th provider — an OpenAI-compatible aggregator of free models with **anonymous keyless access** (~200 req/hr per IP, no signup). Joins the keyless lane with Pollinations/OVHcloud.

## Why
Investigated the candidates from the `freellms.md` provider list. Most were already covered or one-time trial credits. Kilo is the standout: **recurring free, keyless, OpenAI-compatible**, with a few models we don't otherwise have keyless (poolside, stepfun, gpt-oss-120b/kimi via its routing).

## What
- `providers.toml`: keyless `[[provider]] "kilo"` (`auth="none"`, `adapter="openai"`, `base_url=https://api.kilo.ai/api/gateway`).
- **6 models live-validated** (2026-06-08): `openrouter/free`, `kilo-auto/free`, `poolside/laguna-m.1:free`, `poolside/laguna-xs.2:free`, `stepfun/step-3.7-flash:free`, `nvidia/nemotron-3-super-120b-a12b:free`.
- **Dropped:** `nex-agi/nex-n2-pro:free` (no `choices`), `nvidia/nemotron-3-ultra-550b:free` (~128s, too slow).
- Slash/colon model names route via `_parse_model`'s first-slash split, exactly like the existing `openrouter` rows.
- Docs: provider count 16→17; Kilo added to keyless lists; **prompt-logging caveat** noted (free routes may log — don't send confidential data through `kilo/…`).

## Verification
Live end-to-end through the proxy: `kilo/openrouter/free` → **HTTP 200**, `x_freellmpool.provider=kilo`; all 6 models in `/v1/models`; streaming (SSE) works. Full suite green, ruff clean. **Codex-reviewed** — catalog/routing clean; the doc-count nits it flagged are fixed.

## Scope note
Scaleway was also investigated and **skipped**: its free tier is a one-time 1M-token + 60-min-audio new-customer allotment (not recurring), then paid — doesn't fit a free pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Kilo Gateway as a new keyless OpenAI-compatible provider and update documentation to reflect support for 17 providers and expanded keyless access.

New Features:
- Introduce Kilo Gateway as a keyless OpenAI-compatible provider with several free chat models configured in the pool.

Enhancements:
- Update provider and model counts across the README and documentation to reflect 17 supported providers and 240+ validated models.
- Document Kilo Gateway as an additional keyless option alongside OVHcloud and Pollinations, including its rate limits and prompt-logging caveat.