### PR TITLE
docs: roll provider count to 17 (Kilo) across all docs + 3 keyless

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Architecture notes: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 | Tool | What it is | Install | Keyless start | CLI / library / proxy / MCP |
 |---|---|---|---|---|
-| **freellmpool** | Pools many providers' **free tiers** | `pip install` | Yes (2 providers) | All four |
+| **freellmpool** | Pools many providers' **free tiers** | `pip install` | Yes (3 providers) | All four |
 | OpenRouter | Hosted paid aggregator (some free models) | API key | No | API only |
 | LiteLLM | Multi-provider SDK/proxy (bring your own keys) | `pip install` | No | Library + proxy |
 | Self-hosted free-API servers | A server you deploy | Docker + config | No | Server only |
@@ -347,7 +347,7 @@ Code, set `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` so `/v1/models` is disc
 through the Anthropic bridge. See `freellmpool code <agent>`. (Claude Code path is
 experimental: text + tools, no vision.)
 
-**Do I need an API key?** No — Pollinations and OVHcloud work with no key, so a fresh
+**Do I need an API key?** No — Pollinations, OVHcloud, and Kilo Gateway work with no key, so a fresh
 install answers immediately. Add free keys for the other providers for more models and
 higher limits.
 

--- a/docs/best-free-llm-api-gateway.html
+++ b/docs/best-free-llm-api-gateway.html
@@ -27,7 +27,7 @@
 <h1>Best free LLM API gateway (2026)</h1>
 
 <p class="lead"><strong>For using free LLM tiers specifically, the best free, open-source gateway is
-<a href="https://github.com/0xzr/freellmpool">freellmpool</a>: it pools the free tiers of 16 providers
+<a href="https://github.com/0xzr/freellmpool">freellmpool</a>: it pools the free tiers of 17 providers
 behind one OpenAI-compatible endpoint, installs with <code>pip</code>, works with no API key to start,
 and ships as a CLI, a Python library, a local proxy, and an MCP server. LiteLLM is the best choice if you
 bring your own keys and want a mature multi-provider SDK; OpenRouter is best if you want one paid bill for

--- a/docs/capacity-management.html
+++ b/docs/capacity-management.html
@@ -43,7 +43,7 @@
 daily caps fill up. <a href="https://github.com/0xzr/freellmpool">freellmpool</a> ships capacity tools
 that tell you, locally, which of your free providers are usable <em>right now</em>, which are near their
 quota, and which keys to add next.</strong> freellmpool is a free, open-source tool that pools the free
-tiers of 16 LLM providers behind one OpenAI-compatible endpoint; these commands keep that pool healthy.</p>
+tiers of 17 LLM providers behind one OpenAI-compatible endpoint; these commands keep that pool healthy.</p>
 
 <pre><code>pip install freellmpool
 freellmpool capacity status --target 5</code></pre>

--- a/docs/free-alternative-to-openrouter.html
+++ b/docs/free-alternative-to-openrouter.html
@@ -38,7 +38,7 @@ freellmpool</code>).</strong></p>
 <tr><th></th><th>OpenRouter</th><th>freellmpool</th></tr>
 <tr><td>Cost</td><td>Pay per token (some free models)</td><td>Free — pools providers' free tiers</td></tr>
 <tr><td>Hosting</td><td>Hosted service</td><td>Local, open source (MIT)</td></tr>
-<tr><td>Keyless start</td><td>No (account + key)</td><td>Yes (2 keyless providers)</td></tr>
+<tr><td>Keyless start</td><td>No (account + key)</td><td>Yes (3 keyless providers)</td></tr>
 <tr><td>Interface</td><td>API</td><td>CLI + Python library + proxy + MCP server</td></tr>
 <tr><td>Failover</td><td>Yes</td><td>Yes</td></tr>
 </table>
@@ -62,7 +62,7 @@ freellmpool proxy                                    # OpenAI + Anthropic compat
 open-source path, freellmpool pools the LLM providers' own free tiers behind one OpenAI-compatible
 endpoint and is keyless to start.</p>
 <h3>Can freellmpool use OpenRouter too?</h3>
