### PR TITLE
add release and proxy stress tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,12 @@ jobs:
         run: ruff check .
       - name: Validate catalog
         run: python scripts/validate_catalog.py
+      - name: Release metadata readiness
+        run: python scripts/check_release_ready.py --skip-build
+      - name: Proxy stress smoke
+        run: python scripts/stress_proxy.py --profile ci
       - name: Type check focused helpers
-        run: mypy src/freellmpool/routing_modes.py src/freellmpool/catalog_validation.py
+        run: mypy src/freellmpool/routing_modes.py src/freellmpool/catalog_validation.py src/freellmpool/_version.py
       - name: Import smoke
         run: python -c "import freellmpool; from freellmpool import Pool, AsyncPool; print(freellmpool.__version__, Pool, AsyncPool)"
       - name: Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,20 @@ pytest          # 0 network calls — everything is faked
 ruff check src tests
 ```
 
+Useful maintainer checks:
+
+```bash
+python scripts/stress_proxy.py --profile ci
+python scripts/check_release_ready.py --skip-build
+python scripts/check_release_ready.py
+```
+
+`stress_proxy.py` starts a local fake-backed proxy and sends mixed chat,
+streaming, embeddings, Responses, Anthropic Messages, transcription, models,
+and health traffic through the real HTTP server. `check_release_ready.py`
+cross-checks version/provider/model-count metadata; without `--skip-build` it
+also builds the sdist/wheel, runs `twine check`, and fresh-installs the wheel.
+
 ## Adding a provider
 
 The whole catalog is [`src/freellmpool/providers.toml`](src/freellmpool/providers.toml).

--- a/scripts/check_release_ready.py
+++ b/scripts/check_release_ready.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Release readiness checks for freellmpool.
+
+By default this validates metadata/count surfaces and then builds, checks, and
+fresh-installs the wheel from the current checkout. Use ``--skip-build`` for a
+fast CI metadata guard.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+if _SRC.is_dir():
+    sys.path.insert(0, str(_SRC))
+
+from freellmpool._version import __version__  # noqa: E402
+
+
+@dataclass(frozen=True)
+class CatalogCounts:
+    providers: int
+    enabled_chat_models: int
+    cataloged_chat_models: int
+
+    @property
+    def live_bucket(self) -> str:
+        return _bucket(self.enabled_chat_models)
+
+    @property
+    def cataloged_bucket(self) -> str:
+        return _bucket(self.cataloged_chat_models)
+
+
+def _bucket(value: int) -> str:
+    if value < 100:
+        return str(value)
+    return f"{(value // 100) * 100}+"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _load_pyproject(root: Path) -> dict:
+    return tomllib.loads(_read(root / "pyproject.toml"))
+
+
+def catalog_counts(root: Path) -> CatalogCounts:
+    data = tomllib.loads(_read(root / "src" / "freellmpool" / "providers.toml"))
+    providers = data.get("provider") or []
+    enabled = 0
+    cataloged = 0
+    for provider in providers:
+        models = provider.get("models") or []
+        cataloged += len(models)
+        enabled += sum(1 for model in models if model.get("enabled", True))
+    return CatalogCounts(
+        providers=len(providers),
+        enabled_chat_models=enabled,
+        cataloged_chat_models=cataloged,
+    )
+
+
+def metadata_errors(root: Path, *, version: str | None = None) -> list[str]:
+    version = version or __version__
+    errors: list[str] = []
+    pyproject = _load_pyproject(root)
+    project = pyproject["project"]
+    server = json.loads(_read(root / "server.json"))
+    readme = _read(root / "README.md")
+    docs_index = _read(root / "docs" / "index.html")
+    demo = _read(root / "assets" / "demo.svg")
+    changelog = _read(root / "CHANGELOG.md")
+    demo_script = _read(root / "scripts" / "demo.sh")
+    counts = catalog_counts(root)
+
+    def require(condition: bool, message: str) -> None:
+        if not condition:
+            errors.append(message)
+
+    require(project["version"] == version, f"pyproject version is {project['version']}, not {version}")
+    require(__version__ == version, f"package __version__ is {__version__}, not {version}")
+    require(server.get("version") == version, "server.json top-level version mismatch")
+    package_version = ((server.get("packages") or [{}])[0] or {}).get("version")
+    require(package_version == version, "server.json package version mismatch")
+    require(f"Latest release: {version}" in docs_index, "docs/index.html latest release mismatch")
+    require(
+        f'"softwareVersion": "{version}"' in docs_index,
+        "docs/index.html JSON-LD softwareVersion mismatch",
+    )
+    require(f"freellmpool-{version}" in demo, "assets/demo.svg install transcript mismatch")
+    require(re.search(rf"^## \[{re.escape(version)}\]", changelog, re.MULTILINE) is not None, "CHANGELOG missing top-level release entry")
+
+    provider_phrase = f"{counts.providers} LLM providers"
+    require(provider_phrase in project["description"], "pyproject provider count mismatch")
+    require(provider_phrase in server["description"], "server.json provider count mismatch")
+    require(provider_phrase in readme, "README provider count mismatch")
+    require(f"{counts.providers} providers" in demo, "demo SVG provider count mismatch")
+    require(f"{counts.providers} free tiers" in demo, "demo SVG free-tier count mismatch")
+    require(
+        f"{counts.enabled_chat_models} models" in demo,
+        "demo SVG enabled model count mismatch",
+    )
+    require(
+        f"{counts.live_bucket} live-validated" in readme,
+        "README live-validated model bucket mismatch",
+    )
+    require(
+        f"{counts.live_bucket} live-validated" in docs_index,
+        "docs/index.html live-validated model bucket mismatch",
+    )
+    require(
+        f"{counts.cataloged_bucket} cataloged" in project["description"],
+        "pyproject cataloged model bucket mismatch",
+    )
+    require(
+        f"{counts.cataloged_bucket} cataloged" in readme,
+        "README cataloged model bucket mismatch",
+    )
+    require(
+        f"{counts.cataloged_bucket} cataloged" in docs_index,
+        "docs/index.html cataloged model bucket mismatch",
+    )
+    require("16 providers, 56 models" not in demo_script, "scripts/demo.sh has stale proxy count")
+    return errors
+
+
+def _run(cmd: list[str], *, cwd: Path) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True)
+
+
+def build_and_smoke(root: Path, *, version: str, dist_dir: Path | None = None) -> None:
+    if dist_dir is None:
+        tmp = tempfile.TemporaryDirectory(prefix="flp-release-ready-")
+        dist = Path(tmp.name) / "dist"
+    else:
+        tmp = None
+        dist = dist_dir
+        if dist.exists():
+            shutil.rmtree(dist)
+    try:
+        _run([sys.executable, "-m", "build", "--outdir", str(dist)], cwd=root)
+        _run([sys.executable, "-m", "twine", "check", *[str(p) for p in sorted(dist.iterdir())]], cwd=root)
+        wheels = sorted(dist.glob("*.whl"))
+        if not wheels:
+            raise RuntimeError("build produced no wheel")
+        venv = dist.parent / "wheel-smoke"
+        if venv.exists():
+            shutil.rmtree(venv)
+        _run([sys.executable, "-m", "venv", str(venv)], cwd=root)
+        py = venv / "bin" / "python"
+        cli = venv / "bin" / "freellmpool"
+        _run([str(py), "-m", "pip", "install", "--upgrade", "pip"], cwd=root)
+        _run([str(py), "-m", "pip", "install", "--no-cache-dir", str(wheels[0])], cwd=root)
+        check = (
+            "import freellmpool; "
+            f"assert freellmpool.__version__ == {version!r}, freellmpool.__version__; "
+            "from freellmpool import client; "
+            f"assert 'freellmpool/{version}' in client._USER_AGENT, client._USER_AGENT"
+        )
+        _run([str(py), "-c", check], cwd=root)
+        _run([str(cli), "--version"], cwd=root)
+    finally:
+        if tmp is not None:
+            tmp.cleanup()
+
+
+def pypi_smoke(version: str) -> None:
+    with tempfile.TemporaryDirectory(prefix="flp-pypi-smoke-") as td:
+        root = Path(td)
+        venv = root / "venv"
+        _run([sys.executable, "-m", "venv", str(venv)], cwd=root)
+        py = venv / "bin" / "python"
+        cli = venv / "bin" / "freellmpool"
+        _run([str(py), "-m", "pip", "install", "--upgrade", "pip"], cwd=root)
+        _run([str(py), "-m", "pip", "install", "--no-cache-dir", f"freellmpool=={version}"], cwd=root)
+        _run([str(py), "-c", f"import freellmpool; assert freellmpool.__version__ == {version!r}"], cwd=root)
+        _run([str(cli), "--version"], cwd=root)
+
+
+def docker_smoke(image: str, version: str) -> None:
+    docker = shutil.which("docker")
+    if docker is None:
+        raise RuntimeError("docker is not installed")
+    _run([docker, "pull", image], cwd=Path.cwd())
+    _run([docker, "run", "--rm", image, "--version"], cwd=Path.cwd())
+    # Keep this smoke cheap and non-networked inside the container.
+    _run(
+        [
+            docker,
+            "run",
+            "--rm",
+            "-e",
+            "FREELLMPOOL_CONFIG_FILE=/tmp/config.toml",
+            "-e",
+            "FREELLMPOOL_QUOTA_PATH=/tmp/quota.json",
+            image,
+            "doctor",
+        ],
+        cwd=Path.cwd(),
+    )
+    print(f"Docker image {image} smoke passed for {version}.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parent.parent)
+    parser.add_argument("--version", default=__version__)
+    parser.add_argument("--skip-build", action="store_true", help="only run metadata checks")
+    parser.add_argument("--dist-dir", type=Path, help="where to write build artifacts")
+    parser.add_argument("--check-pypi", action="store_true", help="install this version from PyPI")
+    parser.add_argument("--check-docker", metavar="IMAGE", help="pull and smoke-test a Docker image")
+    args = parser.parse_args(argv)
+
+    root = args.root.resolve()
+    errors = metadata_errors(root, version=args.version)
+    if errors:
+        print("Release readiness failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+    print(f"Metadata readiness passed for freellmpool {args.version}.")
+    if not args.skip_build:
+        build_and_smoke(root, version=args.version, dist_dir=args.dist_dir)
+        print("Build, twine check, and fresh wheel smoke passed.")
+    if args.check_pypi:
+        pypi_smoke(args.version)
+        print(f"PyPI smoke passed for freellmpool {args.version}.")
+    if args.check_docker:
+        docker_smoke(args.check_docker, args.version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -16,5 +16,6 @@ freellmpool providers 2>/dev/null | head -7
 sleep 1.5
 
 say "freellmpool proxy   # drop-in OpenAI endpoint for any tool"
-printf "freellmpool proxy on http://127.0.0.1:8080/v1  (16 providers, 56 models)\n"
+summary="$(freellmpool providers 2>/dev/null | head -1 | sed 's/^freellmpool catalog: //')"
+printf "freellmpool proxy on http://127.0.0.1:8080/v1  (%s)\n" "${summary:-provider pool ready}"
 sleep 2.0

--- a/scripts/stress_proxy.py
+++ b/scripts/stress_proxy.py
@@ -264,6 +264,7 @@ def run_stress(*, requests: int, concurrency: int, json_output: bool = False) ->
         started = time.perf_counter()
         results: Counter[str] = Counter()
         failures: list[str] = []
+        status_body: Any = {}
         try:
             with ThreadPoolExecutor(max_workers=concurrency) as ex:
                 futures = [ex.submit(_exercise, base, i) for i in range(requests)]
@@ -272,14 +273,17 @@ def run_stress(*, requests: int, concurrency: int, json_output: bool = False) ->
                     if status != 200:
                         failures.append(f"{name}:{status}")
                     results[name] += 1
-            status_code, status_body = _request_json("GET", f"{base}/status")
-            if status_code != 200:
-                failures.append(f"status:{status_code}")
+            try:
+                status_code, status_body = _request_json("GET", f"{base}/status")
+                if status_code != 200:
+                    failures.append(f"status:{status_code}")
+            except Exception as exc:  # noqa: BLE001 - report status failures in the summary
+                failures.append(f"status:{type(exc).__name__}: {exc}")
         finally:
+            elapsed = time.perf_counter() - started
             httpd.shutdown()
             httpd.server_close()
 
-    elapsed = time.perf_counter() - started
     summary = {
         "ok": not failures,
         "requests": requests,

--- a/scripts/stress_proxy.py
+++ b/scripts/stress_proxy.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Offline proxy stress smoke for regular user traffic.
+
+Starts a local freellmpool proxy backed by fake in-process providers, then sends
+mixed OpenAI/Anthropic-compatible requests through the HTTP server. No network
+provider APIs are called.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+_SRC = Path(__file__).resolve().parent.parent / "src"
+if _SRC.is_dir():
+    sys.path.insert(0, str(_SRC))
+
+from freellmpool.client import HTTPResult  # noqa: E402
+from freellmpool.models import Model, Provider  # noqa: E402
+from freellmpool.proxy import serve  # noqa: E402
+from freellmpool.quota import QuotaStore  # noqa: E402
+from freellmpool.router import Pool  # noqa: E402
+
+_PROFILES = {
+    "ci": {"requests": 144, "concurrency": 24},
+    "local": {"requests": 720, "concurrency": 64},
+    "soak": {"requests": 2400, "concurrency": 128},
+}
+
+
+class _StressState:
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.calls: Counter[str] = Counter()
+
+    def bump(self, key: str) -> None:
+        with self.lock:
+            self.calls[key] += 1
+
+    def snapshot(self) -> dict[str, int]:
+        with self.lock:
+            return dict(self.calls)
+
+
+class _Lines:
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = lines
+        self.closed = False
+
+    def __iter__(self):
+        try:
+            yield from self._lines
+        finally:
+            self.closed = True
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def _openai_body(text: str) -> dict[str, Any]:
+    return {
+        "choices": [{"message": {"role": "assistant", "content": text}}],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 3},
+    }
+
+
+def _make_pool(tmp: Path, state: _StressState) -> Pool:
+    providers = [
+        Provider(
+            id=f"p{i}",
+            label=f"P{i}",
+            adapter="openai",
+            base_url=f"https://p{i}.test/v1",
+            auth="none",
+            models=(Model(f"model-{i}-a", rpd=10_000), Model(f"model-{i}-b", rpd=10_000)),
+        )
+        for i in range(6)
+    ]
+    embedders = [
+        Provider(
+            id="embed",
+            label="Embed",
+            adapter="openai",
+            base_url="https://embed.test/v1",
+            auth="none",
+            models=(Model("embed-small", rpd=10_000),),
+        )
+    ]
+    transcribers = [
+        Provider(
+            id="whisper",
+            label="Whisper",
+            adapter="openai",
+            base_url="https://whisper.test/v1",
+            auth="none",
+            models=(Model("whisper-small", rpd=10_000),),
+        )
+    ]
+
+    def post(url: str, headers: dict, body: dict, timeout: float) -> HTTPResult:
+        del headers, timeout
+        if url.endswith("/embeddings"):
+            state.bump("upstream_embeddings")
+            inputs = body.get("input") or []
+            n = len(inputs) if isinstance(inputs, list) else 1
+            return HTTPResult(
+                200,
+                {
+                    "data": [{"embedding": [0.1, 0.2, 0.3]} for _ in range(n)],
+                    "usage": {"prompt_tokens": n},
+                },
+                "embeddings",
+            )
+        state.bump("upstream_chat")
+        return HTTPResult(200, _openai_body("ok"), "ok")
+
+    def stream_post(url: str, headers: dict, body: dict, timeout: float):
+        del url, headers, body, timeout
+        state.bump("upstream_stream")
+        lines = [
+            'data: {"choices":[{"delta":{"content":"o"}}]}',
+            'data: {"choices":[{"delta":{"content":"k"}}]}',
+            "data: [DONE]",
+        ]
+        return 200, _Lines(lines)
+
+    def transcribe_post(
+        url: str, headers: dict, files: dict, data: dict, timeout: float
+    ) -> HTTPResult:
+        del url, headers, timeout
+        state.bump("upstream_transcription")
+        assert files["file"][1]
+        text = f"transcribed {data.get('model')}"
+        return HTTPResult(200, {"text": text}, text)
+
+    return Pool(
+        providers,
+        quota=QuotaStore(path=tmp / "quota.json", flush_every=1000),
+        env={},
+        post=post,
+        stream_post=stream_post,
+        embedders=embedders,
+        transcribers=transcribers,
+        transcribe_post=transcribe_post,
+        routing="spread",
+    )
+
+
+def _request_json(method: str, url: str, payload: dict | None = None) -> tuple[int, Any]:
+    data = json.dumps(payload).encode("utf-8") if payload is not None else None
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={"Content-Type": "application/json"} if data is not None else {},
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 - localhost only
+        raw = resp.read()
+        ctype = resp.headers.get("Content-Type", "")
+        if "application/json" in ctype:
+            return resp.status, json.loads(raw or b"{}")
+        return resp.status, raw.decode("utf-8", "replace")
+
+
+def _multipart(boundary: str = "BOUNDARY") -> bytes:
+    return (
+        f'--{boundary}\r\nContent-Disposition: form-data; name="model"\r\n\r\n'
+        f"whisper-small\r\n"
+        f'--{boundary}\r\nContent-Disposition: form-data; name="file"; filename="a.wav"\r\n'
+        f"Content-Type: audio/wav\r\n\r\n".encode()
+        + b"RIFF\x00fake"
+        + f"\r\n--{boundary}--\r\n".encode()
+    )
+
+
+def _request_multipart(url: str) -> tuple[int, Any]:
+    boundary = "BOUNDARY"
+    req = urllib.request.Request(
+        url,
+        data=_multipart(boundary),
+        headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+    )
+    with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310 - localhost only
+        return resp.status, json.loads(resp.read() or b"{}")
+
+
+def _exercise(base: str, index: int) -> tuple[str, int]:
+    route = index % 8
+    try:
+        if route == 0:
+            status, _ = _request_json("GET", f"{base}/healthz")
+            return "healthz", status
+        if route == 1:
+            status, body = _request_json("GET", f"{base}/v1/models")
+            assert body["data"]
+            return "models", status
+        if route == 2:
+            status, body = _request_json(
+                "POST",
+                f"{base}/v1/chat/completions",
+                {"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert body["choices"][0]["message"]["content"] == "ok"
+            return "chat", status
+        if route == 3:
+            status, body = _request_json(
+                "POST",
+                f"{base}/v1/chat/completions",
+                {
+                    "model": "auto",
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "hi"}],
+                },
+            )
+            assert "[DONE]" in body
+            return "chat_stream", status
+        if route == 4:
+            status, body = _request_json(
+                "POST", f"{base}/v1/embeddings", {"model": "auto", "input": ["a", "b"]}
+            )
+            assert len(body["data"]) == 2
+            return "embeddings", status
+        if route == 5:
+            status, body = _request_json(
+                "POST", f"{base}/v1/responses", {"model": "auto", "input": "hi"}
+            )
+            assert body["status"] == "completed"
+            return "responses", status
+        if route == 6:
+            status, body = _request_json(
+                "POST",
+                f"{base}/v1/messages",
+                {"model": "auto", "max_tokens": 32, "messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert body["type"] == "message"
+            return "messages", status
+        status, body = _request_multipart(f"{base}/v1/audio/transcriptions")
+        assert body["text"]
+        return "transcriptions", status
+    except urllib.error.HTTPError as exc:
+        return f"http_error_{exc.code}", exc.code
+    except Exception as exc:  # noqa: BLE001 - keep a full stress summary
+        return f"{type(exc).__name__}: {exc}", 0
+
+
+def run_stress(*, requests: int, concurrency: int, json_output: bool = False) -> int:
+    state = _StressState()
+    with tempfile.TemporaryDirectory(prefix="flp-stress-") as td:
+        pool = _make_pool(Path(td), state)
+        httpd = serve(pool, host="127.0.0.1", port=0)
+        thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+        thread.start()
+        base = f"http://127.0.0.1:{httpd.server_address[1]}"
+        started = time.perf_counter()
+        results: Counter[str] = Counter()
+        failures: list[str] = []
+        try:
+            with ThreadPoolExecutor(max_workers=concurrency) as ex:
+                futures = [ex.submit(_exercise, base, i) for i in range(requests)]
+                for fut in as_completed(futures):
+                    name, status = fut.result()
+                    if status != 200:
+                        failures.append(f"{name}:{status}")
+                    results[name] += 1
+            status_code, status_body = _request_json("GET", f"{base}/status")
+            if status_code != 200:
+                failures.append(f"status:{status_code}")
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+
+    elapsed = time.perf_counter() - started
+    summary = {
+        "ok": not failures,
+        "requests": requests,
+        "concurrency": concurrency,
+        "elapsed_s": round(elapsed, 3),
+        "routes": dict(sorted(results.items())),
+        "upstream": state.snapshot(),
+        "pool": status_body.get("pool", {}) if isinstance(status_body, dict) else {},
+        "failures": failures[:20],
+    }
+    if json_output:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(
+            "proxy stress: "
+            f"{requests} requests at concurrency={concurrency} in {elapsed:.2f}s; "
+            f"routes={dict(sorted(results.items()))}"
+        )
+        if failures:
+            print("failures:", ", ".join(failures[:20]), file=sys.stderr)
+    return 0 if not failures else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", choices=sorted(_PROFILES), default="local")
+    parser.add_argument("--requests", type=int)
+    parser.add_argument("--concurrency", type=int)
+    parser.add_argument("--json", action="store_true", help="print a machine-readable summary")
+    args = parser.parse_args(argv)
+
+    profile = _PROFILES[args.profile]
+    requests = args.requests if args.requests is not None else profile["requests"]
+    concurrency = args.concurrency if args.concurrency is not None else profile["concurrency"]
+    if requests <= 0 or concurrency <= 0:
+        parser.error("--requests and --concurrency must be positive")
+    return run_stress(requests=requests, concurrency=concurrency, json_output=args.json)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -3,16 +3,21 @@
 from __future__ import annotations
 
 import json
+import socket
 import threading
+import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
-from helpers import gemini_body, make_post, make_stream_post
+from helpers import gemini_body, make_post, make_stream_post, openai_body
 
 from freellmpool import __version__
+from freellmpool.client import HTTPResult
 from freellmpool.proxy import (
+    _MAX_BODY,
     _MAX_CONNECTIONS,
     _BoundedThreadingHTTPServer,
     _parse_model,
@@ -326,6 +331,27 @@ def _expect_status(url, payload, headers=None):
         return e.code
 
 
+def _raw_http(base: str, request: bytes, *, shutdown_write: bool = False) -> bytes:
+    parts = urllib.parse.urlsplit(base)
+    assert parts.hostname is not None
+    assert parts.port is not None
+    chunks = []
+    with socket.create_connection((parts.hostname, parts.port), timeout=2.0) as sock:
+        sock.settimeout(2.0)
+        sock.sendall(request)
+        if shutdown_write:
+            sock.shutdown(socket.SHUT_WR)
+        while True:
+            try:
+                chunk = sock.recv(65536)
+            except TimeoutError:
+                break
+            if not chunk:
+                break
+            chunks.append(chunk)
+    return b"".join(chunks)
+
+
 def test_malformed_body_returns_400_not_crash(server):
     # non-object body
     assert _expect_status(server + "/v1/chat/completions", [1, 2, 3]) == 400
@@ -347,6 +373,162 @@ def test_malformed_body_returns_400_not_crash(server):
         )[0]
         == 200
     )
+
+
+def test_oversized_json_body_rejected_before_reading_body(server):
+    request = (
+        b"POST /v1/chat/completions HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\n"
+        b"Content-Type: application/json\r\n"
+        + f"Content-Length: {_MAX_BODY + 1}\r\n".encode()
+        + b"Connection: close\r\n\r\n"
+    )
+    raw = _raw_http(server, request)
+
+    assert b" 413 " in raw.splitlines()[0]
+    assert (
+        _post_json(
+            server + "/v1/chat/completions",
+            {"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+        )[0]
+        == 200
+    )
+
+
+def test_truncated_body_returns_400_and_server_stays_alive(server):
+    body = b'{"model":"auto"'
+    request = (
+        b"POST /v1/chat/completions HTTP/1.1\r\n"
+        b"Host: 127.0.0.1\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: 200\r\n"
+        b"Connection: close\r\n\r\n"
+        + body
+    )
+    raw = _raw_http(server, request, shutdown_write=True)
+
+    assert b" 400 " in raw.splitlines()[0]
+    assert _expect_status(server + "/v1/chat/completions", {"model": "auto"}) == 400
+
+
+def test_slow_client_body_times_out_without_pin(providers, env, quota):
+    pool = Pool(providers, quota=quota, env=env, post=make_post({}), stream_post=make_stream_post({}))
+    httpd = serve(pool, host="127.0.0.1", port=0)
+    httpd.RequestHandlerClass.timeout = 0.2
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    try:
+        request = (
+            b"POST /v1/chat/completions HTTP/1.1\r\n"
+            b"Host: 127.0.0.1\r\n"
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: 200\r\n"
+            b"Connection: close\r\n\r\n"
+        )
+        raw = _raw_http(base, request)
+        assert b" 400 " in raw.splitlines()[0]
+        assert (
+            _post_json(
+                base + "/v1/chat/completions",
+                {"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+            )[0]
+            == 200
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def test_streaming_client_disconnect_closes_upstream_iterator(providers, env, quota):
+    class ClosableLines:
+        def __init__(self) -> None:
+            self.closed = threading.Event()
+
+        def __iter__(self):
+            try:
+                for _ in range(200):
+                    time.sleep(0.002)
+                    yield "data: " + json.dumps(
+                        {"choices": [{"delta": {"content": "x" * 2048}}]}
+                    )
+                yield "data: [DONE]"
+            finally:
+                self.closed.set()
+
+        def close(self) -> None:
+            self.closed.set()
+
+    lines = ClosableLines()
+
+    def stream_post(url, headers, body, timeout):
+        return 200, lines
+
+    pool = Pool(providers, quota=quota, env=env, post=make_post({}), stream_post=stream_post)
+    httpd, base = _serve(pool)
+    try:
+        payload = json.dumps(
+            {"model": "auto", "stream": True, "messages": [{"role": "user", "content": "hi"}]}
+        ).encode()
+        parts = urllib.parse.urlsplit(base)
+        assert parts.hostname is not None
+        assert parts.port is not None
+        sock = socket.create_connection((parts.hostname, parts.port), timeout=2.0)
+        try:
+            sock.sendall(
+                b"POST /v1/chat/completions HTTP/1.1\r\n"
+                b"Host: 127.0.0.1\r\n"
+                b"Content-Type: application/json\r\n"
+                + f"Content-Length: {len(payload)}\r\n".encode()
+                + b"Connection: close\r\n\r\n"
+                + payload
+            )
+            raw = b""
+            deadline = time.monotonic() + 2.0
+            while b"data:" not in raw and time.monotonic() < deadline:
+                raw += sock.recv(4096)
+            assert b"data:" in raw
+        finally:
+            sock.close()
+        assert lines.closed.wait(5.0)
+        assert _get_json(base + "/status")[0] == 200
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def test_shutdown_during_inflight_request_completes_without_deadlock(providers, env, quota):
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_post(url, headers, body, timeout):
+        started.set()
+        assert release.wait(3.0)
+        return HTTPResult(200, openai_body("ok"), "ok")
+
+    pool = Pool(providers, quota=quota, env=env, post=blocking_post, stream_post=make_stream_post({}))
+    httpd, base = _serve(pool)
+    result: dict[str, object] = {}
+
+    def call_proxy() -> None:
+        result["value"] = _post_json(
+            base + "/v1/chat/completions",
+            {"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+    worker = threading.Thread(target=call_proxy)
+    worker.start()
+    assert started.wait(2.0)
+    stopper = threading.Thread(target=httpd.shutdown)
+    stopper.start()
+    release.set()
+    worker.join(timeout=3.0)
+    stopper.join(timeout=3.0)
+    httpd.server_close()
+
+    assert not worker.is_alive()
+    assert not stopper.is_alive()
+    assert result["value"][0] == 200
 
 
 def test_proxy_auth(providers, env, quota):

--- a/tests/test_release_tools.py
+++ b/tests/test_release_tools.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script(name: str):
+    path = ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_release_ready_metadata_is_clean():
+    release_ready = _load_script("check_release_ready")
+    counts = release_ready.catalog_counts(ROOT)
+
+    assert counts.providers == 18
+    assert counts.enabled_chat_models >= 200
+    assert counts.cataloged_chat_models >= 300
+    assert release_ready.metadata_errors(ROOT) == []
+
+
+def test_proxy_stress_script_tiny_profile():
+    stress_proxy = _load_script("stress_proxy")
+
+    assert stress_proxy.run_stress(requests=16, concurrency=4, json_output=True) == 0

--- a/tests/test_release_tools.py
+++ b/tests/test_release_tools.py
@@ -22,6 +22,8 @@ def test_release_ready_metadata_is_clean():
     release_ready = _load_script("check_release_ready")
     counts = release_ready.catalog_counts(ROOT)
 
+    # The exact provider count is a release-copy tripwire: adding/removing a provider
+    # should force a deliberate README/docs/server metadata update.
     assert counts.providers == 18
     assert counts.enabled_chat_models >= 200
     assert counts.cataloged_chat_models >= 300


### PR DESCRIPTION
## Summary
- add an offline proxy stress runner that exercises mixed chat, streaming, embeddings, Responses, Anthropic Messages, transcription, models, and health traffic through the real HTTP server
- add a release readiness script that checks version/count metadata and can build, twine-check, and fresh-install the wheel
- wire CI to run metadata readiness, CI-sized proxy stress, and the `_version.py` mypy target
- add focused proxy resilience tests for oversized bodies, truncated/slow clients, streaming disconnect cleanup, and shutdown during in-flight requests
- document the new maintainer commands and stop hard-coding stale counts in `scripts/demo.sh`

## Validation
- `ruff check .`
- `python scripts/validate_catalog.py`
- `mypy src/freellmpool/routing_modes.py src/freellmpool/catalog_validation.py src/freellmpool/_version.py`
- `pytest` (400 passed)
- `python scripts/check_release_ready.py --dist-dir /tmp/flp-release-ready-dist`
- `python scripts/stress_proxy.py --profile local --json` (720 requests at concurrency 64, no failures)
- `python scripts/check_release_ready.py --skip-build --check-pypi --check-docker ghcr.io/0xzr/freellmpool:0.11.2`

Post-release health was also verified for PyPI 0.11.2 and the GHCR 0.11.2 Docker image.