### PR TITLE
[codex] Harden freellmpool routing, retries, and CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -18,5 +18,32 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
+      - name: Restore previous benchmark
+        uses: actions/cache/restore@v4
+        with:
+          path: .benchmarks/latest.json
+          key: hotpath-benchmark-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            hotpath-benchmark-${{ runner.os }}-
       - name: Run local hot-path benchmarks
-        run: python scripts/bench_hotpaths.py
+        run: |
+          mkdir -p .benchmarks
+          python scripts/bench_hotpaths.py | tee .benchmarks/current.json
+      - name: Compare with previous benchmark
+        run: |
+          if [ -f .benchmarks/latest.json ]; then
+            python scripts/compare_benchmarks.py .benchmarks/latest.json .benchmarks/current.json --warn-percent 30
+          else
+            echo "No previous benchmark artifact found; skipping comparison."
+          fi
+          cp .benchmarks/current.json .benchmarks/latest.json
+      - name: Upload benchmark artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hotpath-benchmarks
+          path: .benchmarks/current.json
+      - name: Save benchmark baseline
+        uses: actions/cache/save@v4
+        with:
+          path: .benchmarks/latest.json
+          key: hotpath-benchmark-${{ runner.os }}-${{ github.run_id }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,22 @@
+name: Benchmarks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 5 * * 1"
+
+jobs:
+  hotpaths:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Run local hot-path benchmarks
+        run: python scripts/bench_hotpaths.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - name: Lint
-        run: ruff check src tests
+        run: ruff check .
+      - name: Validate catalog
+        run: python scripts/validate_catalog.py
+      - name: Import smoke
+        run: python -c "import freellmpool; from freellmpool import Pool, AsyncPool; print(freellmpool.__version__, Pool, AsyncPool)"
       - name: Test
-        run: pytest
+        run: pytest --cov=freellmpool --cov-report=term-missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,22 @@ jobs:
         run: ruff check .
       - name: Validate catalog
         run: python scripts/validate_catalog.py
+      - name: Type check focused helpers
+        run: mypy src/freellmpool/routing_modes.py src/freellmpool/catalog_validation.py
       - name: Import smoke
         run: python -c "import freellmpool; from freellmpool import Pool, AsyncPool; print(freellmpool.__version__, Pool, AsyncPool)"
       - name: Test
-        run: pytest --cov=freellmpool --cov-report=term-missing
+        run: pytest --cov=freellmpool --cov-report=term-missing --cov-fail-under=75
+      - name: Wheel smoke
+        run: |
+          python -m build
+          python -m venv /tmp/freellmpool-wheel-smoke
+          /tmp/freellmpool-wheel-smoke/bin/python -m pip install --upgrade pip
+          /tmp/freellmpool-wheel-smoke/bin/python -m pip install dist/*.whl
+          /tmp/freellmpool-wheel-smoke/bin/python -c "import freellmpool; from freellmpool import Pool, AsyncPool; print(freellmpool.__version__, Pool, AsyncPool)"
+          /tmp/freellmpool-wheel-smoke/bin/freellmpool --version
+          FREELLMPOOL_CONFIG_FILE=/tmp/flp-smoke-config.toml \
+          FREELLMPOOL_QUOTA_PATH=/tmp/flp-smoke-quota.json \
+          FREELLMPOOL_CACHE_PATH=/tmp/flp-smoke-cache.db \
+          FREELLMPOOL_EXTERNAL_CATALOG_PATH=/tmp/flp-smoke-external.json \
+            /tmp/freellmpool-wheel-smoke/bin/freellmpool doctor

--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ async with AsyncPool.from_default_config() as pool:
     reply = await pool.aask("Summarize the plot of Hamlet in 20 words.")
 ```
 
-Pass `on_event=...` to either pool to receive structured routing events
-(`attempt`/`success`/`error`/`cooldown`/`exhausted`) for logging or tracing. Add
+Pass `on_event=...` to either pool to receive structured routing/cache events
+(`attempt`/`success`/`error`/`cooldown`/`cache_hit`/`cache_miss`/`exhausted`) for logging or tracing. Add
 your own endpoint with `register_provider(...)`, or a new request shape with
 `register_adapter(name, fn)`.
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,23 @@ required. Step-by-step signup links for each (all free, no card) are in
 A `config.toml` (see [config.toml.example](config.toml.example)) can hold keys,
 model aliases, and settings instead of env vars.
 
+## Local diagnostics and operations
+
+Run `freellmpool doctor` for a no-network local check of package version, config
+paths, configured provider count, routing mode, quota/cache locations, external
+catalog cache age, and bundled catalog validity.
+
+Response caching is off unless `FREELLMPOOL_CACHE_TTL` (seconds) or
+`[settings] cache_ttl` is positive. When enabled, cache rows live in SQLite with
+WAL mode and TTL pruning; `FREELLMPOOL_CACHE_MAX_ENTRIES` caps retained rows
+(default `10000`, set `0` to disable size pruning).
+
+Quota counters are written immediately by default. Long-running proxy/MCP
+processes can reduce file churn with `FREELLMPOOL_QUOTA_FLUSH_EVERY=N`, which
+batches up to `N` successful requests before flushing. Shutdown paths and
+`quota.snapshot()` flush pending counts, so dashboards and process exits still
+see current totals.
+
 ## How routing works
 
 For each request, freellmpool builds the list of `(provider, model)` pairs you

--- a/plugins/llm-freellmpool/llm_freellmpool.py
+++ b/plugins/llm-freellmpool/llm_freellmpool.py
@@ -10,6 +10,7 @@ as env vars to unlock more — see https://github.com/0xzr/freellmpool.
 from __future__ import annotations
 
 import llm
+
 from freellmpool import Pool
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ Issues = "https://github.com/0xzr/freellmpool/issues"
 
 [project.optional-dependencies]
 dev = [
+    "build>=1.2",
+    "mypy>=1.10",
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "ruff>=0.6",
@@ -73,3 +75,8 @@ ignore = ["E501"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_unused_ignores = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ Issues = "https://github.com/0xzr/freellmpool/issues"
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0",
+    "pytest-cov>=5.0",
     "ruff>=0.6",
 ]
 

--- a/scripts/bench_hotpaths.py
+++ b/scripts/bench_hotpaths.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Local hot-path benchmarks for routing/cache/quota/proxy-free operations.
+
+This intentionally avoids network and benchmark dependencies. It prints JSON so
+nightly/manual CI can retain comparable numbers without failing normal PRs over
+machine variance.
+"""
+
+from __future__ import annotations
+
+import json
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+if _SRC.is_dir():
+    sys.path.insert(0, str(_SRC))
+
+from freellmpool.cache import Cache  # noqa: E402
+from freellmpool.client import HTTPResult  # noqa: E402
+from freellmpool.models import Model, Provider  # noqa: E402
+from freellmpool.quota import QuotaStore  # noqa: E402
+from freellmpool.router import Pool  # noqa: E402
+
+
+def _providers(n_providers: int = 32, n_models: int = 12) -> list[Provider]:
+    return [
+        Provider(
+            id=f"p{i}",
+            label=f"P{i}",
+            adapter="openai",
+            base_url=f"https://p{i}.test/v1",
+            auth="none",
+            models=tuple(Model(f"m{j}", rpd=1000) for j in range(n_models)),
+        )
+        for i in range(n_providers)
+    ]
+
+
+def _post(url, headers, body, timeout):
+    return HTTPResult(
+        200,
+        {
+            "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+            "usage": {"prompt_tokens": 3, "completion_tokens": 2},
+        },
+        "ok",
+    )
+
+
+def _time(fn, iterations: int) -> dict:
+    samples = []
+    for _ in range(iterations):
+        start = time.perf_counter()
+        fn()
+        samples.append((time.perf_counter() - start) * 1000.0)
+    return {
+        "iterations": iterations,
+        "mean_ms": round(statistics.mean(samples), 4),
+        "p95_ms": round(sorted(samples)[int(iterations * 0.95) - 1], 4),
+    }
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        quota = QuotaStore(path=root / "quota.json", flush_every=1000)
+        cache = Cache(ttl=3600, path=root / "cache.db", max_entries=1000)
+        pool = Pool(_providers(), quota=quota, env={}, post=_post, cache=cache, routing="spread")
+        messages = [{"role": "user", "content": "hello"}]
+
+        results = {
+            "rank_targets_large_catalog": _time(lambda: pool.rank_targets(messages), 1000),
+            "chat_cache_hit": _time(lambda: pool.chat(messages), 500),
+            "quota_batched_record": _time(lambda: quota.record("p0", "m0"), 2000),
+            "cache_get_put": _time(
+                lambda: (cache.put("bench", {"text": "ok"}), cache.get("bench")),
+                1000,
+            ),
+        }
+        quota.flush()
+    print(json.dumps(results, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/compare_benchmarks.py
+++ b/scripts/compare_benchmarks.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Compare two ``bench_hotpaths.py`` JSON files and report timing regressions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def compare(previous: dict, current: dict, *, warn_percent: float) -> list[str]:
+    warnings: list[str] = []
+    factor = 1.0 + warn_percent / 100.0
+    for name, cur in sorted(current.items()):
+        prev = previous.get(name)
+        if not isinstance(prev, dict) or not isinstance(cur, dict):
+            continue
+        for field in ("mean_ms", "p95_ms"):
+            old = prev.get(field)
+            new = cur.get(field)
+            if not isinstance(old, int | float) or not isinstance(new, int | float):
+                continue
+            if old > 0 and new > old * factor:
+                pct = (new / old - 1.0) * 100.0
+                warnings.append(f"{name}.{field}: {old:.4f} -> {new:.4f} ms (+{pct:.1f}%)")
+    return warnings
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("previous", type=Path)
+    parser.add_argument("current", type=Path)
+    parser.add_argument("--warn-percent", type=float, default=30.0)
+    parser.add_argument("--fail", action="store_true", help="exit 1 when regressions are found")
+    args = parser.parse_args(argv)
+
+    warnings = compare(_load(args.previous), _load(args.current), warn_percent=args.warn_percent)
+    if not warnings:
+        print("Benchmark comparison: no regressions above threshold.")
+        return 0
+    print("Benchmark comparison warnings:", file=sys.stderr)
+    for warning in warnings:
+        print(f"  - {warning}", file=sys.stderr)
+    return 1 if args.fail else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_catalog.py
+++ b/scripts/validate_catalog.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Validate bundled provider catalog structure without making network calls."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+if _SRC.is_dir():
+    sys.path.insert(0, str(_SRC))
+
+from freellmpool.catalog_validation import validate_catalog  # noqa: E402
+
+
+def main() -> int:
+    errors = validate_catalog(Path("src/freellmpool/providers.toml"))
+    if errors:
+        print("Catalog validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print("Catalog validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/freellmpool/aio.py
+++ b/src/freellmpool/aio.py
@@ -39,6 +39,7 @@ from .errors import (
 from .models import Provider, Reply
 from .observe import emit
 from .router import Pool, _is_health_failure
+from .routing_modes import normalize_routing_mode
 
 #: An async transport: ``await apost(url, headers, json_body, timeout) -> HTTPResult``.
 AsyncPostFn = Callable[[str, dict, dict, float], Awaitable["_client.HTTPResult"]]
@@ -127,17 +128,33 @@ class AsyncPool:
         import httpx
 
         client = await self._client_obj()
-        resp = await client.post(
-            url,
-            headers=headers,
-            json=body,
-            timeout=httpx.Timeout(timeout, connect=min(_CONNECT_TIMEOUT, timeout)),
-        )
-        try:
-            data = resp.json()
-        except Exception:  # noqa: BLE001 — non-JSON error bodies
-            data = {}
-        return _client.HTTPResult(status=resp.status_code, body=data, text=resp.text)
+        last_exc: httpx.HTTPError | None = None
+        for attempt in range(_client._MAX_TRANSPORT_ATTEMPTS):
+            try:
+                resp = await client.post(
+                    url,
+                    headers=headers,
+                    json=body,
+                    timeout=httpx.Timeout(timeout, connect=min(_CONNECT_TIMEOUT, timeout)),
+                )
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt + 1 >= _client._MAX_TRANSPORT_ATTEMPTS:
+                    raise
+                await asyncio.sleep(_client._RETRY_BACKOFF_S * (attempt + 1))
+                continue
+            try:
+                data = resp.json()
+            except Exception:  # noqa: BLE001 — non-JSON error bodies
+                data = {}
+            result = _client.HTTPResult(status=resp.status_code, body=data, text=resp.text)
+            if _retryable(result.status) and attempt + 1 < _client._MAX_TRANSPORT_ATTEMPTS:
+                await asyncio.sleep(_client._RETRY_BACKOFF_S * (attempt + 1))
+                continue
+            return result
+        if last_exc is not None:  # pragma: no cover - loop structure guard
+            raise last_exc
+        raise ProviderHTTPError(502, "transport retry loop exhausted", retryable=True)
 
     # ---- per-target async dispatch -----------------------------------
     async def _acall(
@@ -313,12 +330,14 @@ class AsyncPool:
         timeout: float = 90.0,
         tools: list | None = None,
         tool_choice=None,
+        routing: str | None = None,
     ) -> Reply:
         """Async failover completion — same routing/cache/metrics as :meth:`Pool.chat`."""
         p = self._pool
         if not p.providers:
             raise NoProvidersConfigured("no provider has an API key set")
         provider_list = list(providers) if providers else None
+        eff = normalize_routing_mode(routing, p.routing)
 
         cache_key = None
         if p._cache is not None:
@@ -330,10 +349,11 @@ class AsyncPool:
                 temperature,
                 tools,
                 tool_choice,
-                p.routing,
+                eff,
             )
             hit = await asyncio.to_thread(p._cache.get, cache_key)  # blocking sqlite off-loop
             if hit is not None:
+                emit(p._on_event, "cache_hit", key=cache_key)
                 p._bump_stats(cache_hits=1)
                 return Reply(
                     text=hit.get("text", ""),
@@ -345,12 +365,11 @@ class AsyncPool:
                     message=hit.get("message"),
                     cached=True,
                 )
+            emit(p._on_event, "cache_miss", key=cache_key)
 
-        difficulty = (
-            prompt_difficulty(messages, max_tokens, tools) if p.routing == "quality" else None
-        )
+        difficulty = prompt_difficulty(messages, max_tokens, tools) if eff == "quality" else None
         targets = p._order(
-            p._all_targets(include=provider_list, model=model), difficulty=difficulty
+            p._all_targets(include=provider_list, model=model), difficulty=difficulty, routing=eff
         )
         if not targets:
             raise NoProvidersConfigured("no candidate (provider, model) matched the given filters")
@@ -463,6 +482,7 @@ class AsyncPool:
                         "message": reply.message,
                     },
                 )
+                emit(p._on_event, "cache_store", key=cache_key, target=target.name)
             return reply
 
         emit(p._on_event, "exhausted", attempts=len(attempts))

--- a/src/freellmpool/aio.py
+++ b/src/freellmpool/aio.py
@@ -45,6 +45,25 @@ from .routing_modes import normalize_routing_mode
 AsyncPostFn = Callable[[str, dict, dict, float], Awaitable["_client.HTTPResult"]]
 
 
+async def _aread_capped_response(chunks, deadline: float, timeout: float) -> tuple[bytes, str]:
+    out: list[bytes] = []
+    total = 0
+    loop = asyncio.get_running_loop()
+    async for chunk in chunks:
+        total += len(chunk)
+        if total > _client._MAX_RESPONSE_BYTES:
+            raise ProviderHTTPError(
+                502,
+                f"upstream response exceeded {_client._MAX_RESPONSE_BYTES} bytes",
+                retryable=True,
+            )
+        if loop.time() > deadline:
+            raise ProviderHTTPError(504, f"upstream exceeded {timeout:.0f}s deadline", retryable=True)
+        out.append(chunk)
+    raw = b"".join(out)
+    return raw, raw.decode("utf-8", "replace")
+
+
 class AsyncPool:
     """Async counterpart to :class:`~freellmpool.Pool`.
 
@@ -128,32 +147,51 @@ class AsyncPool:
         import httpx
 
         client = await self._client_obj()
+        deadline = asyncio.get_running_loop().time() + timeout
         last_exc: httpx.HTTPError | None = None
+        last_result: _client.HTTPResult | None = None
         for attempt in range(_client._MAX_TRANSPORT_ATTEMPTS):
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                break
             try:
-                resp = await client.post(
+                async with client.stream(
+                    "POST",
                     url,
                     headers=headers,
                     json=body,
-                    timeout=httpx.Timeout(timeout, connect=min(_CONNECT_TIMEOUT, timeout)),
-                )
+                    timeout=httpx.Timeout(remaining, connect=min(_CONNECT_TIMEOUT, remaining)),
+                ) as resp:
+                    raw, text = await _aread_capped_response(
+                        resp.aiter_bytes(), deadline, remaining
+                    )
+                    status = resp.status_code
+                    response_headers = dict(resp.headers)
             except httpx.HTTPError as exc:
                 last_exc = exc
+                if not _client._retryable_transport_error(exc, httpx):
+                    raise
                 if attempt + 1 >= _client._MAX_TRANSPORT_ATTEMPTS:
                     raise
-                await asyncio.sleep(_client._RETRY_BACKOFF_S * (attempt + 1))
+                delay = _client._retry_delay_monotonic(None, attempt, deadline, asyncio.get_running_loop().time)
+                if delay is None:
+                    raise
+                await asyncio.sleep(delay)
                 continue
-            try:
-                data = resp.json()
-            except Exception:  # noqa: BLE001 — non-JSON error bodies
-                data = {}
-            result = _client.HTTPResult(status=resp.status_code, body=data, text=resp.text)
+            result = _client._json_result(status, raw, text, headers=response_headers)
+            last_result = result
             if _retryable(result.status) and attempt + 1 < _client._MAX_TRANSPORT_ATTEMPTS:
-                await asyncio.sleep(_client._RETRY_BACKOFF_S * (attempt + 1))
-                continue
+                delay = _client._retry_delay_monotonic(
+                    result, attempt, deadline, asyncio.get_running_loop().time
+                )
+                if delay is not None:
+                    await asyncio.sleep(delay)
+                    continue
             return result
         if last_exc is not None:  # pragma: no cover - loop structure guard
             raise last_exc
+        if last_result is not None:
+            return last_result
         raise ProviderHTTPError(502, "transport retry loop exhausted", retryable=True)
 
     # ---- per-target async dispatch -----------------------------------

--- a/src/freellmpool/aio.py
+++ b/src/freellmpool/aio.py
@@ -323,7 +323,14 @@ class AsyncPool:
         cache_key = None
         if p._cache is not None:
             cache_key = p._cache.make_key(
-                messages, model, provider_list, max_tokens, temperature, tools, tool_choice
+                messages,
+                model,
+                provider_list,
+                max_tokens,
+                temperature,
+                tools,
+                tool_choice,
+                p.routing,
             )
             hit = await asyncio.to_thread(p._cache.get, cache_key)  # blocking sqlite off-loop
             if hit is not None:

--- a/src/freellmpool/cache.py
+++ b/src/freellmpool/cache.py
@@ -27,24 +27,41 @@ def default_cache_path() -> Path:
     return Path.home() / ".config" / "freellmpool" / "cache.db"
 
 
+def default_max_entries() -> int:
+    try:
+        return max(0, int(os.environ.get("FREELLMPOOL_CACHE_MAX_ENTRIES", "10000")))
+    except ValueError:
+        return 10000
+
+
 class Cache:
     def __init__(
-        self, ttl: float, path: Path | None = None, clock: Callable[[], float] | None = None
+        self,
+        ttl: float,
+        path: Path | None = None,
+        clock: Callable[[], float] | None = None,
+        max_entries: int | None = None,
     ):
         self.ttl = ttl
         self.path = path or default_cache_path()
         self._clock = clock or time.time
+        self.max_entries = default_max_entries() if max_entries is None else max(0, max_entries)
         self.path.parent.mkdir(parents=True, exist_ok=True)
         # `with sqlite3.connect()` manages the transaction but NOT the connection,
         # so every call must also close() it (via contextlib.closing) or it leaks a
         # file handle until GC. `, con` keeps the transaction-commit behavior.
         with closing(self._conn()) as con, con:
+            con.execute("PRAGMA journal_mode=WAL")
+            con.execute("PRAGMA busy_timeout=5000")
             con.execute(
                 "CREATE TABLE IF NOT EXISTS cache (key TEXT PRIMARY KEY, value TEXT, created REAL)"
             )
+            con.execute("CREATE INDEX IF NOT EXISTS idx_cache_created ON cache(created)")
 
     def _conn(self) -> sqlite3.Connection:
-        return sqlite3.connect(self.path, timeout=5)
+        con = sqlite3.connect(self.path, timeout=5)
+        con.execute("PRAGMA busy_timeout=5000")
+        return con
 
     @staticmethod
     def make_key(
@@ -102,5 +119,15 @@ class Cache:
                 )
                 # Reclaim expired rows on write so the table can't grow without bound.
                 con.execute("DELETE FROM cache WHERE created < ?", (now - self.ttl,))
+                if self.max_entries:
+                    con.execute(
+                        """
+                        DELETE FROM cache
+                        WHERE key NOT IN (
+                            SELECT key FROM cache ORDER BY created DESC LIMIT ?
+                        )
+                        """,
+                        (self.max_entries,),
+                    )
         except (sqlite3.Error, TypeError):
             pass  # cache is best-effort — never break a request over it

--- a/src/freellmpool/catalog_validation.py
+++ b/src/freellmpool/catalog_validation.py
@@ -1,0 +1,66 @@
+"""Local catalog validation used by CI and ``freellmpool doctor``."""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from .capability import capability_table, model_capability
+from .config import load_catalog, load_embedders, load_transcribers
+from .models import Provider
+
+_ADAPTERS = {"openai", "gemini", "cloudflare"}
+_AUTH = {"bearer", "none"}
+
+
+def _valid_url(value: str) -> bool:
+    parsed = urlsplit(value)
+    return parsed.scheme == "https" and bool(parsed.netloc) and not any(
+        ch in value for ch in "\r\n\t"
+    )
+
+
+def _check_group(name: str, providers: list[Provider]) -> list[str]:
+    errors: list[str] = []
+    ids = Counter(p.id for p in providers)
+    for provider_id, count in ids.items():
+        if count > 1:
+            errors.append(f"{name}: duplicate provider id {provider_id!r}")
+    for provider in providers:
+        prefix = f"{name}:{provider.id}"
+        if provider.adapter not in _ADAPTERS:
+            errors.append(f"{prefix}: unsupported adapter {provider.adapter!r}")
+        if provider.auth not in _AUTH:
+            errors.append(f"{prefix}: unsupported auth {provider.auth!r}")
+        if not _valid_url(provider.base_url):
+            errors.append(f"{prefix}: base_url must be https without control chars")
+        if not provider.models:
+            errors.append(f"{prefix}: no models configured")
+        model_names = Counter(model.name for model in provider.models)
+        for model_name, count in model_names.items():
+            if count > 1:
+                errors.append(f"{prefix}: duplicate model {model_name!r}")
+        for model in provider.models:
+            if model.rpd < 0:
+                errors.append(f"{prefix}/{model.name}: rpd must be non-negative")
+            if model.context is not None and model.context <= 0:
+                errors.append(f"{prefix}/{model.name}: context must be positive")
+    return errors
+
+
+def validate_catalog(path: Path | None = None) -> list[str]:
+    """Validate provider, embedder, and transcriber rows from ``path`` or bundled catalog."""
+    providers = load_catalog(path)
+    table = capability_table()
+    errors = [
+        *_check_group("provider", providers),
+        *_check_group("embedder", load_embedders(path)),
+        *_check_group("transcriber", load_transcribers(path)),
+    ]
+    for provider in providers:
+        for model in provider.models:
+            score = model_capability(model.name, table)
+            if not 0.0 <= score <= 1.0:
+                errors.append(f"provider:{provider.id}/{model.name}: invalid capability score {score}")
+    return errors

--- a/src/freellmpool/cli.py
+++ b/src/freellmpool/cli.py
@@ -707,6 +707,52 @@ def _in_table(name: str, table) -> bool:
     return normalize_model_name(name) in table
 
 
+def cmd_doctor(args: argparse.Namespace) -> int:
+    from .cache import default_cache_path, default_max_entries
+    from .catalog import default_external_catalog_path, load_external_catalog
+    from .catalog_validation import validate_catalog
+    from .key_inventory import default_config_path
+
+    env = os.environ
+    catalog = load_catalog()
+    configured = configured_providers(catalog, env)
+    pool = Pool.from_default_config()
+    quota_path = pool.quota.path
+    cache_path = default_cache_path()
+    external_path = default_external_catalog_path()
+    external = load_external_catalog(external_path)
+    external_note = "missing"
+    if external_path.exists():
+        import time
+
+        age_hours = max(0.0, (time.time() - external_path.stat().st_mtime) / 3600.0)
+        external_note = f"{age_hours:.1f}h old"
+        if age_hours > 24 * 7:
+            external_note += ", stale"
+    errors = validate_catalog()
+
+    print(f"freellmpool {__version__}")
+    print(f"python: {sys.version.split()[0]}")
+    print(f"config: {default_config_path()}")
+    print(f"providers: {len(configured)}/{len(catalog)} configured")
+    print(f"routing: {pool.routing}")
+    print(f"quota: {quota_path} ({'exists' if quota_path.exists() else 'new'})")
+    print(f"cache: {cache_path} ttl={env.get('FREELLMPOOL_CACHE_TTL', '0')} max={default_max_entries()}")
+    print(
+        f"external catalog: {external_path} "
+        f"({len(external)} cached provider{'s' if len(external) != 1 else ''}, {external_note})"
+    )
+    if errors:
+        print("catalog: FAIL")
+        for error in errors[:20]:
+            print(f"  - {error}")
+        if len(errors) > 20:
+            print(f"  ... {len(errors) - 20} more")
+        return 1
+    print("catalog: ok")
+    return 0
+
+
 def cmd_proxy(args: argparse.Namespace) -> int:
     from .proxy import serve  # lazy: avoids http.server import on other paths
 
@@ -756,6 +802,7 @@ def cmd_proxy(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
     finally:
+        pool.quota.flush()
         httpd.server_close()
     return 0
 
@@ -788,6 +835,8 @@ def cmd_mcp(args: argparse.Namespace) -> int:
         serve_stdio(pool, version=__version__)
     except (KeyboardInterrupt, BrokenPipeError):
         pass
+    finally:
+        pool.quota.flush()
     return 0
 
 
@@ -967,6 +1016,9 @@ def build_parser() -> argparse.ArgumentParser:
     p_bench.add_argument("-p", "--providers", help="comma-separated provider ids to test")
     p_bench.add_argument("--timeout", type=float, default=30.0, help="per-call timeout seconds")
     p_bench.set_defaults(func=cmd_benchmark)
+
+    p_doctor = sub.add_parser("doctor", help="show local diagnostics without calling providers")
+    p_doctor.set_defaults(func=cmd_doctor)
 
     p_proxy = sub.add_parser("proxy", help="run the OpenAI-compatible proxy server")
     p_proxy.add_argument("--host", default="127.0.0.1")

--- a/src/freellmpool/client.py
+++ b/src/freellmpool/client.py
@@ -82,6 +82,8 @@ _USER_AGENT = "freellmpool/0.11 (+https://github.com/0xzr/freellmpool)"
 _CONNECT_TIMEOUT = 10.0  # fail fast on dead/unreachable providers so failover is quick
 # Cap a single upstream reply so a broken/malicious provider can't OOM the proxy.
 _MAX_RESPONSE_BYTES = 32 * 1024 * 1024  # 32 MiB
+_MAX_TRANSPORT_ATTEMPTS = 2
+_RETRY_BACKOFF_S = 0.2
 _shared = None  # one pooled, keep-alive httpx.Client shared across calls/threads
 _shared_lock = threading.Lock()
 
@@ -127,26 +129,54 @@ def default_post(url: str, headers: dict, json_body: dict, timeout: float) -> HT
     so a slow-drip upstream (one byte before each per-read timeout) can't pin a worker
     indefinitely. Either guard raises, which the router treats as a failed attempt and
     fails over."""
+    import httpx
+
+    last_exc: httpx.HTTPError | None = None
+    for attempt in range(_MAX_TRANSPORT_ATTEMPTS):
+        try:
+            result = _post_once(url, headers, json_body, timeout)
+        except httpx.HTTPError as exc:
+            last_exc = exc
+            if attempt + 1 >= _MAX_TRANSPORT_ATTEMPTS:
+                raise
+            time.sleep(_RETRY_BACKOFF_S * (attempt + 1))
+            continue
+        if _retryable(result.status) and attempt + 1 < _MAX_TRANSPORT_ATTEMPTS:
+            time.sleep(_RETRY_BACKOFF_S * (attempt + 1))
+            continue
+        return result
+    if last_exc is not None:  # pragma: no cover - loop structure guard
+        raise last_exc
+    raise ProviderHTTPError(502, "transport retry loop exhausted", retryable=True)
+
+
+def _post_once(url: str, headers: dict, json_body: dict, timeout: float) -> HTTPResult:
     deadline = time.monotonic() + timeout
     with _client().stream(
         "POST", url, headers=headers, json=json_body, timeout=_timeout(timeout)
     ) as resp:
-        chunks: list[bytes] = []
-        total = 0
-        for chunk in resp.iter_bytes():
-            total += len(chunk)
-            if total > _MAX_RESPONSE_BYTES:
-                raise ProviderHTTPError(
-                    502, f"upstream response exceeded {_MAX_RESPONSE_BYTES} bytes", retryable=True
-                )
-            if time.monotonic() > deadline:
-                raise ProviderHTTPError(
-                    504, f"upstream exceeded {timeout:.0f}s deadline", retryable=True
-                )
-            chunks.append(chunk)
+        raw, text = _read_capped_response(resp.iter_bytes(), deadline, timeout)
         status = resp.status_code
-    raw = b"".join(chunks)
-    text = raw.decode("utf-8", "replace")
+    return _json_result(status, raw, text)
+
+
+def _read_capped_response(chunks, deadline: float, timeout: float) -> tuple[bytes, str]:
+    out: list[bytes] = []
+    total = 0
+    for chunk in chunks:
+        total += len(chunk)
+        if total > _MAX_RESPONSE_BYTES:
+            raise ProviderHTTPError(
+                502, f"upstream response exceeded {_MAX_RESPONSE_BYTES} bytes", retryable=True
+            )
+        if time.monotonic() > deadline:
+            raise ProviderHTTPError(504, f"upstream exceeded {timeout:.0f}s deadline", retryable=True)
+        out.append(chunk)
+    raw = b"".join(out)
+    return raw, raw.decode("utf-8", "replace")
+
+
+def _json_result(status: int, raw: bytes, text: str) -> HTTPResult:
     try:
         body = json.loads(raw) if raw else {}
         if not isinstance(body, dict):
@@ -548,27 +578,35 @@ def default_multipart_post(
     so a redirect can't exfiltrate the API key (SSRF). Streams + caps the response like
     ``default_post`` so a broken provider can't OOM the proxy and a slow-drip upstream can't
     pin a worker past the deadline."""
+    import httpx
+
+    last_exc: httpx.HTTPError | None = None
+    for attempt in range(_MAX_TRANSPORT_ATTEMPTS):
+        try:
+            result = _multipart_once(url, headers, files, data, timeout)
+        except httpx.HTTPError as exc:
+            last_exc = exc
+            if attempt + 1 >= _MAX_TRANSPORT_ATTEMPTS:
+                raise
+            time.sleep(_RETRY_BACKOFF_S * (attempt + 1))
+            continue
+        if _retryable(result.status) and attempt + 1 < _MAX_TRANSPORT_ATTEMPTS:
+            time.sleep(_RETRY_BACKOFF_S * (attempt + 1))
+            continue
+        return result
+    if last_exc is not None:  # pragma: no cover - loop structure guard
+        raise last_exc
+    raise ProviderHTTPError(502, "transport retry loop exhausted", retryable=True)
+
+
+def _multipart_once(url: str, headers: dict, files: dict, data: dict, timeout: float) -> HTTPResult:
     deadline = time.monotonic() + timeout
     with _client().stream(
         "POST", url, headers=headers, files=files, data=data, timeout=_timeout(timeout)
     ) as resp:
-        chunks: list[bytes] = []
-        total = 0
-        for chunk in resp.iter_bytes():
-            total += len(chunk)
-            if total > _MAX_RESPONSE_BYTES:
-                raise ProviderHTTPError(
-                    502, f"upstream response exceeded {_MAX_RESPONSE_BYTES} bytes", retryable=True
-                )
-            if time.monotonic() > deadline:
-                raise ProviderHTTPError(
-                    504, f"upstream exceeded {timeout:.0f}s deadline", retryable=True
-                )
-            chunks.append(chunk)
+        raw, text = _read_capped_response(resp.iter_bytes(), deadline, timeout)
         status = resp.status_code
         ctype = resp.headers.get("content-type", "")
-    raw = b"".join(chunks)
-    text = raw.decode("utf-8", "replace")
     if "application/json" in ctype:
         try:
             body = json.loads(raw) if raw else {}

--- a/src/freellmpool/client.py
+++ b/src/freellmpool/client.py
@@ -15,12 +15,14 @@ router and adapters can be unit-tested without touching the network.
 from __future__ import annotations
 
 import json
+import random
 import re
 import sys
 import threading
 import time
 from collections.abc import Callable
 from dataclasses import dataclass
+from email.utils import parsedate_to_datetime
 
 from .errors import ProviderHTTPError
 from .models import EmbedReply, Provider, Reply, TranscribeReply
@@ -68,6 +70,7 @@ class HTTPResult:
     status: int
     body: dict
     text: str
+    headers: dict | None = None
 
 
 PostFn = Callable[[str, dict, dict, float], HTTPResult]
@@ -131,33 +134,50 @@ def default_post(url: str, headers: dict, json_body: dict, timeout: float) -> HT
     fails over."""
     import httpx
 
+    deadline = time.monotonic() + timeout
     last_exc: httpx.HTTPError | None = None
+    last_result: HTTPResult | None = None
     for attempt in range(_MAX_TRANSPORT_ATTEMPTS):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
         try:
-            result = _post_once(url, headers, json_body, timeout)
+            result = _post_once(url, headers, json_body, remaining, deadline)
         except httpx.HTTPError as exc:
             last_exc = exc
+            if not _retryable_transport_error(exc, httpx):
+                raise
             if attempt + 1 >= _MAX_TRANSPORT_ATTEMPTS:
                 raise
-            time.sleep(_RETRY_BACKOFF_S * (attempt + 1))
+            delay = _retry_delay(None, attempt, deadline)
+            if delay is None:
+                raise
+            time.sleep(delay)
             continue
+        last_result = result
         if _retryable(result.status) and attempt + 1 < _MAX_TRANSPORT_ATTEMPTS:
-            time.sleep(_RETRY_BACKOFF_S * (attempt + 1))
-            continue
+            delay = _retry_delay(result, attempt, deadline)
+            if delay is not None:
+                time.sleep(delay)
+                continue
         return result
     if last_exc is not None:  # pragma: no cover - loop structure guard
         raise last_exc
+    if last_result is not None:
+        return last_result
     raise ProviderHTTPError(502, "transport retry loop exhausted", retryable=True)
 
 
-def _post_once(url: str, headers: dict, json_body: dict, timeout: float) -> HTTPResult:
-    deadline = time.monotonic() + timeout
+def _post_once(
+    url: str, headers: dict, json_body: dict, timeout: float, deadline: float
+) -> HTTPResult:
     with _client().stream(
         "POST", url, headers=headers, json=json_body, timeout=_timeout(timeout)
     ) as resp:
         raw, text = _read_capped_response(resp.iter_bytes(), deadline, timeout)
         status = resp.status_code
-    return _json_result(status, raw, text)
+        headers = dict(getattr(resp, "headers", {}) or {})
+    return _json_result(status, raw, text, headers=headers)
 
 
 def _read_capped_response(chunks, deadline: float, timeout: float) -> tuple[bytes, str]:
@@ -176,14 +196,61 @@ def _read_capped_response(chunks, deadline: float, timeout: float) -> tuple[byte
     return raw, raw.decode("utf-8", "replace")
 
 
-def _json_result(status: int, raw: bytes, text: str) -> HTTPResult:
+def _json_result(status: int, raw: bytes, text: str, headers: dict | None = None) -> HTTPResult:
     try:
         body = json.loads(raw) if raw else {}
         if not isinstance(body, dict):
             body = {}
     except (json.JSONDecodeError, ValueError):
         body = {}
-    return HTTPResult(status=status, body=body, text=text)
+    return HTTPResult(status=status, body=body, text=text, headers=headers)
+
+
+def _header(headers: dict | None, name: str) -> str | None:
+    if not headers:
+        return None
+    direct = headers.get(name)
+    if direct is not None:
+        return str(direct)
+    low = name.lower()
+    for key, value in headers.items():
+        if str(key).lower() == low:
+            return str(value)
+    return None
+
+
+def _retry_after_seconds(headers: dict | None) -> float | None:
+    raw = _header(headers, "Retry-After")
+    if not raw:
+        return None
+    raw = raw.strip()
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        pass
+    try:
+        return max(0.0, parsedate_to_datetime(raw).timestamp() - time.time())
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _retry_delay(result: HTTPResult | None, attempt: int, deadline: float) -> float | None:
+    return _retry_delay_monotonic(result, attempt, deadline, time.monotonic)
+
+
+def _retry_delay_monotonic(
+    result: HTTPResult | None, attempt: int, deadline: float, now
+) -> float | None:
+    base = _retry_after_seconds(result.headers if result is not None else None)
+    if base is None:
+        base = _RETRY_BACKOFF_S * (attempt + 1)
+    jitter = random.uniform(0.0, min(0.1, base * 0.1)) if base > 0 else 0.0
+    delay = base + jitter
+    return delay if now() + delay < deadline else None
+
+
+def _retryable_transport_error(exc, httpx) -> bool:
+    return isinstance(exc, (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout))
 
 
 class _StreamLines:
@@ -580,33 +647,50 @@ def default_multipart_post(
     pin a worker past the deadline."""
     import httpx
 
+    deadline = time.monotonic() + timeout
     last_exc: httpx.HTTPError | None = None
+    last_result: HTTPResult | None = None
     for attempt in range(_MAX_TRANSPORT_ATTEMPTS):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
         try:
-            result = _multipart_once(url, headers, files, data, timeout)
+            result = _multipart_once(url, headers, files, data, remaining, deadline)
         except httpx.HTTPError as exc:
             last_exc = exc
+            if not _retryable_transport_error(exc, httpx):
+                raise
             if attempt + 1 >= _MAX_TRANSPORT_ATTEMPTS:
                 raise
-            time.sleep(_RETRY_BACKOFF_S * (attempt + 1))
+            delay = _retry_delay(None, attempt, deadline)
+            if delay is None:
+                raise
+            time.sleep(delay)
             continue
+        last_result = result
         if _retryable(result.status) and attempt + 1 < _MAX_TRANSPORT_ATTEMPTS:
-            time.sleep(_RETRY_BACKOFF_S * (attempt + 1))
-            continue
+            delay = _retry_delay(result, attempt, deadline)
+            if delay is not None:
+                time.sleep(delay)
+                continue
         return result
     if last_exc is not None:  # pragma: no cover - loop structure guard
         raise last_exc
+    if last_result is not None:
+        return last_result
     raise ProviderHTTPError(502, "transport retry loop exhausted", retryable=True)
 
 
-def _multipart_once(url: str, headers: dict, files: dict, data: dict, timeout: float) -> HTTPResult:
-    deadline = time.monotonic() + timeout
+def _multipart_once(
+    url: str, headers: dict, files: dict, data: dict, timeout: float, deadline: float
+) -> HTTPResult:
     with _client().stream(
         "POST", url, headers=headers, files=files, data=data, timeout=_timeout(timeout)
     ) as resp:
         raw, text = _read_capped_response(resp.iter_bytes(), deadline, timeout)
         status = resp.status_code
-        ctype = resp.headers.get("content-type", "")
+        response_headers = dict(getattr(resp, "headers", {}) or {})
+        ctype = _header(response_headers, "content-type") or ""
     if "application/json" in ctype:
         try:
             body = json.loads(raw) if raw else {}
@@ -616,7 +700,7 @@ def _multipart_once(url: str, headers: dict, files: dict, data: dict, timeout: f
             body = {}  # keep _err_message safe; transcribe() falls back to result.text
     else:
         body = {"text": text}  # response_format=text returns the transcription as plain text
-    return HTTPResult(status=status, body=body, text=text)
+    return HTTPResult(status=status, body=body, text=text, headers=response_headers)
 
 
 def transcribe(

--- a/src/freellmpool/mcp_server.py
+++ b/src/freellmpool/mcp_server.py
@@ -33,10 +33,10 @@ import time
 
 from .config import resolve_alias, split_provider_model
 from .router import Pool
+from .routing_modes import routing_override
 from .tokenmax import HARD_CAP, RAINBOW_BANNER, fan_out, select_targets
 
 _DEFAULT_PROTOCOL = "2025-06-18"
-_ROUTING_MODES = ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
 _MAX_PANEL = 5
 
 # Returned in the `initialize` handshake (MCP's standard `instructions` field) so the
@@ -213,7 +213,7 @@ def _text(text: str, is_error: bool = False) -> dict:
 
 def _routing_arg(value) -> str | None:
     """Map the tool's routing arg to a pool routing override (auto/unknown -> None)."""
-    return value if isinstance(value, str) and value in _ROUTING_MODES else None
+    return routing_override(value)
 
 
 def _messages(system, prompt: str) -> list[dict[str, str]]:
@@ -568,30 +568,35 @@ def serve_stdio(pool: Pool, version: str = "0.0.0") -> None:
         except Exception:  # noqa: BLE001
             pass
 
-    for line in sys.stdin:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            msg = json.loads(line)
-        except (json.JSONDecodeError, ValueError):
-            emit(_error(None, -32700, "parse error: invalid JSON"))
-            continue
-        if isinstance(msg, list):  # JSON-RPC batch
-            if not msg:
-                emit(_error(None, -32600, "invalid request: empty batch"))
+    try:
+        for line in sys.stdin:
+            line = line.strip()
+            if not line:
                 continue
-            responses = [
-                r
-                for r in (
-                    handle_message(pool, m, version=version, send_notification=send_notification)
-                    for m in msg
-                )
-                if r
-            ]
-            # JSON-RPC 2.0: a batch gets a single response that is an array of the
-            # individual responses (omitting notifications). All-notifications → no reply.
-            if responses:
-                write_obj(responses)
-            continue
-        emit(handle_message(pool, msg, version=version, send_notification=send_notification))
+            try:
+                msg = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                emit(_error(None, -32700, "parse error: invalid JSON"))
+                continue
+            if isinstance(msg, list):  # JSON-RPC batch
+                if not msg:
+                    emit(_error(None, -32600, "invalid request: empty batch"))
+                    continue
+                responses = [
+                    r
+                    for r in (
+                        handle_message(
+                            pool, m, version=version, send_notification=send_notification
+                        )
+                        for m in msg
+                    )
+                    if r
+                ]
+                # JSON-RPC 2.0: a batch gets a single response that is an array of the
+                # individual responses (omitting notifications). All-notifications → no reply.
+                if responses:
+                    write_obj(responses)
+                continue
+            emit(handle_message(pool, msg, version=version, send_notification=send_notification))
+    finally:
+        pool.quota.flush()

--- a/src/freellmpool/metrics.py
+++ b/src/freellmpool/metrics.py
@@ -95,12 +95,16 @@ class Metrics:
         targets are penalized mostly by failure rate, with latency as a tiebreak.
         """
         with self._lock:
-            st = self._stats.get(key)
-            if st is None or st.total == 0:
-                return _UNKNOWN_SCORE
-            lat_s = (st.ewma_ms or 0.0) / 1000.0
-            return (1.0 - st.success_rate) * 10.0 + min(lat_s, 10.0) * 0.1
+            return score_stat(self._stats.get(key))
 
 
 def _copy(st: Stat) -> Stat:
     return Stat(st.ok, st.fail, st.ewma_ms, st.last_ms, st.last_error)
+
+
+def score_stat(st: Stat | None) -> float:
+    """Routing penalty for a copied :class:`Stat`; mirrors :meth:`Metrics.score`."""
+    if st is None or st.total == 0:
+        return _UNKNOWN_SCORE
+    lat_s = (st.ewma_ms or 0.0) / 1000.0
+    return (1.0 - st.success_rate) * 10.0 + min(lat_s, 10.0) * 0.1

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -41,6 +41,7 @@ from .errors import (
     NoProvidersConfigured,
 )
 from .router import Pool
+from .routing_modes import PUBLIC_ROUTING_ALIASES, routing_override
 from .savings import usd_saved
 
 _MAX_BODY = 16 * 1024 * 1024  # 16 MB cap on request bodies
@@ -58,7 +59,7 @@ def _model_ids(pool: Pool) -> list[str]:
     # INVARIANT: always non-empty (the routing aliases are unconditional). _anthropic_models_payload
     # relies on this for first_id/last_id = ids[0]/ids[-1] without a guard — keep these seeds
     # unconditional, or restore that guard.
-    ids = ["auto", "spread", "fast", "quality", "fair"]
+    ids = list(PUBLIC_ROUTING_ALIASES)
     for provider in pool.providers:
         for m in provider.models:
             if m.enabled:
@@ -178,23 +179,20 @@ def _status_payload(pool: Pool, recent: Sequence[dict], tokenmax: dict | None = 
     }
 
 
-_ROUTING_MODES = frozenset({"fair", "fast", "quality", "spread", "legacy", "model", "model-fast"})
-
-
 def _routing_and_model(headers, requested: str) -> tuple[str | None, str]:
     """Resolve a per-request routing override. A valid mode in the
     ``X-Freellmpool-Routing`` header, or the model name itself being a routing
     keyword (e.g. ``fast``/``quality``), selects that mode and falls back to ``auto``
     model selection. Returns ``(routing_override, requested_model)``."""
-    override = (headers.get("X-Freellmpool-Routing", "") or "").lower()
-    override = override if override in _ROUTING_MODES else None
+    override = routing_override(headers.get("X-Freellmpool-Routing"))
     if isinstance(requested, str):
         # accept bare or provider-qualified aliases: 'spread', 'freellmpool/spread',
         # and 'freellmpool/auto' (opencode sends its provider name as the prefix). No real
         # pool model is named after a routing keyword or 'auto', so the suffix check is safe.
         alias = requested.rsplit("/", 1)[-1].lower()
-        if alias in _ROUTING_MODES:
-            override = override or alias
+        alias_override = routing_override(alias)
+        if alias_override is not None:
+            override = override or alias_override
             requested = "auto"
         elif alias == "auto":
             requested = "auto"  # 'auto' / 'freellmpool/auto' → default routing, no provider filter
@@ -1255,6 +1253,7 @@ def serve(
         api_key = os.environ.get("FREELLMPOOL_PROXY_KEY") or None
     handler = make_handler(pool, api_key)
     httpd = _BoundedThreadingHTTPServer((host, port), handler)
+    httpd.pool = pool
     # Worker threads are daemons so a stuck request can't block process/server
     # shutdown (Ctrl-C, container stop).
     httpd.daemon_threads = True
@@ -1274,6 +1273,12 @@ class _BoundedThreadingHTTPServer(ThreadingHTTPServer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._slots = threading.BoundedSemaphore(_MAX_CONNECTIONS)
+
+    def server_close(self) -> None:
+        pool = getattr(self, "pool", None)
+        if pool is not None:
+            pool.quota.flush()
+        super().server_close()
 
     def process_request(self, request, client_address):
         if not self._slots.acquire(blocking=False):

--- a/src/freellmpool/quota.py
+++ b/src/freellmpool/quota.py
@@ -40,11 +40,28 @@ def default_quota_path() -> Path:
 class QuotaStore:
     """A small JSON-backed counter keyed by (day, provider_id, model)."""
 
-    def __init__(self, path: Path | None = None, clock: Callable[[], datetime] | None = None):
+    def __init__(
+        self,
+        path: Path | None = None,
+        clock: Callable[[], datetime] | None = None,
+        flush_every: int | None = None,
+    ):
         self.path = path or default_quota_path()
         self._clock = clock or (lambda: datetime.now(UTC))
         self._lock = threading.Lock()  # the proxy is threaded; guard read-modify-write
+        if flush_every is None:
+            try:
+                flush_every = int(os.environ.get("FREELLMPOOL_QUOTA_FLUSH_EVERY", "1"))
+            except ValueError:
+                flush_every = 1
+        self.flush_every = max(1, flush_every)
+        self._pending_counts: dict[str, dict[str, int]] = {}
+        self._pending_ops = 0
         self._data: dict = self._load()
+        if self.flush_every > 1:
+            import atexit
+
+            atexit.register(self.flush)
 
     def _load(self) -> dict:
         try:
@@ -105,7 +122,24 @@ class QuotaStore:
             return int(self._today().get(self._key(provider_id, model), 0))
 
     def record(self, provider_id: str, model: str, n: int = 1) -> int:
-        with self._lock, self._file_lock():
+        with self._lock:
+            if self.flush_every <= 1:
+                return self._record_and_save_locked(provider_id, model, n)
+
+            day = _utc_day(self._clock())
+            bucket = self._today()
+            key = self._key(provider_id, model)
+            bucket[key] = int(bucket.get(key, 0)) + n
+            self._pending_counts.setdefault(day, {})
+            self._pending_counts[day][key] = int(self._pending_counts[day].get(key, 0)) + n
+            self._pending_ops += 1
+            count = bucket[key]
+            if self._pending_ops >= self.flush_every:
+                self._flush_locked()
+            return count
+
+    def _record_and_save_locked(self, provider_id: str, model: str, n: int) -> int:
+        with self._file_lock():
             # Reload under the lock so concurrent processes' increments survive
             # (we'd otherwise write a stale whole-file snapshot over theirs).
             self._data = self._load()
@@ -121,6 +155,36 @@ class QuotaStore:
                 pass
             return count
 
+    def flush(self) -> None:
+        """Persist any locally batched quota increments."""
+        with self._lock:
+            self._flush_locked()
+
+    def _flush_locked(self) -> None:
+        if not self._pending_counts:
+            return
+        current_day = _utc_day(self._clock())
+        with self._file_lock():
+            merged = self._load()
+            bucket = merged.get(current_day)
+            if bucket is None:
+                merged = {current_day: {}}
+                bucket = merged[current_day]
+            for day, changes in self._pending_counts.items():
+                if day != current_day:
+                    continue
+                for key, amount in changes.items():
+                    bucket[key] = int(bucket.get(key, 0)) + amount
+            old_data = self._data
+            self._data = merged
+            try:
+                self._save()
+            except OSError:
+                self._data = old_data
+                return
+            self._pending_counts.clear()
+            self._pending_ops = 0
+
     def over_budget(self, provider_id: str, model: str, rpd: int) -> bool:
         """True if a positive rpd hint exists and today's use meets/exceeds it."""
         if rpd <= 0:
@@ -133,5 +197,11 @@ class QuotaStore:
         Reloads from disk (a cheap, atomic os.replace target) so a long-running
         proxy reflects increments other processes have made."""
         with self._lock:
-            self._data = self._load()
-            return dict(self._today())
+            self._flush_locked()
+            current_day = _utc_day(self._clock())
+            loaded = self._load()
+            bucket = dict(loaded.get(current_day, {}))
+            for key, amount in self._pending_counts.get(current_day, {}).items():
+                bucket[key] = int(bucket.get(key, 0)) + amount
+            self._data = {current_day: bucket}
+            return bucket

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -42,7 +42,7 @@ from .errors import (
     NoProvidersConfigured,
     ProviderHTTPError,
 )
-from .metrics import Metrics
+from .metrics import Metrics, score_stat
 from .models import EmbedReply, Provider, Reply, TranscribeReply
 from .observe import EventHook, emit
 from .quota import QuotaStore
@@ -444,9 +444,11 @@ class Pool:
         the ordering is a hint — failover still reaches all.
         """
 
-        # One snapshot instead of a locked read per target (matters for large catalogs).
+        # One quota and metrics snapshot instead of locked reads per target (matters
+        # for large catalogs and route explanations).
         snap = self.quota.snapshot()
         metrics = self.metrics
+        msnap = metrics.snapshot()
         mode = (
             routing
             if routing in ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
@@ -459,10 +461,19 @@ class Pool:
         def over_of(t: Target) -> int:
             return 1 if (t.rpd > 0 and used_of(t) >= t.rpd) else 0
 
+        def stat_of(t: Target):
+            return msnap.get(t.name)
+
+        def failing_of(t: Target) -> bool:
+            st = stat_of(t)
+            return bool(st and st.failing)
+
+        def score_of(t: Target) -> float:
+            return score_stat(stat_of(t))
+
         if mode == "quality":
             table = capability_table()
             need = difficulty if difficulty is not None else 0.5
-            msnap = metrics.snapshot()  # one locked read for failing + latency
 
             def lat_pen(t: Target) -> float:
                 # Latency penalty in [0,1]: a measured target's smoothed latency
@@ -472,7 +483,7 @@ class Pool:
                 # below the difficulty bar, this term only re-orders models that
                 # *already clear* the bar — so quality stops parking on a giant that
                 # takes tens of seconds when a comparably-capable model answers in ~1s.
-                st = msnap.get(t.name)
+                st = stat_of(t)
                 if st is None or st.ewma_ms is None:
                     return _QUALITY_UNKNOWN_LAT
                 return min(st.ewma_ms / 1000.0, _QUALITY_SLOW_S) / _QUALITY_SLOW_S
@@ -480,10 +491,9 @@ class Pool:
             def quality_key(t: Target) -> tuple[int, int, float, int]:
                 # over-budget, then known-failing sink to the back (still reachable);
                 # then capability-fit blended with latency; then least-used.
-                st = msnap.get(t.name)
                 return (
                     over_of(t),
-                    1 if (st and st.failing) else 0,
+                    1 if failing_of(t) else 0,
                     fit_penalty(model_capability(t.model, table), need) + lat_pen(t),
                     used_of(t),
                 )
@@ -493,10 +503,10 @@ class Pool:
         if mode in ("legacy", "model", "model-fast"):
 
             def legacy_fast_key(t: Target) -> tuple[int, float, int]:
-                return (over_of(t), metrics.score(t.name), used_of(t))
+                return (over_of(t), score_of(t), used_of(t))
 
             def legacy_fair_key(t: Target) -> tuple[int, int, int]:
-                return (over_of(t), 1 if metrics.failing(t.name) else 0, used_of(t))
+                return (over_of(t), 1 if failing_of(t) else 0, used_of(t))
 
             key = legacy_fast_key if mode == "model-fast" else legacy_fair_key
             return sorted(targets, key=key)
@@ -508,25 +518,25 @@ class Pool:
             stats.targets.append(target)
             target_used = used_of(target)
             target_over = over_of(target)
-            target_failing = metrics.failing(target.name)
+            target_failing = failing_of(target)
             stats.used += target_used
             stats.all_over = stats.all_over and bool(target_over)
             stats.all_failing = stats.all_failing and target_failing
-            stats.best_score = min(stats.best_score, metrics.score(target.name))
+            stats.best_score = min(stats.best_score, score_of(target))
 
         def target_fair_key(t: Target) -> tuple[int, int, int]:
-            return (over_of(t), 1 if metrics.failing(t.name) else 0, used_of(t))
+            return (over_of(t), 1 if failing_of(t) else 0, used_of(t))
 
         def target_fast_key(t: Target) -> tuple[int, float, int]:
-            return (over_of(t), metrics.score(t.name), used_of(t))
+            return (over_of(t), score_of(t), used_of(t))
 
         def target_spread_key(t: Target) -> tuple[int, int, int, float]:
             # least-used TIER first (spread across the whole pool), then fastest within tier.
             return (
                 over_of(t),
-                1 if metrics.failing(t.name) else 0,
+                1 if failing_of(t) else 0,
                 used_of(t) // _SPREAD_BUCKET,
-                metrics.score(t.name),
+                score_of(t),
             )
 
         if mode == "fast":

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -46,6 +46,7 @@ from .metrics import Metrics, score_stat
 from .models import EmbedReply, Provider, Reply, TranscribeReply
 from .observe import EventHook, emit
 from .quota import QuotaStore
+from .routing_modes import normalize_routing_mode
 from .stats import StatsStore
 
 # A parsed "context limit" below this is treated as garbled/implausible and not
@@ -131,6 +132,28 @@ class Pool:
         stats_store: StatsStore | None = None,
     ):
         self.providers = providers
+        targets: list[Target] = []
+        enabled_targets: list[Target] = []
+        targets_by_provider: dict[str, list[Target]] = {}
+        enabled_by_provider: dict[str, list[Target]] = {}
+        targets_by_model: dict[str, list[Target]] = {}
+        enabled_by_model: dict[str, list[Target]] = {}
+        for provider in providers:
+            for model_obj in provider.models:
+                target = Target(provider, model_obj.name, model_obj.rpd, model_obj.context)
+                targets.append(target)
+                targets_by_provider.setdefault(provider.id, []).append(target)
+                targets_by_model.setdefault(model_obj.name, []).append(target)
+                if model_obj.enabled:
+                    enabled_targets.append(target)
+                    enabled_by_provider.setdefault(provider.id, []).append(target)
+                    enabled_by_model.setdefault(model_obj.name, []).append(target)
+        self._targets = tuple(targets)
+        self._enabled_targets = tuple(enabled_targets)
+        self._targets_by_provider = {k: tuple(v) for k, v in targets_by_provider.items()}
+        self._enabled_targets_by_provider = {k: tuple(v) for k, v in enabled_by_provider.items()}
+        self._targets_by_model = {k: tuple(v) for k, v in targets_by_model.items()}
+        self._enabled_targets_by_model = {k: tuple(v) for k, v in enabled_by_model.items()}
         self.embedders = embedders or []
         self.transcribers = transcribers or []
         self._transcribe_post = transcribe_post
@@ -147,11 +170,7 @@ class Pool:
         # "quality"— match prompt difficulty to model capability (benchmark-scored),
         #            so hard prompts get strong models and easy ones get light ones.
         # "legacy"/"model" keep the old per-(provider, model) balancing behavior.
-        self.routing = (
-            routing
-            if routing in ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
-            else "fair"
-        )
+        self.routing = normalize_routing_mode(routing)
         self._on_event = on_event
         # provider_id -> monotonic time until which to deprioritize after a 429
         self._cooldown_until: dict[str, float] = {}
@@ -209,16 +228,12 @@ class Pool:
         explainer and multi-model panel (which fan out across the top targets) without
         re-implementing routing. Read-only — does not call any provider."""
         provider_list = list(providers) if providers else None
-        eff = (
-            routing
-            if routing in ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
-            else self.routing
-        )
+        eff = normalize_routing_mode(routing, self.routing)
         difficulty = prompt_difficulty(messages) if eff == "quality" else None
         return self._order(
             self._all_targets(include=provider_list, model=model),
             difficulty=difficulty,
-            routing=routing,
+            routing=eff,
         )
 
     def _mark_cooldown(self, provider_id: str, now: float) -> None:
@@ -404,19 +419,10 @@ class Pool:
         model: str | None = None,
     ) -> list[Target]:
         include_set = {p.strip() for p in include} if include else None
-        targets: list[Target] = []
-        for provider in self.providers:
-            if include_set is not None and provider.id not in include_set:
-                continue
-            for m in provider.models:
-                if model is not None:
-                    if m.name != model:
-                        continue
-                    # explicit model pin: allow it even if disabled by default
-                elif not m.enabled:
-                    continue  # auto routing skips off-by-default models
-                targets.append(Target(provider, m.name, m.rpd, m.context))
-        return targets
+        source = self._targets_by_model.get(model, ()) if model is not None else self._enabled_targets
+        if include_set is None:
+            return list(source)
+        return [target for target in source if target.provider.id in include_set]
 
     def _order(
         self, targets: list[Target], difficulty: float | None = None, routing: str | None = None
@@ -449,11 +455,7 @@ class Pool:
         snap = self.quota.snapshot()
         metrics = self.metrics
         msnap = metrics.snapshot()
-        mode = (
-            routing
-            if routing in ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
-            else self.routing
-        )
+        mode = normalize_routing_mode(routing, self.routing)
 
         def used_of(t: Target) -> int:
             return int(snap.get(f"{t.provider.id}::{t.model}", 0))
@@ -639,11 +641,7 @@ class Pool:
         # Resolve the effective routing mode *before* the cache key so that a
         # per-request override (fast/quality/fair/…) keys its own cache bucket and
         # never serves a reply produced under a different mode's intent.
-        eff = (
-            routing
-            if routing in ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
-            else self.routing
-        )
+        eff = normalize_routing_mode(routing, self.routing)
         cache_key = None
         if self._cache is not None:
             cache_key = self._cache.make_key(
@@ -651,6 +649,7 @@ class Pool:
             )
             hit = self._cache.get(cache_key)
             if hit is not None:
+                emit(self._on_event, "cache_hit", key=cache_key)
                 self._bump_stats(cache_hits=1)
                 return Reply(
                     text=hit.get("text", ""),
@@ -662,12 +661,13 @@ class Pool:
                     message=hit.get("message"),
                     cached=True,
                 )
+            emit(self._on_event, "cache_miss", key=cache_key)
 
         difficulty = prompt_difficulty(messages, max_tokens, tools) if eff == "quality" else None
         targets = self._order(
             self._all_targets(include=provider_list, model=model),
             difficulty=difficulty,
-            routing=routing,
+            routing=eff,
         )
         if not targets:
             raise NoProvidersConfigured("no candidate (provider, model) matched the given filters")
@@ -795,6 +795,7 @@ class Pool:
                         "message": reply.message,
                     },
                 )
+                emit(self._on_event, "cache_store", key=cache_key, target=target.name)
             return reply
 
         emit(self._on_event, "exhausted", attempts=len(attempts))
@@ -826,16 +827,12 @@ class Pool:
         """
         if not self.providers:
             raise NoProvidersConfigured("no provider has an API key set")
-        eff = (
-            routing
-            if routing in ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
-            else self.routing
-        )
+        eff = normalize_routing_mode(routing, self.routing)
         difficulty = prompt_difficulty(messages, max_tokens) if eff == "quality" else None
         targets = self._order(
             self._all_targets(include=providers, model=model),
             difficulty=difficulty,
-            routing=routing,
+            routing=eff,
         )
         targets = [t for t in targets if t.provider.adapter != "gemini"]
         if not targets:

--- a/src/freellmpool/routing_modes.py
+++ b/src/freellmpool/routing_modes.py
@@ -21,7 +21,7 @@ def normalize_routing_mode(value: str | None, default: str = "fair") -> str:
     return fallback if fallback in _ROUTING_SET else "fair"
 
 
-def routing_override(value) -> str | None:
+def routing_override(value: object) -> str | None:
     """Return a valid override mode, or ``None`` for ``auto``/unknown values."""
     if not isinstance(value, str):
         return None

--- a/src/freellmpool/routing_modes.py
+++ b/src/freellmpool/routing_modes.py
@@ -1,0 +1,31 @@
+"""Shared routing-mode normalization.
+
+These helpers keep the library, proxy, and MCP server in sync: a misspelled mode
+falls back to the pool default, while public aliases such as ``auto`` mean
+"do not override the pool default".
+"""
+
+from __future__ import annotations
+
+ROUTING_MODES = ("fair", "fast", "quality", "spread", "legacy", "model", "model-fast")
+PUBLIC_ROUTING_ALIASES = ("auto", "spread", "fast", "quality", "fair")
+_ROUTING_SET = frozenset(ROUTING_MODES)
+
+
+def normalize_routing_mode(value: str | None, default: str = "fair") -> str:
+    """Return a valid internal routing mode, falling back to ``default``."""
+    mode = value.strip().lower() if isinstance(value, str) else ""
+    if mode in _ROUTING_SET:
+        return mode
+    fallback = default.strip().lower() if isinstance(default, str) else "fair"
+    return fallback if fallback in _ROUTING_SET else "fair"
+
+
+def routing_override(value) -> str | None:
+    """Return a valid override mode, or ``None`` for ``auto``/unknown values."""
+    if not isinstance(value, str):
+        return None
+    mode = value.strip().lower()
+    if mode == "auto":
+        return None
+    return mode if mode in _ROUTING_SET else None

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -7,9 +7,12 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
 from helpers import gemini_body, make_post
 
+from freellmpool import client as sync_client
 from freellmpool.aio import AsyncPool
+from freellmpool.errors import ProviderHTTPError
 from freellmpool.router import Pool
 
 
@@ -143,3 +146,84 @@ def test_async_custom_adapter_runs_via_thread(quota):
         assert reply.text == "from-plugin"  # plugin adapter reached on the async path
     finally:
         plugins._reset_for_tests()
+
+
+class _AsyncResp:
+    def __init__(self, chunks, *, status=200, headers=None):
+        self._chunks = chunks
+        self.status_code = status
+        self.headers = headers or {"content-type": "application/json"}
+
+    async def aiter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+
+class _AsyncCM:
+    def __init__(self, resp):
+        self._resp = resp
+
+    async def __aenter__(self):
+        return self._resp
+
+    async def __aexit__(self, *args):
+        return False
+
+
+def test_async_default_apost_streams_response(providers, env, quota):
+    class Client:
+        def stream(self, *args, **kwargs):
+            return _AsyncCM(_AsyncResp([b'{"choices":[{"message":{"content":"ok"}}]}']))
+
+    pool = AsyncPool(Pool(providers, quota=quota, env=env))
+
+    async def client_obj():
+        return Client()
+
+    pool._client_obj = client_obj
+    result = asyncio.run(pool._apost("https://x.test/v1", {}, {}, 30.0))
+    assert result.body["choices"][0]["message"]["content"] == "ok"
+
+
+def test_async_default_apost_caps_oversized_response(providers, env, quota, monkeypatch):
+    class Client:
+        def stream(self, *args, **kwargs):
+            return _AsyncCM(_AsyncResp([b"xx", b"xx"]))
+
+    pool = AsyncPool(Pool(providers, quota=quota, env=env))
+
+    async def client_obj():
+        return Client()
+
+    pool._client_obj = client_obj
+    monkeypatch.setattr(sync_client, "_MAX_RESPONSE_BYTES", 3)
+    with pytest.raises(ProviderHTTPError):
+        asyncio.run(pool._apost("https://x.test/v1", {}, {}, 30.0))
+
+
+def test_async_default_apost_retries_with_original_request_headers(providers, env, quota):
+    calls = []
+    request_headers = {"Authorization": "Bearer k", "Content-Type": "application/json"}
+
+    class Client:
+        def stream(self, *args, **kwargs):
+            calls.append(dict(kwargs["headers"]))
+            if len(calls) == 1:
+                return _AsyncCM(
+                    _AsyncResp(
+                        [b'{"error":"slow"}'],
+                        status=429,
+                        headers={"Retry-After": "0", "x-response": "provider"},
+                    )
+                )
+            return _AsyncCM(_AsyncResp([b'{"choices":[{"message":{"content":"ok"}}]}']))
+
+    pool = AsyncPool(Pool(providers, quota=quota, env=env))
+
+    async def client_obj():
+        return Client()
+
+    pool._client_obj = client_obj
+    result = asyncio.run(pool._apost("https://x.test/v1", request_headers, {}, 30.0))
+    assert result.status == 200
+    assert calls == [request_headers, request_headers]

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -95,6 +95,30 @@ def test_async_uses_response_cache(providers, env, quota, tmp_path):
     assert len(apost.calls) == 1
 
 
+def test_async_cache_key_includes_pool_routing(providers, env, quota, tmp_path):
+    from freellmpool.cache import Cache
+
+    cache = Cache(ttl=60, path=tmp_path / "cache.sqlite")
+    fast_post = _async_post({})
+    fast = AsyncPool(
+        Pool(providers, quota=quota, env=env, cache=cache, routing="fast"),
+        apost=fast_post,
+    )
+    asyncio.run(fast.aask("same question", providers=["alpha", "beta"]))
+    assert len(fast_post.calls) == 1
+
+    quality_post = _async_post({})
+    quality = AsyncPool(
+        Pool(providers, quota=quota, env=env, cache=cache, routing="quality"),
+        apost=quality_post,
+    )
+    reply = asyncio.run(quality.aask("same question", providers=["alpha", "beta"]))
+
+    assert reply.cached is False
+    assert len(quality_post.calls) == 1
+    assert quality.stats["cache_hits"] == 0
+
+
 def test_async_custom_adapter_runs_via_thread(quota):
     from freellmpool import plugins
     from freellmpool.models import Model, Provider, Reply

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,27 @@
+"""Local benchmark comparison helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "compare_benchmarks.py"
+_SPEC = importlib.util.spec_from_file_location("compare_benchmarks", _SCRIPT_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+compare = _MODULE.compare
+
+
+def test_compare_benchmarks_reports_large_regressions():
+    previous = {"rank": {"mean_ms": 10.0, "p95_ms": 20.0}}
+    current = {"rank": {"mean_ms": 12.0, "p95_ms": 31.0}}
+    warnings = compare(previous, current, warn_percent=30.0)
+    assert warnings == ["rank.p95_ms: 20.0000 -> 31.0000 ms (+55.0%)"]
+
+
+def test_compare_benchmarks_ignores_small_changes():
+    previous = {"rank": {"mean_ms": 10.0, "p95_ms": 20.0}}
+    current = {"rank": {"mean_ms": 12.0, "p95_ms": 25.0}}
+    assert compare(previous, current, warn_percent=30.0) == []

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import sqlite3
+import threading
+
 from helpers import make_post, make_stream_post
 
 from freellmpool.cache import Cache
@@ -17,6 +20,39 @@ def test_cache_get_put_and_ttl(tmp_path):
     assert c.get(key)["text"] == "cached"
     t[0] = 200.0  # 100s later, ttl 50 → expired
     assert c.get(key) is None
+
+
+def test_cache_uses_wal_and_prunes_to_max_entries(tmp_path):
+    t = [100.0]
+    c = Cache(ttl=999.0, path=tmp_path / "c.db", clock=lambda: t[0], max_entries=2)
+    with sqlite3.connect(c.path) as con:
+        assert con.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+    for key in ("k1", "k2", "k3"):
+        c.put(key, {"text": key})
+        t[0] += 1
+    with sqlite3.connect(c.path) as con:
+        rows = con.execute("SELECT key FROM cache ORDER BY created").fetchall()
+    assert [row[0] for row in rows] == ["k2", "k3"]
+
+
+def test_cache_concurrent_get_put_is_best_effort(tmp_path):
+    c = Cache(ttl=999.0, path=tmp_path / "c.db", max_entries=100)
+
+    def worker(n):
+        for i in range(25):
+            key = f"{n}-{i}"
+            c.put(key, {"text": key})
+            assert c.get(key) in (None, {"text": key})
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in range(6)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    with sqlite3.connect(c.path) as con:
+        count = con.execute("SELECT COUNT(*) FROM cache").fetchone()[0]
+    assert count <= 100
 
 
 def test_make_key_includes_tool_choice():

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -55,6 +55,17 @@ def test_cache_concurrent_get_put_is_best_effort(tmp_path):
     assert count <= 100
 
 
+def test_cache_connection_errors_are_best_effort(tmp_path, monkeypatch):
+    c = Cache(ttl=999.0, path=tmp_path / "c.db")
+
+    def broken_conn():
+        raise sqlite3.OperationalError("disk unavailable")
+
+    monkeypatch.setattr(c, "_conn", broken_conn)
+    assert c.get("missing") is None
+    c.put("k", {"text": "ok"})  # must not raise
+
+
 def test_make_key_includes_tool_choice():
     args = ([{"role": "user", "content": "hi"}], None, None, 1024, 0.0, [{"type": "function"}])
     k_auto = Cache.make_key(*args, "auto")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,6 +58,21 @@ def test_cli_capacity_status_smoke(monkeypatch, capsys):
     assert "LLM capacity:" in out
 
 
+def test_cli_doctor_smoke(tmp_path, monkeypatch, capsys):
+    from freellmpool.cli import main
+
+    monkeypatch.setenv("FREELLMPOOL_CONFIG_FILE", str(tmp_path / "config.toml"))
+    monkeypatch.setenv("FREELLMPOOL_QUOTA_PATH", str(tmp_path / "quota.json"))
+    monkeypatch.setenv("FREELLMPOOL_CACHE_PATH", str(tmp_path / "cache.db"))
+    monkeypatch.setenv("FREELLMPOOL_EXTERNAL_CATALOG_PATH", str(tmp_path / "external.json"))
+
+    assert main(["doctor"]) == 0
+    out = capsys.readouterr().out
+    assert "freellmpool" in out
+    assert "providers:" in out
+    assert "catalog: ok" in out
+
+
 def test_cli_keys_checklist_smoke(monkeypatch, capsys):
     from freellmpool.cli import main
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -177,6 +177,61 @@ def test_timeout_has_fast_connect():
     assert C._timeout(3.0).connect == 3.0  # connect never exceeds the overall timeout
 
 
+class _CM:
+    def __init__(self, resp):
+        self.resp = resp
+
+    def __enter__(self):
+        return self.resp
+
+    def __exit__(self, *args):
+        return False
+
+
+class _Resp:
+    def __init__(self, status, body):
+        self.status_code = status
+        self._raw = json.dumps(body).encode()
+
+    def iter_bytes(self):
+        yield self._raw
+
+
+def test_default_post_retries_retryable_status(monkeypatch):
+    calls = []
+
+    class Client:
+        def stream(self, *args, **kwargs):
+            calls.append(1)
+            status = 503 if len(calls) == 1 else 200
+            return _CM(_Resp(status, openai_body("ok")))
+
+    monkeypatch.setattr(C, "_client", lambda: Client())
+    monkeypatch.setattr(C, "_RETRY_BACKOFF_S", 0.0)
+    result = C.default_post("https://x.test/v1", {}, {}, 30.0)
+    assert result.status == 200
+    assert len(calls) == 2
+
+
+def test_default_post_retries_transport_error(monkeypatch):
+    import httpx
+
+    calls = []
+
+    class Client:
+        def stream(self, *args, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                raise httpx.ConnectError("temporary")
+            return _CM(_Resp(200, openai_body("ok")))
+
+    monkeypatch.setattr(C, "_client", lambda: Client())
+    monkeypatch.setattr(C, "_RETRY_BACKOFF_S", 0.0)
+    result = C.default_post("https://x.test/v1", {}, {}, 30.0)
+    assert result.status == 200
+    assert len(calls) == 2
+
+
 def test_client_singleton_under_concurrency():
     import threading as _t
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -189,9 +189,10 @@ class _CM:
 
 
 class _Resp:
-    def __init__(self, status, body):
+    def __init__(self, status, body, headers=None):
         self.status_code = status
         self._raw = json.dumps(body).encode()
+        self.headers = headers or {}
 
     def iter_bytes(self):
         yield self._raw
@@ -230,6 +231,87 @@ def test_default_post_retries_transport_error(monkeypatch):
     result = C.default_post("https://x.test/v1", {}, {}, 30.0)
     assert result.status == 200
     assert len(calls) == 2
+
+
+def test_default_post_honors_retry_after(monkeypatch):
+    calls = []
+    sleeps = []
+
+    class Client:
+        def stream(self, *args, **kwargs):
+            calls.append(1)
+            if len(calls) == 1:
+                return _CM(_Resp(429, {"error": "slow"}, {"Retry-After": "2"}))
+            return _CM(_Resp(200, openai_body("ok")))
+
+    monkeypatch.setattr(C, "_client", lambda: Client())
+    monkeypatch.setattr(C.random, "uniform", lambda lo, hi: 0.0)
+    monkeypatch.setattr(C.time, "sleep", sleeps.append)
+    result = C.default_post("https://x.test/v1", {}, {}, 30.0)
+    assert result.status == 200
+    assert sleeps == [2.0]
+    assert len(calls) == 2
+
+
+def test_default_post_skips_retry_after_past_timeout(monkeypatch):
+    calls = []
+
+    class Client:
+        def stream(self, *args, **kwargs):
+            calls.append(1)
+            return _CM(_Resp(429, {"error": "slow"}, {"Retry-After": "999"}))
+
+    monkeypatch.setattr(C, "_client", lambda: Client())
+    monkeypatch.setattr(C.random, "uniform", lambda lo, hi: 0.0)
+    result = C.default_post("https://x.test/v1", {}, {}, 0.5)
+    assert result.status == 429
+    assert len(calls) == 1
+
+
+def test_default_post_returns_retryable_status_after_retry_sleep_exhausts_deadline(monkeypatch):
+    calls = []
+    sleeps = []
+
+    class Client:
+        def stream(self, *args, **kwargs):
+            calls.append(1)
+            return _CM(_Resp(429, {"error": "slow"}))
+
+    times = iter([0.0, 0.0, 0.1, 0.1, 2.0])
+    monkeypatch.setattr(C, "_client", lambda: Client())
+    monkeypatch.setattr(C, "_RETRY_BACKOFF_S", 0.5)
+    monkeypatch.setattr(C.random, "uniform", lambda lo, hi: 0.0)
+    monkeypatch.setattr(C.time, "monotonic", lambda: next(times))
+    monkeypatch.setattr(C.time, "sleep", sleeps.append)
+
+    result = C.default_post("https://x.test/v1", {}, {}, 1.0)
+    assert result.status == 429
+    assert sleeps == [0.5]
+    assert len(calls) == 1
+
+
+def test_default_post_does_not_retry_read_error(monkeypatch):
+    import httpx
+
+    calls = []
+
+    class Resp:
+        status_code = 200
+        headers = {}
+
+        def iter_bytes(self):
+            raise httpx.ReadError("read failed")
+            yield b""  # pragma: no cover
+
+    class Client:
+        def stream(self, *args, **kwargs):
+            calls.append(1)
+            return _CM(Resp())
+
+    monkeypatch.setattr(C, "_client", lambda: Client())
+    with pytest.raises(httpx.ReadError):
+        C.default_post("https://x.test/v1", {}, {}, 30.0)
+    assert len(calls) == 1
 
 
 def test_client_singleton_under_concurrency():

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -167,7 +167,9 @@ def test_default_post_enforces_deadline(monkeypatch):
             "Cl", (), {"stream": lambda self, *a, **k: _FakeCM(_FakeResp([b"a", b"b"]))}
         )(),
     )
-    times = iter([1000.0, 1000.5, 9999.0])  # deadline calc, chunk1 ok, chunk2 past deadline
+    times = iter(
+        [1000.0, 1000.5, 1000.5, 9999.0]
+    )  # deadline calc, attempt check, chunk1 ok, chunk2 past deadline
     monkeypatch.setattr(C.time, "monotonic", lambda: next(times))
     with pytest.raises(ProviderHTTPError):
         C.default_post("https://x.test/v1", {}, {}, 30.0)

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -6,6 +6,7 @@ import logging
 
 from helpers import make_post
 
+from freellmpool.cache import Cache
 from freellmpool.observe import configure_logging_from_env, emit, logger
 from freellmpool.router import Pool
 
@@ -42,6 +43,24 @@ def test_a_broken_hook_does_not_break_routing(providers, env, quota):
     pool = Pool(providers, quota=quota, env=env, post=make_post({}), on_event=boom)
     reply = pool.chat([{"role": "user", "content": "hi"}])
     assert reply.text == "ok"  # completion still succeeds despite the bad hook
+
+
+def test_cache_events_are_emitted(providers, env, quota, tmp_path):
+    events = []
+    pool = Pool(
+        providers,
+        quota=quota,
+        env=env,
+        post=make_post({}),
+        cache=Cache(ttl=60, path=tmp_path / "cache.db"),
+        on_event=events.append,
+    )
+    pool.ask("same")
+    pool.ask("same")
+    kinds = [event["event"] for event in events]
+    assert "cache_miss" in kinds
+    assert "cache_store" in kinds
+    assert "cache_hit" in kinds
 
 
 def test_emit_without_hook_is_noop():

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -6,6 +6,7 @@ import json
 import threading
 import urllib.error
 import urllib.request
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 from helpers import gemini_body, make_post, make_stream_post
@@ -44,6 +45,43 @@ def test_chat_completions_shape(server):
     assert body["object"] == "chat.completion"
     assert body["choices"][0]["message"]["content"] == "ok"
     assert "x_freellmpool" in body
+
+
+def test_concurrent_chat_requests_share_pool_safely(providers, env, quota):
+    post = make_post({})
+    pool = Pool(providers, quota=quota, env=env, post=post, stream_post=make_stream_post({}))
+    httpd = serve(pool, host="127.0.0.1", port=0)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    try:
+        with ThreadPoolExecutor(max_workers=8) as ex:
+            results = list(
+                ex.map(
+                    lambda _: _post_json(
+                        base + "/v1/chat/completions",
+                        {"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+                    ),
+                    range(16),
+                )
+            )
+        assert all(status == 200 for status, _body in results)
+        assert pool.stats["requests"] == 16
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def test_server_close_flushes_batched_quota(providers, env, tmp_path):
+    from freellmpool.quota import QuotaStore
+
+    quota = QuotaStore(path=tmp_path / "quota.json", flush_every=100)
+    pool = Pool(providers, quota=quota, env=env, post=make_post({}))
+    httpd = serve(pool, host="127.0.0.1", port=0)
+    pool.ask("hi", providers=["alpha"])
+    assert not (tmp_path / "quota.json").exists()
+    httpd.server_close()
+    assert QuotaStore(path=tmp_path / "quota.json").snapshot()
 
 
 def test_models_route(server):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -55,18 +55,20 @@ def test_concurrent_chat_requests_share_pool_safely(providers, env, quota):
     thread.start()
     base = f"http://127.0.0.1:{httpd.server_address[1]}"
     try:
-        with ThreadPoolExecutor(max_workers=8) as ex:
+        total = 80
+        with ThreadPoolExecutor(max_workers=16) as ex:
             results = list(
                 ex.map(
                     lambda _: _post_json(
                         base + "/v1/chat/completions",
                         {"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
                     ),
-                    range(16),
+                    range(total),
                 )
             )
         assert all(status == 200 for status, _body in results)
-        assert pool.stats["requests"] == 16
+        assert pool.stats["requests"] == total
+        assert sum(quota.snapshot().values()) == total
     finally:
         httpd.shutdown()
         httpd.server_close()

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -58,3 +58,38 @@ def test_record_merges_concurrent_external_writes(tmp_path):
     assert b.snapshot() == {"groq::m": 1, "cerebras::n": 1}
     # and A sees B's write after a reload
     assert a.snapshot() == {"groq::m": 1, "cerebras::n": 1}
+
+
+def test_batched_record_flushes_on_threshold(tmp_path):
+    s = QuotaStore(
+        path=tmp_path / "q.json",
+        clock=lambda: datetime(2026, 6, 2, 12, 0, tzinfo=UTC),
+        flush_every=3,
+    )
+    assert s.record("groq", "m") == 1
+    assert not (tmp_path / "q.json").exists()
+    assert s.record("groq", "m") == 2
+    assert not (tmp_path / "q.json").exists()
+    assert s.record("groq", "m") == 3
+    assert _store(tmp_path, 2).used("groq", "m") == 3
+
+
+def test_batched_flush_merges_external_writes(tmp_path):
+    a = QuotaStore(
+        path=tmp_path / "q.json",
+        clock=lambda: datetime(2026, 6, 2, 12, 0, tzinfo=UTC),
+        flush_every=10,
+    )
+    b = _store(tmp_path, 2)
+    a.record("groq", "m")
+    b.record("cerebras", "n")
+    a.flush()
+    assert _store(tmp_path, 2).snapshot() == {"groq::m": 1, "cerebras::n": 1}
+
+
+def test_malformed_quota_file_recovers_on_record(tmp_path):
+    path = tmp_path / "q.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    s = QuotaStore(path=path, clock=lambda: datetime(2026, 6, 2, 12, 0, tzinfo=UTC))
+    assert s.record("groq", "m") == 1
+    assert _store(tmp_path, 2).snapshot() == {"groq::m": 1}

--- a/tests/test_quota.py
+++ b/tests/test_quota.py
@@ -93,3 +93,19 @@ def test_malformed_quota_file_recovers_on_record(tmp_path):
     s = QuotaStore(path=path, clock=lambda: datetime(2026, 6, 2, 12, 0, tzinfo=UTC))
     assert s.record("groq", "m") == 1
     assert _store(tmp_path, 2).snapshot() == {"groq::m": 1}
+
+
+def test_batched_flush_failure_keeps_pending_visible(tmp_path, monkeypatch):
+    s = QuotaStore(
+        path=tmp_path / "q.json",
+        clock=lambda: datetime(2026, 6, 2, 12, 0, tzinfo=UTC),
+        flush_every=10,
+    )
+    s.record("groq", "m", 2)
+    with monkeypatch.context() as m:
+        m.setattr(s, "_save", lambda: (_ for _ in ()).throw(OSError("disk full")))
+        s.flush()  # best effort; must keep pending increments
+        assert s.snapshot() == {"groq::m": 2}
+
+    s.flush()
+    assert _store(tmp_path, 2).snapshot() == {"groq::m": 2}

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -227,6 +227,32 @@ def test_disabled_model_skipped_by_auto_but_reachable_explicitly(env, quota):
     assert pool.ask("hi", model="off-model").model == "off-model"
 
 
+def test_all_targets_uses_indexed_filters(env, quota):
+    from freellmpool.models import Model, Provider
+
+    a = Provider(
+        id="a",
+        label="A",
+        adapter="openai",
+        base_url="https://a.test/v1",
+        auth="none",
+        models=(Model("shared"), Model("off", enabled=False)),
+    )
+    b = Provider(
+        id="b",
+        label="B",
+        adapter="openai",
+        base_url="https://b.test/v1",
+        auth="none",
+        models=(Model("shared"),),
+    )
+    pool = Pool([a, b], quota=quota, env=env, post=make_post({}))
+
+    assert [t.name for t in pool._all_targets()] == ["a/shared", "b/shared"]
+    assert [t.name for t in pool._all_targets(model="off")] == ["a/off"]
+    assert [t.name for t in pool._all_targets(include=["b"], model="shared")] == ["b/shared"]
+
+
 def test_tool_calls_reply_is_success(providers, env, quota):
     tc = [{"id": "c", "type": "function", "function": {"name": "f", "arguments": "{}"}}]
     post = make_post(

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -326,3 +326,19 @@ def test_chat_routing_override_end_to_end(tmp_path, monkeypatch, quota):
     # a per-call routing="quality" still sends the hard prompt to the strong model
     assert pool.chat(_HARD, routing="quality").model == "big"
     assert pool.routing == "fast"  # default untouched
+
+
+def test_achat_routing_override_end_to_end(tmp_path, monkeypatch, quota):
+    import asyncio
+
+    from freellmpool.aio import AsyncPool
+
+    pool = _qpool(tmp_path, monkeypatch, quota)
+    pool.routing = "fast"
+
+    async def apost(url, headers, body, timeout):
+        return pool._post(url, headers, body, timeout)
+
+    apool = AsyncPool(pool, apost=apost)
+    assert asyncio.run(apool.achat(_HARD, routing="quality")).model == "big"
+    assert pool.routing == "fast"

--- a/tests/test_routing_modes.py
+++ b/tests/test_routing_modes.py
@@ -1,0 +1,26 @@
+"""Shared routing-mode normalization across library/proxy/MCP."""
+
+from __future__ import annotations
+
+from freellmpool.proxy import _routing_and_model
+from freellmpool.routing_modes import normalize_routing_mode, routing_override
+
+
+def test_normalize_routing_mode_strips_and_falls_back():
+    assert normalize_routing_mode(" Quality ", "fair") == "quality"
+    assert normalize_routing_mode("bogus", "fast") == "fast"
+    assert normalize_routing_mode("bogus", "also-bogus") == "fair"
+
+
+def test_routing_override_treats_auto_as_default():
+    assert routing_override("auto") is None
+    assert routing_override(" spread ") == "spread"
+    assert routing_override("missing") is None
+
+
+def test_proxy_model_alias_and_header_use_same_normalizer():
+    assert _routing_and_model({}, "freellmpool/quality") == ("quality", "auto")
+    assert _routing_and_model({"X-Freellmpool-Routing": " Fast "}, "auto") == (
+        "fast",
+        "auto",
+    )

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -51,6 +51,13 @@ def test_corrupt_file_does_not_crash(tmp_path):
     assert s.snapshot()["requests"] == 1
 
 
+def test_stats_save_failure_is_best_effort(tmp_path, monkeypatch):
+    s = StatsStore(tmp_path / "s.json")
+    monkeypatch.setattr(s, "_save", lambda: (_ for _ in ()).throw(OSError("disk full")))
+    s.add(requests=1)  # must not raise
+    assert not (tmp_path / "s.json").exists()
+
+
 def test_pool_writes_through_to_stats_store(providers, env, quota, tmp_path):
     store = StatsStore(tmp_path / "s.json")
     pool = Pool(providers, quota=quota, env=env, post=make_post({}), stats_store=store)


### PR DESCRIPTION
## Summary

This PR hardens freellmpool hot paths and local operations:

- reduces routing metric lock churn
- normalizes routing modes and includes routing in cache keys
- adds cache WAL/pruning and quota batching safeguards
- adds `freellmpool doctor`, catalog validation, benchmark tooling, and CI/package smoke checks
- hardens sync/async retry handling with deadline-aware `Retry-After` behavior and response caps

## Review Notes

Claude Fable reviewed the retry/async transport changes before push. Findings were addressed before opening this PR: preserve retryable responses on deadline exhaustion, avoid replaying read-phase POST transport errors, stream async responses with size/deadline caps, and keep original request headers across async retries.

## Verification

- `ruff check .`
- `mypy src/freellmpool/routing_modes.py src/freellmpool/catalog_validation.py`
- `python scripts/validate_catalog.py`
- `python scripts/bench_hotpaths.py` plus comparator smoke
- wheel build + fresh venv install + CLI/doctor smoke
- `pytest --cov=freellmpool --cov-report=term-missing --cov-fail-under=75`
- Result: `389 passed`, `81.20%` coverage