-<p>Yes — OpenRouter is one of the 16 providers freellmpool can pool, so its free models become part of
+<p>Yes — OpenRouter is one of the 17 providers freellmpool can pool, so its free models become part of
 the failover pool alongside Groq, Cerebras, Gemini and the rest.</p>
 
 <p class="meta">Part of <a href="https://github.com/0xzr/freellmpool">freellmpool</a> (MIT, free, open source). Updated 2026-06-03.</p>

--- a/docs/free-claude-api.html
+++ b/docs/free-claude-api.html
@@ -61,7 +61,7 @@ is bounded by the free-tier models, and the path is experimental (text and tool 
 <h2>Why use freellmpool for this</h2>
 <ul>
 <li>It's the only part you install — one <code>pip</code>, no key to start.</li>
-<li>Failover across 16 providers, so a single tier's rate limit doesn't stop you.</li>
+<li>Failover across 17 providers, so a single tier's rate limit doesn't stop you.</li>
 <li>The same proxy also serves the OpenAI API, so OpenAI-SDK tools work too.</li>
 </ul>
 

--- a/docs/free-llm-api-providers-list.html
+++ b/docs/free-llm-api-providers-list.html
@@ -7,7 +7,7 @@
 <meta name="description" content="A 2026 list of LLM providers with a free API tier — Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere and more — with whether they need an API key, how many models, and free-tier signals. Plus how to pool them all with freellmpool.">
 <link rel="canonical" href="https://0xzr.github.io/freellmpool/free-llm-api-providers-list.html">
 <meta property="og:title" content="Free LLM API providers list (2026)">
-<meta property="og:description" content="16 providers with free LLM API tiers, compared — and how to pool them all.">
+<meta property="og:description" content="17 providers with free LLM API tiers, compared — and how to pool them all.">
 <meta property="og:type" content="article">
 <style>
  :root{--bg:#0b0e14;--fg:#e6e6e6;--mut:#8a93a2;--card:#141925;--bd:#232a39;--ac:#6ea8ff}
@@ -27,7 +27,7 @@
 <p class="tag"><a href="https://0xzr.github.io/freellmpool/">freellmpool</a> › reference</p>
 <h1>Free LLM API providers (2026)</h1>
 
-<p class="lead"><strong>These 16 providers offer a free LLM API tier you can call today. Two need no API
+<p class="lead"><strong>These 17 providers offer a free LLM API tier you can call today. Three need no API
 key at all. The table shows whether a key is required, roughly how many models the free tier exposes, and
 a free-tier signal where known. The catch with using several is that each has its own SDK and limits — the
 open-source <a href="https://github.com/0xzr/freellmpool">freellmpool</a> pools all of them behind one
@@ -51,6 +51,7 @@ OpenAI-compatible endpoint with failover, so you get their combined free capacit
 <tr><td>Z.ai / Zhipu GLM</td><td>Yes (free)</td><td class=num>2</td><td>~1,000 req/day</td></tr>
 <tr><td>Ollama Cloud</td><td>Yes (free)</td><td class=num>40</td><td>Qualitative free limits</td></tr>
 <tr><td>LongCat (Meituan)</td><td>Yes (free)</td><td class=num>1</td><td>Free preview</td></tr>
+<tr><td>Kilo Gateway</td><td>No (keyless)</td><td class=num>6</td><td>Anonymous; ~200 req/hour per IP</td></tr>
 </table>
 <p class="tag">* Count of models freellmpool routes to on each free tier (live-validated; varies as tiers change).
 ** Free-tier signals are approximate and change without notice — always check the provider's current
@@ -71,8 +72,8 @@ freellmpool providers                                         # see which tiers 
 <h2>FAQ</h2>
 <h3>Which LLM providers have a free API tier?</h3>
 <p>As of 2026, free API tiers are offered by Groq, Cerebras, Google Gemini, NVIDIA, OpenRouter, GitHub
-Models, Cloudflare, Mistral, Cohere, SambaNova, Z.ai/Zhipu, Ollama Cloud, LongCat, LLM7, Pollinations, and
-OVHcloud. Pollinations and OVHcloud work with no API key.</p>
+Models, Cloudflare, Mistral, Cohere, SambaNova, Z.ai/Zhipu, Ollama Cloud, LongCat, LLM7, Pollinations,
+OVHcloud, and Kilo Gateway. Pollinations, OVHcloud, and Kilo Gateway work with no API key.</p>
 <h3>What's the free LLM API with the highest limit?</h3>
 <p>Among the common free tiers, Cerebras advertises one of the largest daily request caps, and providers
 like Groq and OpenRouter offer roughly a thousand requests/day on free models. Limits change often — pool

--- a/docs/free-openai-api-alternatives.html
+++ b/docs/free-openai-api-alternatives.html
@@ -62,7 +62,7 @@ summarization, and everyday coding, not the hardest reasoning. Daily limits rese
 <h2>FAQ</h2>
 <h3>Is there a free OpenAI API key?</h3>
 <p>OpenAI itself doesn't offer a free API tier, but several other providers do, and freellmpool lets you
-use them through the same OpenAI-compatible interface — two of them (Pollinations, OVHcloud) need no key
+use them through the same OpenAI-compatible interface — three of them (Pollinations, OVHcloud, Kilo Gateway) need no key
 at all, so <code>pip install freellmpool &amp;&amp; freellmpool ask "..."</code> works immediately.</p>
 <h3>Can I keep my existing OpenAI code?</h3>
 <p>Yes. Point <code>OPENAI_BASE_URL</code> at the local freellmpool proxy; the SDK calls are unchanged and

--- a/docs/freellmpool-vs-litellm-vs-openrouter.html
+++ b/docs/freellmpool-vs-litellm-vs-openrouter.html
@@ -38,7 +38,7 @@ OpenRouter when you want one paid bill for many frontier models.</strong></p>
 <tr><th></th><th>freellmpool</th><th>LiteLLM</th><th>OpenRouter</th></tr>
 <tr><td>Core idea</td><td>Pool providers' <b>free</b> tiers</td><td>Standardize calls to <b>your</b> provider keys</td><td>Hosted paid aggregator</td></tr>
 <tr><td>Cost</td><td>Free</td><td>OSS; you pay providers</td><td>Pay per token (a few free models)</td></tr>
-<tr><td>Keyless start</td><td>Yes (2 providers)</td><td>No</td><td>No</td></tr>
+<tr><td>Keyless start</td><td>Yes (3 providers)</td><td>No</td><td>No</td></tr>
 <tr><td>Install</td><td><code>pip install</code></td><td><code>pip install</code></td><td>API key</td></tr>
 <tr><td>Interfaces</td><td>CLI, library, proxy, MCP</td><td>Library, proxy</td><td>API</td></tr>
 <tr><td>Failover</td><td>Yes</td><td>Yes (router)</td><td>Yes</td></tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@ MIT license
 <h2>How it compares</h2>
 <table>
 <tr><th>Tool</th><th>What it is</th><th>Install</th><th>Keyless start</th><th>CLI / library / proxy / MCP</th></tr>
-<tr><td><strong>freellmpool</strong></td><td>Pools many providers' <em>free tiers</em></td><td><code>pip install</code></td><td>Yes (2 providers)</td><td>All four</td></tr>
+<tr><td><strong>freellmpool</strong></td><td>Pools many providers' <em>free tiers</em></td><td><code>pip install</code></td><td>Yes (3 providers)</td><td>All four</td></tr>
 <tr><td>OpenRouter</td><td>Hosted paid aggregator (some free models)</td><td>API key</td><td>No (account + key)</td><td>API only</td></tr>
 <tr><td>LiteLLM</td><td>Multi-provider SDK/proxy (bring your own keys)</td><td><code>pip install</code></td><td>No</td><td>Library + proxy</td></tr>
 <tr><td>Self-hosted free-API servers</td><td>A server you deploy</td><td>Docker + config</td><td>No (deploy first)</td><td>Server only</td></tr>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # freellmpool
 
-> Free, open-source, OpenAI-compatible gateway that pools the free tiers of 16 LLM
+> Free, open-source, OpenAI-compatible gateway that pools the free tiers of 17 LLM
 > providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere
 > and more) behind one endpoint, with automatic failover and per-day quota tracking.
 > Works as a CLI, a Python library, a local proxy, and an MCP server. Keyless to

--- a/docs/run-coding-agents-on-free-models.html
+++ b/docs/run-coding-agents-on-free-models.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>How to run Claude Code, Codex, or Aider on free LLM models (no API bill)</title>
-<meta name="description" content="A step-by-step guide to running Claude Code, OpenAI Codex, Aider, Cline, and Cursor on free LLM tiers using freellmpool — a local OpenAI- and Anthropic-compatible proxy that pools 16 free providers. Keyless to start.">
+<meta name="description" content="A step-by-step guide to running Claude Code, OpenAI Codex, Aider, Cline, and Cursor on free LLM tiers using freellmpool — a local OpenAI- and Anthropic-compatible proxy that pools 17 free providers. Keyless to start.">
 <link rel="canonical" href="https://0xzr.github.io/freellmpool/run-coding-agents-on-free-models.html">
 <meta property="og:title" content="Run Claude Code, Codex, or Aider on free LLM models">
 <meta property="og:description" content="Point your coding agent at one local proxy and run it on pooled free LLM tiers — no code changes, keyless to start.">
@@ -39,8 +39,8 @@
 <p class="lead"><strong>You can run Claude Code, OpenAI Codex, Aider, Cline, Continue, or Cursor on
 free LLM tiers by pointing them at a local proxy that speaks the OpenAI and Anthropic APIs. The
 open-source tool <a href="https://github.com/0xzr/freellmpool">freellmpool</a> is that proxy: it pools
-the free tiers of 16 providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere
-and more) behind one endpoint, with automatic failover. Two providers need no API key, so you can start
+the free tiers of 17 providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere
+and more) behind one endpoint, with automatic failover. Three providers need no API key, so you can start
 for free in under a minute and change no code in the agent.</strong></p>
 
 <h2>1. Install and start the proxy</h2>

