### PR TITLE
[codex] Prepare 0.11.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and the project aims to follow
 [Semantic Versioning](https://semver.org/).
 
+## [0.11.1] — 2026-06-10
+
+Hardening and operations release after the 0.11 capacity tooling.
+
+### Added
+- **`freellmpool doctor`** — a no-network local diagnostics command that reports
+  package version, config paths, configured provider count, routing mode,
+  quota/cache paths, external catalog cache age, and bundled catalog validity.
+- **Local catalog validation and hot-path benchmarks.** `scripts/validate_catalog.py`
+  validates bundled provider metadata in CI, while `scripts/bench_hotpaths.py`
+  and `scripts/compare_benchmarks.py` track routing/cache/quota hot paths.
+- CI now runs catalog validation, focused mypy checks, coverage with a minimum
+  threshold, and a built-wheel smoke test including `freellmpool doctor`.
+
+### Changed
+- Routing now normalizes mode names consistently and indexes provider/model
+  targets so large catalogs avoid repeated scans and metric lock churn.
+- Response cache keys include the active routing mode, preventing cross-mode
+  cache hits between `fast`, `quality`, and `fair` routing.
+- Cache storage uses SQLite WAL mode, prunes expired rows, and supports a
+  `FREELLMPOOL_CACHE_MAX_ENTRIES` cap.
+- Quota counters can batch writes with `FREELLMPOOL_QUOTA_FLUSH_EVERY=N` while
+  still flushing on snapshots and shutdown paths.
+
+### Fixed
+- Sync and async HTTP transports now honor bounded retries with `Retry-After`
+  support without losing the last provider response when the retry delay consumes
+  the request deadline.
+- POST retries no longer replay read-phase transport errors after a request may
+  have reached the provider; only connect/pool-acquisition failures are retried.
+- The async transport now streams and caps response bodies like the sync path,
+  enforcing response-size and wall-clock deadline guards.
+- Async retry attempts keep the original request headers instead of accidentally
+  reusing a provider response's headers.
+- Cache, quota, and stats persistence paths handle disk/SQLite failures as
+  best-effort operations instead of crashing hot paths.
+
 ## [0.11.0] — 2026-06-06
 
 Capacity management — see what's usable right now and keep your free tiers

--- a/docs/index.html
+++ b/docs/index.html
@@ -157,7 +157,7 @@ capacity varies through the day. The proxy is meant for local/single-user use.</
 
 </div>
 
-<p class="meta">Free and open source (MIT). Latest release: 0.11.0. Page updated 2026-06-06.
+<p class="meta">Free and open source (MIT). Latest release: 0.11.1. Page updated 2026-06-10.
 Project: <a href="https://github.com/0xzr/freellmpool">github.com/0xzr/freellmpool</a></p>
 
 </div>
@@ -172,7 +172,7 @@ Project: <a href="https://github.com/0xzr/freellmpool">github.com/0xzr/freellmpo
   "description": "Free, open-source OpenAI-compatible gateway that pools the free tiers of 18 LLM providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere and more) behind one endpoint, with automatic failover. CLI, Python library, local proxy, and MCP server. Keyless to start.",
   "url": "https://0xzr.github.io/freellmpool/",
   "downloadUrl": "https://pypi.org/project/freellmpool/",
-  "softwareVersion": "0.11.0",
+  "softwareVersion": "0.11.1",
   "license": "https://opensource.org/licenses/MIT",
   "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
   "author": {"@type": "Person", "name": "0xzr"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "freellmpool"
-version = "0.11.0"
+version = "0.11.1"
 description = "Pool the free tiers of 18 LLM providers (300+ models) behind one OpenAI-compatible endpoint. Free, zero-config, with automatic failover and quota tracking."
 readme = "README.md"
 license = "MIT"

--- a/src/freellmpool/__init__.py
+++ b/src/freellmpool/__init__.py
@@ -20,7 +20,7 @@ from .models import EmbedReply, Model, Provider, Reply
 from .plugins import register_adapter, register_provider
 from .router import Pool
 
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 
 def __getattr__(name: str):

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -32,6 +32,7 @@ from collections.abc import Sequence
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlsplit
 
+from . import __version__
 from .anthropic_shim import estimate_tokens, reply_to_message, reply_to_sse, request_to_chat
 from .config import known_aliases, resolve_alias
 from .errors import (
@@ -224,7 +225,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
         return snap
 
     class Handler(BaseHTTPRequestHandler):
-        server_version = "freellmpool/0.10"
+        server_version = f"freellmpool/{__version__}"
         # Socket read timeout: a slow/stalled client can't pin a worker thread + fd
         # indefinitely. setup() applies this to the connection via settimeout().
         timeout = 75

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -11,6 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 from helpers import gemini_body, make_post, make_stream_post
 
+from freellmpool import __version__
 from freellmpool.proxy import _parse_model, serve
 from freellmpool.router import Pool
 
@@ -45,6 +46,11 @@ def test_chat_completions_shape(server):
     assert body["object"] == "chat.completion"
     assert body["choices"][0]["message"]["content"] == "ok"
     assert "x_freellmpool" in body
+
+
+def test_proxy_server_header_uses_package_version(server):
+    with urllib.request.urlopen(server + "/v1/models") as resp:  # noqa: S310
+        assert f"freellmpool/{__version__}" in resp.headers["Server"]
 
 
 def test_concurrent_chat_requests_share_pool_safely(providers, env, quota):


### PR DESCRIPTION
## Summary

Prepare the 0.11.1 patch release after #39.

- bump package metadata and runtime `__version__` to 0.11.1
- add 0.11.1 changelog notes for retry, cache/quota, diagnostics, benchmark, and CI hardening
- update homepage release metadata and structured data

## Verification

- `ruff check .`
- `python -c "import freellmpool; print(freellmpool.__version__)"`
- `freellmpool --version`
- `python scripts/validate_catalog.py`
- `pytest`
- `python -m build --outdir /tmp/flp-release-dist`
- fresh venv wheel install + import/CLI/doctor smoke
