### PR TITLE
[codex] Fix proxy burst backlog handling

### DIFF
--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -1270,6 +1270,7 @@ class _BoundedThreadingHTTPServer(ThreadingHTTPServer):
     Past the cap, new connections get a quick 503 and are dropped."""
 
     daemon_threads = True
+    request_queue_size = _MAX_CONNECTIONS
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -12,7 +12,12 @@ import pytest
 from helpers import gemini_body, make_post, make_stream_post
 
 from freellmpool import __version__
-from freellmpool.proxy import _parse_model, serve
+from freellmpool.proxy import (
+    _MAX_CONNECTIONS,
+    _BoundedThreadingHTTPServer,
+    _parse_model,
+    serve,
+)
 from freellmpool.router import Pool
 
 
@@ -51,6 +56,10 @@ def test_chat_completions_shape(server):
 def test_proxy_server_header_uses_package_version(server):
     with urllib.request.urlopen(server + "/v1/models") as resp:  # noqa: S310
         assert f"freellmpool/{__version__}" in resp.headers["Server"]
+
+
+def test_proxy_listen_backlog_matches_connection_cap():
+    assert _BoundedThreadingHTTPServer.request_queue_size == _MAX_CONNECTIONS
 
 
 def test_concurrent_chat_requests_share_pool_safely(providers, env, quota):


### PR DESCRIPTION
## Summary

Stress testing mixed proxy traffic showed occasional `ConnectionResetError` under bursty 32+ client loads even though the proxy worker cap is 128. The server had a 128 worker-slot cap but still inherited the stdlib listen backlog default, so short bursts could reset before being accepted and handled.

This aligns the listen backlog with `_MAX_CONNECTIONS`, preserving the existing hard cap while letting bursts queue and receive normal handling.

## Stress Evidence

Before this patch, a mixed local proxy workload (`/v1/models`, `/v1/chat/completions`, streaming chat, `/v1/embeddings`, `/v1/messages`) produced connection resets at 32/48/64 concurrent clients.

After this patch, the same isolated workload completed cleanly through 64 concurrent clients:

- 16 workers: all 480 requests HTTP 200
- 32 workers: all 480 requests HTTP 200
- 48 workers: all 480 requests HTTP 200
- 64 workers: all 480 requests HTTP 200

The larger synthetic workload also passed: 900 direct library operations, 500 async operations, and 720 mixed proxy requests with cache hits, quota batching, embeddings, transcription, streaming, Anthropic messages, and synthetic retryable provider errors.

## Verification

- `ruff check .`
- focused `mypy`
- `python scripts/validate_catalog.py`
- `python scripts/bench_hotpaths.py` + comparator smoke
- CLI smoke: `doctor`, `providers`, `models --all`
- full coverage gate: `391 passed`, `81.20%` coverage
- package build + fresh wheel install smoke

## Summary by Sourcery

Align proxy HTTP server listen backlog with the connection cap to prevent dropped burst connections.

Bug Fixes:
- Set the proxy server's request queue size to match the maximum connection cap to reduce connection resets under burst load.

Tests:
- Add a test asserting the proxy server listen backlog equals the configured maximum connections cap.