--- a/docs/run-opencode-on-free-models.html
+++ b/docs/run-opencode-on-free-models.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Run OpenCode on free LLM models (no API bill) — with a live in-editor dashboard</title>
-<meta name="description" content="Run the OpenCode coding agent on free LLM tiers with freellmpool — a local OpenAI-compatible proxy that pools 16 free providers. Includes an embedded TUI dashboard, per-request quality routing, and usage tools. Keyless to start.">
+<meta name="description" content="Run the OpenCode coding agent on free LLM tiers with freellmpool — a local OpenAI-compatible proxy that pools 17 free providers. Includes an embedded TUI dashboard, per-request quality routing, and usage tools. Keyless to start.">
 <link rel="canonical" href="https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html">
 <meta property="og:title" content="Run OpenCode on free LLM models — with a live dashboard">
 <meta property="og:description" content="Point OpenCode at one local proxy and code on pooled free LLM tiers — with an embedded dashboard, quality routing, and usage tools. Keyless to start.">
@@ -39,8 +39,8 @@
 <p class="lead"><strong>You can run the <a href="https://opencode.ai">OpenCode</a> coding agent on
 free LLM tiers — no API bill — by pointing it at a local proxy that speaks the OpenAI API. The
 open-source tool <a href="https://github.com/0xzr/freellmpool">freellmpool</a> is that proxy: it pools
