### PR TITLE
add Node 24 Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,34 @@
+name: Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/**
+      - .github/workflows/pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/configure-pages@v6
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: docs
+      - id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- Add an explicit GitHub Pages deployment workflow for the existing `docs/` static site.
- Use Node 24-compatible first-party actions: `checkout@v6`, `configure-pages@v6`, `upload-pages-artifact@v5`, and `deploy-pages@v5`.
- Keep site content unchanged and deploy the current `docs/` directory as-is.

## Review Gate
- Opus reviewed the exact unpushed diff and found no blockers.
- Merge-time condition from Opus: switch Pages from `build_type=legacy` to `build_type=workflow` before merging, then verify the workflow deployment.

## Validation
- `actionlint .github/workflows/*.yml`
- `python scripts/check_release_ready.py --skip-build`
- Live tag verification for all new action refs.

## Deployment Plan
1. Wait for PR CI.
2. Run final Opus review before merge.
3. Switch Pages build type to workflow via GitHub API.
4. Merge PR and watch the new Pages workflow deploy.

## Summary by Sourcery

Add a GitHub Pages workflow to deploy the existing docs site using current GitHub Actions for Node 24 compatibility.

CI:
- Introduce a dedicated GitHub Actions workflow to build and deploy the docs/ static site to GitHub Pages on pushes to main and manual dispatch.

Deployment:
- Configure GitHub Pages deployment to use the workflow-based build for the docs/ directory without changing site content.