### PR TITLE
test: keep agent docs in sync

### DIFF
--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -147,6 +147,22 @@ API key `anything`, Model `auto`.
 Settings → Models → enable **Override OpenAI Base URL** → `http://localhost:8080/v1`,
 API key `anything`. (Free-tier models are slower than paid frontier models.)
 
+### Claude Code
+Claude Code can use the experimental Anthropic bridge at `/v1/messages`:
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8080
+export ANTHROPIC_AUTH_TOKEN=dummy
+export ANTHROPIC_API_KEY=dummy
+export ANTHROPIC_MODEL=auto
+export ANTHROPIC_SMALL_FAST_MODEL=auto
+export CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1
+claude
+```
+
+Pin a concrete backend with `ANTHROPIC_MODEL=provider/model`, for example
+`alibaba_cloud_model_studio/qwen3-plus`.
+
 ### OpenAI Codex CLI
 Codex speaks the Responses API, which freellmpool shims at `/v1/responses` — see
 [AGENTS.md](AGENTS.md#openai-codex-cli).

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from freellmpool.agents import AGENTS, list_agents, render
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_list_agents():
@@ -42,10 +45,14 @@ def test_all_agent_keys_appear_in_supported_agent_list():
 
 
 def test_all_agent_keys_appear_in_integrations_guide():
-    integrations = Path("docs/INTEGRATIONS.md").read_text(encoding="utf-8").lower()
-    coding_agents_section = integrations.split("## coding agents & editors", 1)[1].split(
-        "## chat uis", 1
-    )[0]
+    integrations = (ROOT / "docs" / "INTEGRATIONS.md").read_text(encoding="utf-8")
+    match = re.search(
+        r"^##\s+coding agents(?:\s*&\s*editors)?\s*$\n(?P<body>.*?)(?=^##\s+|\Z)",
+        integrations,
+        flags=re.IGNORECASE | re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None
+    coding_agents_section = match.group("body").casefold()
 
     for name in AGENTS:
-        assert name in coding_agents_section
+        assert name.casefold() in coding_agents_section

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from freellmpool.agents import AGENTS, list_agents, render
 
 
@@ -31,3 +33,19 @@ def test_agents_legacy_shape_is_preserved():
     assert "steps" in rec
     assert "note" in rec
     assert any("freellmpool proxy" in step for step in rec["steps"])
+
+
+def test_all_agent_keys_appear_in_supported_agent_list():
+    out = list_agents()
+    for name in AGENTS:
+        assert name in out
+
+
+def test_all_agent_keys_appear_in_integrations_guide():
+    integrations = Path("docs/INTEGRATIONS.md").read_text(encoding="utf-8").lower()
+    coding_agents_section = integrations.split("## coding agents & editors", 1)[1].split(
+        "## chat uis", 1
+    )[0]
+
+    for name in AGENTS:
+        assert name in coding_agents_section


### PR DESCRIPTION
Fixes #51

Summary:
- Add parity coverage for `AGENTS`, `list_agents()`, and the coding-agent section in `docs/INTEGRATIONS.md`.
- Add the missing Claude Code integration notes using the existing `claude` profile settings.

Validation:
- `ruff check .`
- `python -m pytest tests/test_agents.py -q`
- `pytest --cov --cov-fail-under=80` (691 passed, 90.95% coverage; 3 ResourceWarning entries from existing sqlite test cleanup)

## Summary by Sourcery

Keep coding-agent integrations and supported agent list in sync with documented agents.

Documentation:
- Document Claude Code integration using the Anthropic bridge in the integrations guide.

Tests:
- Add tests ensuring all AGENTS entries appear in list_agents() output and in the coding agents section of the integrations guide.