-the free tiers of 16 providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere
-and more) behind one endpoint, with automatic failover. Two providers need no API key, so you can start
+the free tiers of 17 providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere
+and more) behind one endpoint, with automatic failover. Three providers need no API key, so you can start
 for free in under a minute. It also ships an OpenCode plugin with a <strong>live dashboard, quality
 routing, and usage tools</strong> built in.</strong></p>
 

--- a/docs/use-multiple-free-llm-apis.html
+++ b/docs/use-multiple-free-llm-apis.html
@@ -29,7 +29,7 @@
 OpenRouter, Cloudflare and more — pool them behind one endpoint so each request goes to a provider you
 have capacity on and fails over when one is rate-limited. The open-source <a
 href="https://github.com/0xzr/freellmpool">freellmpool</a> does exactly this: one OpenAI-compatible
-interface over 16 providers, with per-day quota tracking so you drain each tier evenly. Two providers are
+interface over 17 providers, with per-day quota tracking so you drain each tier evenly. Three providers are
 keyless, so you can start with no signup.</strong></p>
 
 <h2>Why combine them</h2>
@@ -69,7 +69,7 @@ per-model balancing.</p>
 each request to one you have capacity on and fails over automatically. You can also pin a provider per
 call with <code>-p</code>.</p>
 <h3>Do I need an API key for every provider?</h3>
