### PR TITLE
Fix health checks against stale provider models

### DIFF
--- a/src/freellmpool/benchmark.py
+++ b/src/freellmpool/benchmark.py
@@ -16,6 +16,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 
 from . import client as _client
+from .catalog import discover_openai_models
 from .errors import ProviderHTTPError
 from .router import Pool
 
@@ -41,6 +42,42 @@ def _pick_model(provider, model: str | None) -> str | None:
     return provider.models[0].name if provider.models else None
 
 
+def _pick_model_for_health(
+    provider, model: str | None, pool: Pool, timeout: float
+) -> tuple[str | None, str | None]:
+    """Pick a probe model, preferring ids currently listed by /models.
+
+    The packaged/user catalog can drift. Health checks should report real health,
+    not burn a request on a retired model when the provider exposes discovery.
+    """
+    discovered: set[str] | None = None
+    if provider.adapter == "openai":
+        try:
+            discovered = set(
+                discover_openai_models(
+                    provider.base_url,
+                    api_key=provider.api_key(pool.env),
+                    timeout=min(timeout, 10.0),
+                )
+            )
+        except ValueError:
+            discovered = None
+
+    if model:
+        if discovered is not None and model not in discovered:
+            return None, f"model not listed by /models: {model}"
+        picked = provider.model(model)
+        return (picked.name if picked else model), None
+
+    if discovered:
+        for m in provider.models:
+            if m.enabled and m.name in discovered:
+                return m.name, None
+        return sorted(discovered)[0], None
+
+    return _pick_model(provider, model), None
+
+
 def benchmark(
     pool: Pool,
     *,
@@ -55,10 +92,14 @@ def benchmark(
     fastest-first (successes), then failures."""
     include = {p.strip() for p in providers} if providers else None
     targets: list[tuple] = []
+    skipped: list[BenchRow] = []
     for p in pool.providers:
         if include is not None and p.id not in include:
             continue
-        name = _pick_model(p, model)
+        name, skip_note = _pick_model_for_health(p, model, pool, timeout)
+        if skip_note:
+            skipped.append(BenchRow(f"{p.id}/{model}", False, None, None, skip_note))
+            continue
         if name:
             targets.append((p, name))
 
@@ -92,9 +133,10 @@ def benchmark(
         return BenchRow(key, False, None, None, "empty completion")
 
     if not targets:
-        return []
+        return skipped
     with ThreadPoolExecutor(max_workers=min(workers, len(targets))) as ex:
         rows = list(ex.map(run, targets))
+    rows.extend(skipped)
     rows.sort(key=lambda r: (not r.ok, r.latency_ms if r.latency_ms is not None else 1e18))
     return rows
 

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -35,6 +35,85 @@ def test_run_healthcheck_success():
     assert rows[0].target == "demo/model"
 
 
+def test_run_healthcheck_uses_discovered_model_when_catalog_is_stale(monkeypatch):
+    from freellmpool import benchmark
+
+    provider = Provider(
+        id="hugging_face",
+        label="Hugging Face",
+        adapter="openai",
+        base_url="https://router.huggingface.co/v1",
+        auth="none",
+        models=(Model("meta-llama/Meta-Llama-3.1-8B-Instruct"),),
+    )
+    post = make_post({})
+
+    monkeypatch.setattr(
+        benchmark,
+        "discover_openai_models",
+        lambda *args, **kwargs: ["Qwen/Qwen3-Coder-30B-A3B-Instruct"],
+    )
+
+    rows = run_healthcheck(Pool([provider], post=post), timeout=1)
+
+    assert rows[0].ok
+    assert rows[0].target == "hugging_face/Qwen/Qwen3-Coder-30B-A3B-Instruct"
+    assert post.calls[0]["body"]["model"] == "Qwen/Qwen3-Coder-30B-A3B-Instruct"
+
+
+def test_run_healthcheck_falls_back_to_catalog_model_when_discovery_is_empty(monkeypatch):
+    from freellmpool import benchmark
+
+    provider = Provider(
+        id="demo",
+        label="Demo",
+        adapter="openai",
+        base_url="https://example.test/v1",
+        auth="none",
+        models=(Model("catalog-model"),),
+    )
+    post = make_post({})
+
+    monkeypatch.setattr(
+        benchmark,
+        "discover_openai_models",
+        lambda *args, **kwargs: [],
+    )
+
+    rows = run_healthcheck(Pool([provider], post=post), timeout=1)
+
+    assert rows[0].ok
+    assert rows[0].target == "demo/catalog-model"
+    assert post.calls[0]["body"]["model"] == "catalog-model"
+
+
+def test_run_healthcheck_does_not_post_pinned_model_missing_from_discovery(monkeypatch):
+    from freellmpool import benchmark
+
+    provider = Provider(
+        id="demo",
+        label="Demo",
+        adapter="openai",
+        base_url="https://example.test/v1",
+        auth="none",
+        models=(Model("stale"),),
+    )
+    post = make_post({})
+
+    monkeypatch.setattr(
+        benchmark,
+        "discover_openai_models",
+        lambda *args, **kwargs: ["live"],
+    )
+
+    rows = run_healthcheck(Pool([provider], post=post), model="stale", timeout=1)
+
+    assert not rows[0].ok
+    assert rows[0].target == "demo/stale"
+    assert rows[0].note == "model not listed by /models: stale"
+    assert post.calls == []
+
+
 def test_run_healthcheck_failure_and_rate_limit(monkeypatch):
     from freellmpool import healthcheck
 


### PR DESCRIPTION
## Summary

Fixes provider health checks when the local/provider catalog contains stale model ids. This can happen with OpenAI-compatible aggregators such as Hugging Face Router, where user overrides or older catalogs may still list retired models like `meta-llama/Meta-Llama-3.1-8B-Instruct`.

`freellmpool providers health` previously picked the first configured model from TOML and sent a chat completion probe directly. If that model was gone, health reported a provider failure even though other models from the same provider were still live.

## Changes

- Ask OpenAI-compatible providers `/models` endpoint before selecting the health/benchmark probe model.
- Prefer a currently advertised enabled catalog model when discovery is available.
- Fall back to a discovered model when every catalog model is stale.
- Fall back to the catalog model when `/models` discovery fails or returns no model ids.
- For pinned `--model`, report `model not listed by /models` locally when discovery says the model is absent, avoiding an unnecessary chat completion POST.
- Add regression tests for stale catalog replacement, empty discovery fallback, and pinned missing-model handling.

## Tests

- `.venv/bin/python -m pytest tests/test_healthcheck.py -q`
- `.venv/bin/python -m ruff check tests/test_healthcheck.py`
- `.venv/bin/python -m pytest -q`

## Notes

No UI change. No browserless/screenshot run needed.
