### PR TITLE
docs: fix last stale '16 providers' in free-claude-api.html

### DIFF
--- a/docs/free-claude-api.html
+++ b/docs/free-claude-api.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Free Claude API: how to use Claude-style models (and Claude Code) for free</title>
-<meta name="description" content="Anthropic doesn't offer a free Claude API tier, but you can run Claude Code and Anthropic-API apps on free LLM models using freellmpool — a local proxy that implements the Anthropic Messages API and routes it to 16 pooled free providers. Keyless to start.">
+<meta name="description" content="Anthropic doesn't offer a free Claude API tier, but you can run Claude Code and Anthropic-API apps on free LLM models using freellmpool — a local proxy that implements the Anthropic Messages API and routes it to 17 pooled free providers. Keyless to start.">
 <link rel="canonical" href="https://0xzr.github.io/freellmpool/free-claude-api.html">
 <meta property="og:title" content="Free Claude API alternative — run Claude Code on free models">
 <meta property="og:description" content="Run Anthropic-API apps and Claude Code on free LLM tiers via a local Anthropic-compatible proxy.">
@@ -29,7 +29,7 @@
 <p class="lead"><strong>Anthropic doesn't publish a free Claude API tier, so "a free Claude API key"
 doesn't exist. What you can do is run Claude Code and any Anthropic-API app against <em>free</em> LLM
 models by pointing them at <a href="https://github.com/0xzr/freellmpool">freellmpool</a> — a local proxy
-that implements the Anthropic Messages API (<code>/v1/messages</code>) and routes it to 16 pooled free
+that implements the Anthropic Messages API (<code>/v1/messages</code>) and routes it to 17 pooled free
 providers with failover. It's keyless to start (<code>pip install freellmpool</code>), and your tool keeps
 speaking the Anthropic API unchanged.</strong></p>
 


### PR DESCRIPTION
The #32 rollout missed this page — it phrased it "16 pooled free providers", which my count-bump patterns didn't match. Now 17, consistent with the rest of the site and the GitHub About (also updated to 17). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Correct the provider count in the free-claude-api HTML description to 17 pooled free providers.