-<p>No. Two providers are keyless so freellmpool works immediately; add keys for the others over time to
+<p>No. Three providers are keyless so freellmpool works immediately; add keys for the others over time to
 grow your total free capacity.</p>
 
 <p class="meta">Part of <a href="https://github.com/0xzr/freellmpool">freellmpool</a> (MIT, free, open source). Updated 2026-06-03.</p>

--- a/plugins/llm-freellmpool/README.md
+++ b/plugins/llm-freellmpool/README.md
@@ -4,7 +4,7 @@
 
 A plugin for [llm](https://llm.datasette.io) that lets you run **free LLMs** through
 [freellmpool](https://github.com/0xzr/freellmpool) — which pools the free tiers of
-16 providers (Groq, Cerebras, NVIDIA NIM, Gemini, OpenRouter, Cloudflare, …) with
+17 providers (Groq, Cerebras, NVIDIA NIM, Gemini, OpenRouter, Cloudflare, …) with
 automatic failover. **It works with zero API keys** thanks to freellmpool's keyless
 providers.
 

--- a/plugins/llm-freellmpool/pyproject.toml
+++ b/plugins/llm-freellmpool/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "llm-freellmpool"
 version = "0.1.0"
-description = "Use free LLMs in Simon Willison's llm CLI via freellmpool — pool 16 free providers, works with zero API keys."
+description = "Use free LLMs in Simon Willison's llm CLI via freellmpool — pool 17 free providers, works with zero API keys."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "freellmpool"
 version = "0.11.0"
-description = "Pool the free tiers of 16 LLM providers (300+ models) behind one OpenAI-compatible endpoint. Free, zero-config, with automatic failover and quota tracking."
+description = "Pool the free tiers of 17 LLM providers (300+ models) behind one OpenAI-compatible endpoint. Free, zero-config, with automatic failover and quota tracking."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.11"

--- a/src/freellmpool/mcp_server.py
+++ b/src/freellmpool/mcp_server.py
@@ -62,7 +62,7 @@ TOOLS = [
     {
         "name": "free_llm_ask",
         "description": (
-            "Ask a free LLM (pooled across 16 free providers, with automatic failover). "
+            "Ask a free LLM (pooled across 17 free providers, with automatic failover). "
             "Offload a self-contained subtask — drafting, summarizing, classifying, "
             "brainstorming, a quick lookup — to a free model. The reply tells you which "
             "provider/model actually served it."


### PR DESCRIPTION
Follow-up to #31. That PR added Kilo Gateway but only bumped README/index/ACCOUNTS — the rest of the user-facing surface still said **16 providers** / **two keyless**. This rolls it out everywhere.

- **pyproject.toml** + **plugins/llm-freellmpool** descriptions, the **MCP tool description** (`mcp_server.py`), **docs/llms.txt**.
- All **SEO landing pages** (9 of them).
- **free-llm-api-providers-list.html**: added a **Kilo Gateway row** to the comparison table (keyless, 6 models, ~200 req/hr/IP) + the prose list.
- **Keyless count 2 → 3** (Pollinations, OVHcloud, Kilo) everywhere it appeared.

CHANGELOG left untouched (historical record). Docs/metadata only — no code or behavior change; full suite still green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)