### PR TITLE
chore: refresh Python maintenance policy

### DIFF
--- a/.coverage-thresholds.json
+++ b/.coverage-thresholds.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$comment": "Coverage thresholds for orchestrator agents and CI. Portable across projects — adjust values per-repo.",
+  "thresholds": {
+    "lines": 80,
+    "branches": 80,
+    "functions": 80,
+    "statements": 80
+  },
+  "enforcement": {
+    "command": "pytest --cov --cov-fail-under=80",
+    "blockPRCreation": true,
+    "blockTaskCompletion": true,
+    "description": "Orchestrator agents MUST check coverage against these thresholds before marking any task complete or creating a PR. If coverage drops below any threshold, the task fails."
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    versioning-strategy: "increase-if-necessary"
     groups:
       python-dependencies:
         patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # Works out of the box with no keys (keyless providers). Add provider keys as
 # env vars to unlock more, e.g. `-e GROQ_API_KEY=...`. When exposing the proxy
 # beyond localhost, set FREELLMPOOL_PROXY_KEY to require a Bearer token.
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 COPY pyproject.toml README.md ./

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries",

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -1,9 +1,29 @@
 from __future__ import annotations
 
+import json
 import re
+import tomllib
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ci_python_versions() -> list[str]:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    match = re.search(r"python-version:\s*\[([^\]]+)\]", workflow)
+
+    assert match is not None, "CI must define a Python test matrix"
+    return re.findall(r'["\'](3\.\d+)["\']', match.group(1))
+
+
+def _coverage_floor() -> int:
+    config = json.loads((ROOT / ".coverage-thresholds.json").read_text(encoding="utf-8"))
+    floor = int(config["thresholds"]["lines"])
+
+    assert f"--cov-fail-under={floor}" in config["enforcement"]["command"]
+    assert config["enforcement"]["blockPRCreation"] is True
+    assert config["enforcement"]["blockTaskCompletion"] is True
+    return floor
 
 
 def test_ci_enforces_repository_coverage_floor() -> None:
@@ -11,7 +31,7 @@ def test_ci_enforces_repository_coverage_floor() -> None:
     match = re.search(r"--cov-fail-under=(\d+)", workflow)
 
     assert match is not None, "CI must enforce an explicit coverage floor"
-    assert int(match.group(1)) >= 80
+    assert int(match.group(1)) == _coverage_floor()
 
 
 def test_dependabot_covers_project_supply_chains() -> None:
@@ -19,6 +39,46 @@ def test_dependabot_covers_project_supply_chains() -> None:
 
     for ecosystem in ("pip", "github-actions", "docker"):
         assert f'package-ecosystem: "{ecosystem}"' in config
+
+
+def test_dependabot_preserves_compatible_python_lower_bounds() -> None:
+    config = (ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8")
+    update_blocks = re.split(r"(?=^  - package-ecosystem:)", config, flags=re.MULTILINE)
+    pip_block = next(
+        block
+        for block in update_blocks
+        if re.search(r'^  - package-ecosystem:\s*["\']?pip["\']?\s*$', block, re.MULTILINE)
+    )
+
+    assert re.search(
+        r'^    versioning-strategy:\s*["\']?increase-if-necessary["\']?\s*$',
+        pip_block,
+        re.MULTILINE,
+    )
+
+
+def test_supported_python_versions_match_ci() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    classifiers = pyproject["project"]["classifiers"]
+    supported = {
+        match.group(1)
+        for classifier in classifiers
+        if (match := re.fullmatch(r"Programming Language :: Python :: (3\.\d+)", classifier))
+    }
+    tested = _ci_python_versions()
+
+    assert len(tested) == len(set(tested)), "CI Python matrix must not contain duplicates"
+    assert set(tested) == supported
+    assert "3.14" in supported
+
+
+def test_container_uses_supported_python_314() -> None:
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+    match = re.search(r"^FROM python:(3\.\d+)-slim$", dockerfile, re.MULTILINE)
+
+    assert match is not None, "Dockerfile must use a versioned official Python slim image"
+    assert match.group(1) == "3.14"
+    assert match.group(1) in _ci_python_versions()
 
 
 def test_container_defaults_are_local_and_non_root() -> None:


### PR DESCRIPTION
## Summary

- adopt Python 3.14 for the container and add it to classifiers/CI
- preserve compatible Python dependency lower bounds in weekly Dependabot runs
- restore the repository coverage threshold source of truth and test configuration parity

## Validation

- `ruff check .`
- `pytest --cov --cov-fail-under=80` (711 passed, 90.29%)
- cold quickstart, catalog/count/release metadata, proxy stress, focused strict mypy, import smoke
- full release build, twine check, and fresh wheel install
- Python 3.14.6 Docker build, import/CLI, proxy startup, and `/healthz` smoke
- independent adversarial Codex review: PASS

Supersedes #61. PR #62 is obsoleted by the Dependabot policy change.

## Summary by Sourcery

Refresh Python support, CI, and coverage enforcement policies to align container, classifiers, and automation with the current maintenance strategy.

New Features:
- Add explicit configuration to synchronize supported Python versions between CI, packaging classifiers, and the Docker container image.

Bug Fixes:
- Restore the repository coverage threshold source of truth and ensure CI enforces the configured coverage floor exactly.

Enhancements:
- Extend the CI Python matrix and packaging classifiers to include Python 3.14 and require the container image to use a supported Python 3.14 runtime.
- Add tests that verify Dependabot preserves compatible Python dependency lower bounds via a conservative versioning strategy.

Tests:
- Introduce configuration-parity tests that validate CI coverage flags, Dependabot policies, supported Python versions, and Docker base image versioning against repository config files.