### PR TITLE
perf: parallelize health-check /models discovery (follow-up to #35/#36)

### DIFF
--- a/src/freellmpool/benchmark.py
+++ b/src/freellmpool/benchmark.py
@@ -91,20 +91,17 @@ def benchmark(
     """Time one call per configured provider, concurrently. Returns rows sorted
     fastest-first (successes), then failures."""
     include = {p.strip() for p in providers} if providers else None
-    targets: list[tuple] = []
-    skipped: list[BenchRow] = []
-    for p in pool.providers:
-        if include is not None and p.id not in include:
-            continue
-        name, skip_note = _pick_model_for_health(p, model, pool, timeout)
-        if skip_note:
-            skipped.append(BenchRow(f"{p.id}/{model}", False, None, None, skip_note))
-            continue
-        if name:
-            targets.append((p, name))
+    candidates = [p for p in pool.providers if include is None or p.id in include]
 
-    def run(item) -> BenchRow:
-        provider, mname = item
+    def run(provider) -> BenchRow | None:
+        # Model selection (incl. the /models discovery probe) runs INSIDE the worker so it's
+        # parallelized across the pool — not serialized before the threadpool, which would add
+        # up to N*min(timeout,10s) of preflight latency on slow endpoints.
+        mname, skip_note = _pick_model_for_health(provider, model, pool, timeout)
+        if skip_note:
+            return BenchRow(f"{provider.id}/{model}", False, None, None, skip_note)
+        if not mname:
+            return None  # nothing probeable (no catalog model and no discovery) — omit, as before
         key = f"{provider.id}/{mname}"
         started = time.monotonic()
         try:
@@ -132,11 +129,10 @@ def benchmark(
         pool.metrics.record_failure(key, "empty completion")
         return BenchRow(key, False, None, None, "empty completion")
 
-    if not targets:
-        return skipped
-    with ThreadPoolExecutor(max_workers=min(workers, len(targets))) as ex:
-        rows = list(ex.map(run, targets))
-    rows.extend(skipped)
+    if not candidates:
+        return []
+    with ThreadPoolExecutor(max_workers=min(workers, len(candidates))) as ex:
+        rows = [r for r in ex.map(run, candidates) if r is not None]
     rows.sort(key=lambda r: (not r.ok, r.latency_ms if r.latency_ms is not None else 1e18))
     return rows
 

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -55,6 +55,9 @@ _TRANSCRIPTION_FORMATS = ("json", "text", "verbose_json")
 def _model_ids(pool: Pool) -> list[str]:
     # "auto" + per-request routing aliases (mapped to a routing mode by the proxy),
     # then every enabled provider/model id.
+    # INVARIANT: always non-empty (the routing aliases are unconditional). _anthropic_models_payload
+    # relies on this for first_id/last_id = ids[0]/ids[-1] without a guard — keep these seeds
+    # unconditional, or restore that guard.
     ids = ["auto", "spread", "fast", "quality", "fair"]
     for provider in pool.providers:
         for m in provider.models:


### PR DESCRIPTION
Follow-up to #35/#36 (thanks @arthurlacoste).

#35 added per-provider `/models` discovery to the health check so it probes a *live* model instead of a retired catalog id — a real improvement. But it ran the discovery **serially in the preflight loop**, before the threadpool, adding up to `N × min(timeout, 10s)` of latency before any probe starts (≈ minutes for ~18 providers with slow endpoints).

A **Codex** review caught this (an opus review had waved it through — which is why I ran both). This moves `_pick_model_for_health` (discovery + selection) **inside the per-provider worker** so it runs concurrently across the pool.

**Row semantics unchanged** (verified by the existing #35 tests + full suite): skip rows still emitted with their note and **no probe POST** for a pinned model missing from `/models`; probe rows produced; providers with nothing probeable are omitted (worker returns `None`, filtered); empty candidate set returns `[]`.

Also documents the `_model_ids` non-empty invariant that #36's guard-free `first_id/last_id = ids[0]/ids[-1]` now relies on.

Full suite green, ruff clean, Codex-reviewed (RESOLVED).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Parallelize per-provider model selection for health-check benchmarking to reduce preflight latency and document a routing ID invariant relied on by Anthropic payload construction.

Enhancements:
- Move health-check /models discovery and model selection into per-provider worker tasks so they run concurrently instead of serially.
- Filter benchmark results to omit providers with no probeable model while still returning skip rows for providers with explicit skip notes.
- Document the invariant that pooled routing/model ID lists are always non-empty to justify guard-free first/last ID access in Anthropic payload generation.