### PR TITLE
Add test to verify .env.example documents all keyless providers which are available in providers.toml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,7 +55,6 @@ LONGCAT_API_KEY=
 #   • Pollinations            (anonymous/keyless)
 #   • OVHcloud AI Endpoints  (anonymous/keyless)
 #   • Kilo Gateway           (anonymous/keyless)
-#   • OpenCode               (anonymous/keyless)
 #   • LLM7                    (works without a key; set LLM7_API_KEY for more)
 # So freellmpool works out of the box even with this whole file empty.
 # ---------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,7 @@ LONGCAT_API_KEY=
 #   • Pollinations            (anonymous/keyless)
 #   • OVHcloud AI Endpoints  (anonymous/keyless)
 #   • Kilo Gateway           (anonymous/keyless)
+#   • OpenCode               (anonymous/keyless)
 #   • LLM7                    (works without a key; set LLM7_API_KEY for more)
 # So freellmpool works out of the box even with this whole file empty.
 # ---------------------------------------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,6 +43,34 @@ def test_keyless_providers_always_configured():
     assert "pollinations" in ids  # keyless
     assert "groq" not in ids  # needs a key
 
+def test_env_example_documents_keyless_providers():
+    """Verify .env.example lists all default-enabled keyless/key-optional providers."""
+    from pathlib import Path
+    
+    # Get keyless providers from catalog (auth=none or key_optional=true)
+    catalog = load_catalog()
+    keyless_ids = {
+        p.id for p in catalog 
+        if (p.auth == "none" or (hasattr(p, 'key_optional') and p.key_optional))
+    }
+    
+    # Read .env.example
+    env_file = Path(__file__).parent.parent / ".env.example"
+    env_content = env_file.read_text()
+    
+    # Extract zero-setup section
+    start = env_content.find("# Zero-setup providers")
+    end = env_content.find("# So freellmpool works")
+    zero_setup_section = env_content[start:end]
+    
+    # Convert to lowercase for case-insensitive comparison
+    zero_setup_lower = zero_setup_section.lower()
+    
+    # Verify each keyless provider is documented
+    for provider_id in keyless_ids:
+        assert provider_id.lower() in zero_setup_lower, \
+            f"Keyless provider '{provider_id}' must be documented in .env.example zero-setup section"
+
 
 def test_configured_filter_by_env():
     catalog = load_catalog()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from freellmpool.config import configured_providers, known_aliases, load_catalog, resolve_alias
 
 
@@ -45,31 +47,28 @@ def test_keyless_providers_always_configured():
 
 def test_env_example_documents_keyless_providers():
     """Verify .env.example lists all default-enabled keyless/key-optional providers."""
-    from pathlib import Path
-    
-    # Get keyless providers from catalog (auth=none or key_optional=true)
     catalog = load_catalog()
-    keyless_ids = {
-        p.id for p in catalog 
-        if (p.auth == "none" or (hasattr(p, 'key_optional') and p.key_optional))
+    default_enabled_keyless_ids = {
+        p.id for p in catalog if p.keyless and any(model.enabled for model in p.models)
     }
-    
-    # Read .env.example
-    env_file = Path(__file__).parent.parent / ".env.example"
-    env_content = env_file.read_text()
-    
-    # Extract zero-setup section
+    disabled_keyless_ids = {
+        p.id for p in catalog if p.keyless and not any(model.enabled for model in p.models)
+    }
+
+    env_content = (Path(__file__).parent.parent / ".env.example").read_text()
     start = env_content.find("# Zero-setup providers")
     end = env_content.find("# So freellmpool works")
     zero_setup_section = env_content[start:end]
-    
-    # Convert to lowercase for case-insensitive comparison
     zero_setup_lower = zero_setup_section.lower()
-    
-    # Verify each keyless provider is documented
-    for provider_id in keyless_ids:
-        assert provider_id.lower() in zero_setup_lower, \
+
+    for provider_id in default_enabled_keyless_ids:
+        assert provider_id.lower() in zero_setup_lower, (
             f"Keyless provider '{provider_id}' must be documented in .env.example zero-setup section"
+        )
+    for provider_id in disabled_keyless_ids:
+        assert provider_id.lower() not in zero_setup_lower, (
+            f"Disabled keyless provider '{provider_id}' must not be documented as zero-setup"
+        )
 
 
 def test_configured_filter_by_env():


### PR DESCRIPTION
## Issue
Fixes #50

## Changes
- Added `test_env_example_documents_keyless_providers()` test in `tests/test_config.py`
- Test verifies that `.env.example` lists all default-enabled keyless/key-optional providers
- Uses case-insensitive matching for provider IDs
- Test will catch if enabled providers drift from documentation

## Verification
- All tests pass: `pytest tests/test_config.py`
- Code style passes: `ruff check .`

## Summary by Sourcery

Tests:
- Add a test verifying that .env.example documents all default-enabled keyless/key-optional providers from the provider catalog.