### PR TITLE
update GitHub Actions for Node 24

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,9 +9,9 @@ jobs:
   hotpaths:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install
@@ -19,7 +19,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
       - name: Restore previous benchmark
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: .benchmarks/latest.json
           key: hotpath-benchmark-${{ runner.os }}-${{ github.run_id }}
@@ -38,12 +38,12 @@ jobs:
           fi
           cp .benchmarks/current.json .benchmarks/latest.json
       - name: Upload benchmark artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hotpath-benchmarks
           path: .benchmarks/current.json
       - name: Save benchmark baseline
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: .benchmarks/latest.json
           key: hotpath-benchmark-${{ runner.os }}-${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- Update official GitHub Actions in CI, benchmarks, and Docker workflows to the current Node 24-ready majors.
- Keep workflow semantics, permissions, cache keys, artifact names, and publish behavior unchanged.

## Review Gate
- Opus reviewed the exact pre-push diff and found no workflow semantic blockers.
- Opus required live tag verification before push/merge; verified OK for `actions/checkout@v6`, `actions/setup-python@v6`, `actions/upload-artifact@v7`, and `actions/cache@v5`.

## Validation
- `.venv/bin/ruff check .`
- `.venv/bin/python scripts/check_release_ready.py --skip-build`
- `.venv/bin/python scripts/stress_proxy.py --profile ci`
- `actionlint` was unavailable locally (`command not found`).

## Notes
- PR CI exercises `ci.yml`.
- I will manually dispatch the benchmark workflow on this branch because it contains the cache/artifact action updates.
- I will not manually dispatch the Docker workflow because it can publish images; the Docker change is limited to checkout.