### PR TITLE
audit: verify documented models live + add OVH keyless embedder & transcriber

### DIFF
--- a/docs/free-llm-api-providers-list.html
+++ b/docs/free-llm-api-providers-list.html
@@ -36,7 +36,7 @@ OpenAI-compatible endpoint with failover, so you get their combined free capacit
 <table>
 <tr><th>Provider</th><th>API key?</th><th class=num>Free models*</th><th>Free-tier signal**</th></tr>
 <tr><td>Pollinations</td><td>No (keyless)</td><td class=num>3</td><td>Anonymous; rate-limited per IP</td></tr>
-<tr><td>OVHcloud AI Endpoints</td><td>No (keyless)</td><td class=num>13</td><td>Anonymous tier</td></tr>
+<tr><td>OVHcloud AI Endpoints</td><td>No (keyless)</td><td class=num>17</td><td>Anonymous tier (chat + embeddings + Whisper)</td></tr>
 <tr><td>LLM7</td><td>Optional</td><td class=num>9</td><td>~60/hour without a token</td></tr>
 <tr><td>Groq</td><td>Yes (free)</td><td class=num>9</td><td>~1,000 req/day (per model)</td></tr>
 <tr><td>Cerebras</td><td>Yes (free)</td><td class=num>4</td><td>~14,400 req/day (large cap)</td></tr>

--- a/src/freellmpool/providers.toml
+++ b/src/freellmpool/providers.toml
@@ -592,6 +592,19 @@ models = [
     { name = "snowflake/arctic-embed-l", rpd = 0 },
 ]
 
+# OVHcloud — KEYLESS embeddings (BGE), no key/signup. Our only keyless embedder → works on a
+# fresh install. Live-validated 2026-06-09 (bge-m3 dim=1024, bge-multilingual-gemma2 dim=3584).
+[[embedder]]
+id = "ovh"
+label = "OVHcloud (keyless)"
+adapter = "openai"
+base_url = "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1"
+auth = "none"
+models = [
+    { name = "bge-multilingual-gemma2", rpd = 0 },
+    { name = "bge-m3", rpd = 0 },
+]
+
 # ── transcribers: audio→text (OpenAI /audio/transcriptions shape). Failover order. ──
 # Quality-first order from a local WER smoke test (5 known-speech clips, 2026-06-08): Voxtral
 # was most accurate (WER 0.024), then whisper-large-v3 (0.070), then -turbo (0.062, fastest).
@@ -612,6 +625,19 @@ label = "Groq (Whisper)"
 adapter = "openai"
 base_url = "https://api.groq.com/openai/v1"
 key_env = "GROQ_API_KEY"
+models = [
+    { name = "whisper-large-v3", rpd = 0 },
+    { name = "whisper-large-v3-turbo", rpd = 0 },
+]
+
+# OVHcloud — KEYLESS Whisper, no key/signup; the always-available ASR fallback (anon ~2 RPM/IP).
+# Last so keyed higher-quality providers win when configured; live-validated 2026-06-09.
+[[transcriber]]
+id = "ovh"
+label = "OVHcloud (Whisper, keyless)"
+adapter = "openai"
+base_url = "https://oai.endpoints.kepler.ai.cloud.ovh.net/v1"
+auth = "none"
 models = [
     { name = "whisper-large-v3", rpd = 0 },
     { name = "whisper-large-v3-turbo", rpd = 0 },

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -38,7 +38,11 @@ def test_embedder_catalog_loads():
 def test_configured_embedders_filter():
     cat = load_embedders()
     got = {e.id for e in configured_embedders(cat, {"COHERE_API_KEY": "x"})}
-    assert got == {"cohere"}
+    # exactly cohere (keyed, key present) + ovh (keyless → always configured); no other keyed
+    # embedder (github/cloudflare/mistral/nvidia) should leak in on just COHERE_API_KEY.
+    assert got == {"cohere", "ovh"}
+    # keyless-only: with no keys at all, only keyless embedders are configured.
+    assert {e.id for e in configured_embedders(cat, {})} == {"ovh"}
 
 
 def test_client_embed_shape():

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -29,6 +29,8 @@ def test_transcriber_catalog_loads():
     # Catalog order IS failover/`auto` order (Pool.transcribe iterates the list). Quality-first
     # per the WER smoke test: Mistral Voxtral (most accurate) precedes Groq Whisper.
     assert ids.index("mistral") < ids.index("groq")
+    # Keyless OVHcloud Whisper is LAST = the always-available fallback after keyed providers.
+    assert ids[-1] == "ovh"
     # Within Groq, whisper-large-v3 precedes -turbo (quality-first).
     groq = next(t for t in cat if t.id == "groq")
     gm = [m.name for m in groq.models]
@@ -41,12 +43,13 @@ def test_transcriber_catalog_loads():
 def test_configured_transcribers_filter():
     cat = load_transcribers()
     got = {t.id for t in configured_transcribers(cat, {"GROQ_API_KEY": "x"})}
-    assert got == {"groq"}  # only providers whose key is set are configured
+    assert got == {"groq", "ovh"}  # groq (keyed) + ovh (keyless); mistral needs its key
     both = {
         t.id for t in configured_transcribers(cat, {"GROQ_API_KEY": "x", "MISTRAL_API_KEY": "y"})
     }
-    assert {"groq", "mistral"} <= both
-    assert configured_transcribers(cat, {}) == []  # no key → nothing configured
+    assert both == {"groq", "mistral", "ovh"}
+    # keyless-only: with no keys, only the keyless OVH transcriber is configured.
+    assert {t.id for t in configured_transcribers(cat, {})} == {"ovh"}
 
 
 def test_client_transcribe_shape():


### PR DESCRIPTION
## Audit
Probed every documented model on all providers we hold keys for (discovery diff + completion probes). **Result: every enabled documented model is live.** The parallel-probe "DEAD"s were **429 rate-limit false-positives** (llm7 is 1/sec, pollinations 1-concurrent, GitHub anti-scrape) — confirmed alive via a serial re-probe. The only genuinely-dead 404 models (cerebras `qwen3-235b`/`llama3.1-8b`, github `gpt-5`/`o1`/`o3`, nvidia `deepseek-r1`) are **already disabled**. **No removals needed.**

## New (keyless, live-validated end-to-end through the proxy)
Discovery showed OVHcloud (already a keyless chat provider) also exposes embeddings + Whisper:
- **embedder `ovh`** — `bge-multilingual-gemma2` (3584-dim), `bge-m3` (1024-dim). **Our first keyless embedder** (works with zero keys).
- **transcriber `ovh`** — `whisper-large-v3` + `-turbo`. A 3rd ASR provider, **keyless**, placed **last** so keyed higher-quality providers (Mistral Voxtral → Groq) win when configured and OVH is the always-available fallback.

## Tests
Filter tests now assert **exact** configured-sets (a keyless provider is always configured — would catch a future mis-config) and lock the **OVH-last** failover contract.

Full suite green, ruff clean. **Codex-reviewed** (catalog/failover correct; test exactness + OVH-last assertion added per its review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)