### PR TITLE
feat: improve agent and deployment adoption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Proxy stress smoke
         run: python scripts/stress_proxy.py --profile ci
       - name: Type check focused helpers
-        run: mypy src/freellmpool/routing_modes.py src/freellmpool/catalog_validation.py src/freellmpool/_version.py
+        run: mypy --follow-imports=skip src/freellmpool/routing_modes.py src/freellmpool/catalog_validation.py src/freellmpool/_version.py src/freellmpool/readiness.py
       - name: Import smoke
         run: python -c "import freellmpool; from freellmpool import Pool, AsyncPool; print(freellmpool.__version__, Pool, AsyncPool)"
       - name: Test
@@ -65,6 +65,25 @@ jobs:
           FREELLMPOOL_CACHE_PATH=/tmp/flp-smoke-cache.db \
           FREELLMPOOL_EXTERNAL_CATALOG_PATH=/tmp/flp-smoke-external.json \
             /tmp/freellmpool-wheel-smoke/bin/freellmpool doctor
+
+  opencode-packages:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+      - name: Use trusted-publishing-capable npm
+        run: npm install --global npm@11.5.1
+      - name: Pack, install, and load both integrations
+        run: node scripts/check_opencode_packages.mjs
 
   docker-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-opencode.yml
+++ b/.github/workflows/publish-opencode.yml
@@ -1,0 +1,109 @@
+name: Publish OpenCode package
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Package to publish
+        required: true
+        type: choice
+        options:
+          - opencode-freellmpool
+          - opencode-freellmpool-tui
+      version:
+        description: Exact manifest version
+        required: true
+        type: string
+      commit:
+        description: Exact current main merge SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - name: Validate immutable commit input
+        env:
+          RELEASE_COMMIT: ${{ inputs.commit }}
+        run: |
+          case "$RELEASE_COMMIT" in
+            *[!0-9a-f]*|"") exit 1 ;;
+          esac
+          test "${#RELEASE_COMMIT}" -eq 40
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.commit }}
+          fetch-depth: 0
+
+      - name: Require the exact current main tip
+        env:
+          RELEASE_COMMIT: ${{ inputs.commit }}
+        run: |
+          git fetch --no-tags origin main
+          test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
+          test "$(git rev-parse origin/main)" = "$RELEASE_COMMIT"
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Use trusted-publishing-capable npm
+        run: npm install --global npm@11.5.1
+
+      - name: Pack, install, and load both integrations
+        run: node scripts/check_opencode_packages.mjs
+
+      - name: Resolve and validate package
+        id: package
+        env:
+          PACKAGE_NAME: ${{ inputs.package }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          case "$PACKAGE_NAME" in
+            opencode-freellmpool) package_dir=integrations/opencode ;;
+            opencode-freellmpool-tui) package_dir=integrations/opencode-tui ;;
+            *) exit 1 ;;
+          esac
+          manifest_name=$(node -p "require('./$package_dir/package.json').name")
+          manifest_version=$(node -p "require('./$package_dir/package.json').version")
+          test "$manifest_name" = "$PACKAGE_NAME"
+          test "$manifest_version" = "$RELEASE_VERSION"
+          if npm view "$PACKAGE_NAME@$RELEASE_VERSION" version >/dev/null 2>&1; then
+            echo "Refusing to overwrite existing $PACKAGE_NAME@$RELEASE_VERSION" >&2
+            exit 1
+          fi
+          echo "directory=$package_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Publish selected package with provenance
+        working-directory: ${{ steps.package.outputs.directory }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if test -n "$NPM_TOKEN"; then
+            export NODE_AUTH_TOKEN="$NPM_TOKEN"
+          fi
+          npm publish --access public --provenance
+
+      - name: Verify registry metadata and tarball
+        env:
+          PACKAGE_NAME: ${{ inputs.package }}
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          test "$(npm view "$PACKAGE_NAME@$RELEASE_VERSION" version)" = "$RELEASE_VERSION"
+          registry_tarball=$(npm view "$PACKAGE_NAME@$RELEASE_VERSION" dist.tarball)
+          test -n "$registry_tarball"
+          npm pack "$PACKAGE_NAME@$RELEASE_VERSION" --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- Advisory proxy operations APIs: public `/livez` and `/readyz`, an
+  authenticated secret-free `/v1/providers` inventory, and
+  `/v1/models?ready=true` filtering.
+- A print-only Hermes Agent custom-endpoint profile and setup documentation.
+- Registry-ready OpenCode server/TUI packages with clean tarball install/load
+  validation and a protected manual publication workflow.
 - Experimental metaswarm review adapter integration, with setup docs and no-key
   smoke coverage for fail-closed `auth_missing` behavior.
 - A dated [live model-activity audit](docs/MODEL_ACTIVITY_AUDIT_2026-07-14.md)
@@ -20,6 +26,8 @@ All notable changes to this project are documented here. The format is based on
 - Weekly Dependabot coverage for Python, GitHub Actions, and container images.
 
 ### Changed
+- Corrected the OpenCode integrations to use the proxy's actual port 8080
+  default and refreshed the dated competitor comparison from pinned sources.
 - Refreshed the provider catalog to 239 enabled chat routes and 397 cataloged
   chat models, adding live-verified current models and disabling stale, retired,
   empty, degraded, or repeatedly timing-out routes.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ the 30-second target on a clean Linux/Python 3.12 environment, with no API keys
 when a keyless provider is up:
 
 ```bash
+# One command when uv is installed; no checkout or manually managed virtualenv:
+uvx freellmpool ask --max-tokens 32 "Reply with one short sentence: freellmpool is ready."
+```
+
+Portable virtual-environment path:
+
+```bash
 python3 -m venv .venv
 . .venv/bin/activate
 python -m pip install --upgrade pip
@@ -111,7 +118,19 @@ freellmpool proxy                       # starts http://localhost:8080
 freellmpool code claude                 # prints the one-line setup for Claude Code
 freellmpool profile list                # richer installable profiles
 freellmpool profile show metaswarm      # Tailnet-aware Metaswarm profile
-# (also: codex, aider, cline, continue, cursor, opencode, metaswarm)
+freellmpool profile install hermes       # Hermes custom-endpoint config
+# (also: codex, aider, cline, continue, cursor, hermes, opencode, metaswarm)
+```
+
+The Hermes profile prints (and never writes) this supported custom-endpoint
+block; `hermes model` provides the interactive equivalent:
+
+```yaml
+model:
+  provider: custom
+  default: quality
+  base_url: http://localhost:8080/v1
+  api_key: anything
 ```
 
 Claude Code gateway mode can also be launched directly:
@@ -136,6 +155,9 @@ estimated savings, tokens served free, provider race, latency), per-request
 **quality routing** via the model picker (`freellmpool/auto|fast|quality|fair`), and `freellmpool_status`
 / `freellmpool_models` tools — see [integrations/opencode-tui](integrations/opencode-tui)
 and the [guide](https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html).
+The `opencode-freellmpool` and `opencode-freellmpool-tui` npm tarballs are
+validated in CI; registry publication is still pending, so the linked local-file
+instructions remain the working install path.
 
 **New in 0.11:** capacity tools — `freellmpool capacity status` shows which free
 tiers are usable right now, `freellmpool providers health` live-probes them, and
@@ -240,7 +262,7 @@ run on free models too. `freellmpool code <agent>` prints the exact setup, while
 without mutating third-party config:
 
 ```bash
-freellmpool code aider       # also: claude, codex, cline, continue, cursor, opencode
+freellmpool code aider       # also: claude, codex, cline, continue, cursor, hermes, opencode
 freellmpool profile show opencode
 freellmpool profile doctor opencode --dry-run
 ```
@@ -253,10 +275,17 @@ Main proxy surfaces:
 - `/v1/embeddings` and `/v1/audio/transcriptions` — OpenAI-compatible embedding
   and Whisper-style multipart transcription.
 - `/v1/models` — routing aliases plus concrete `provider/model` ids.
+- `/v1/models?ready=true` — the same shape, limited to locally ready targets.
+- `/v1/providers` — authenticated, secret-free provider/model readiness details.
 - `/freellmpool/battle` and `/playground` — bounded browser/JSON model comparisons.
-- `/dashboard`, `/status`, `/healthz`, `/badge.svg` — local operations surfaces.
+- `/healthz` and `/livez` — public process liveness aliases.
+- `/readyz` — public advisory local-capacity readiness (200 when at least one
+  provider is ready, otherwise 503); it never live-probes an upstream.
+- `/dashboard`, `/status`, and `/badge.svg` — local operations surfaces.
 
-`/playground` and the API routes are auth-protected when the proxy key is set.
+`/playground`, `/v1/providers`, and model inventory are auth-protected when
+the proxy key is set. Liveness/readiness stay public for orchestrator probes;
+readiness is a local quota/cooldown snapshot, not an upstream health guarantee.
 Setup snippets for specific tools are in [docs/INTEGRATIONS.md](docs/INTEGRATIONS.md)
 and [docs/AGENTS.md](docs/AGENTS.md). The repo also includes an experimental
 [metaswarm review adapter](integrations/metaswarm) for using `freellmpool` as an
@@ -536,23 +565,25 @@ Architecture notes: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ## How it compares
 
+Comparison snapshot: 2026-07-19. Competitor rows link to the exact README commit
+used for the claims; scopes change quickly, so treat this as a dated map rather
+than a permanent ranking.
+
 | Tool | Keyless start | # providers | Failover | MCP server | CLI | Transcription | Local/self-hosted | License |
 |---|---|---:|---|---|---|---|---|---|
-| **freellmpool** | Yes: Pollinations, OVHcloud, Kilo Gateway; LLM7 is key-optional | 22 cataloged chat providers | Yes: tries the next provider on rate limits, timeouts, 5xx, empty replies, and transport errors | Yes: `freellmpool mcp` | Yes: `freellmpool ask`, `tokenmax`, `providers`, `proxy`, and more | Yes: OpenAI-compatible `/v1/audio/transcriptions` with provider failover | Yes: local Python package and local proxy | MIT |
-| OpenRouter free models | No: OpenRouter account/API key required | One hosted OpenRouter account routing across many upstreams; the free-model router currently lists free variants | Yes: OpenRouter handles provider routing/fallbacks | Not a native MCP server; OpenRouter docs show MCP-client/tool patterns | No first-party local CLI in the docs checked | Yes: OpenRouter now documents audio transcription APIs | No: hosted service | Proprietary service |
-| LiteLLM | No: bring provider keys or hosted LiteLLM credentials | 100+ LLM providers | Yes: router/fallbacks, including transcription fallbacks | Yes: LiteLLM Proxy includes an MCP Gateway | Yes: SDK/proxy command surface, not a one-shot free-model CLI | Yes: `/audio/transcriptions` support | Yes: self-host the proxy or use hosted LiteLLM | MIT for core repo; commercial license for enterprise-only pieces |
-| FreeLLMAPI | No: add your own free-tier provider keys; keyless providers can be configured after setup | 16 free-tier providers plus custom OpenAI-compatible endpoints | Yes: fallback chain on 429, 5xx, and timeouts | No native MCP server in the README checked | Dashboard/server, desktop app, and Docker; no first-class one-shot CLI in the README checked | No: `/v1/audio/*` is listed as not yet supported | Yes: self-hosted Node/Docker proxy | MIT |
+| **freellmpool** | Yes, when a configured keyless provider is available | 22 chat providers cataloged locally | Yes: retryable provider failures, empty replies, and transport errors | Yes: `freellmpool mcp` | One-shot CLI plus profiles, library, and proxy commands | Yes: `/v1/audio/transcriptions` with failover | Yes: small Python package and local proxy | MIT |
+| [OpenRouter free models](https://openrouter.ai/openrouter/free/providers) | No: hosted API use requires an account/key | Hosted router; the linked free router listed 22 models at snapshot | [Yes](https://openrouter.ai/docs/guides/routing/model-fallbacks): hosted provider/model fallbacks | [Yes](https://openrouter.ai/blog/announcements/openrouter-mcp-server/): hosted remote MCP server | Hosted API/SDK and agent SDK, not a local gateway CLI | [Audio input/transcription](https://openrouter.ai/docs/guides/overview/multimodal/audio) through multimodal chat | No: hosted service | Proprietary service |
+| [LiteLLM](https://github.com/BerriAI/litellm/blob/5d4c4d0fce45c73c4b56b48e46dfc4e56e8b0aa5/README.md) | No: bring provider or hosted-gateway credentials | README claims 100+ LLMs/providers | Yes: router retries/fallbacks | Yes: AI Gateway includes an MCP Gateway | Python SDK and proxy/gateway CLI surface | Yes: `/audio/transcriptions` | Yes: self-hosted proxy or hosted offering | MIT core; commercial enterprise features |
+| [OmniRoute](https://github.com/diegosouzapw/OmniRoute/blob/d8ff51874c8add566d43225988b9bc67e0542d65/README.md) | Yes: its setup documents a no-auth OpenCode option | README claims 268 integrations/providers and 90+ free options | Yes: layered fallback/circuit-breaker routing | Yes: MCP and A2A control planes | Broad management CLI and one-command agent setup | Audio translation is documented; other media capabilities vary by provider | Yes: Node application with dashboard, Docker, desktop/PWA paths | MIT |
+| [FreeLLMAPI](https://github.com/tashfeenahmed/freellmapi/blob/759de8e7ed1edc1cd513c9777cd0a807fb5ceee3/README.md) | Server starts with a Docker one-liner; inference capacity is configured afterward | README claims **28 free LLM providers** and 339 endpoints | Yes: provider/key routing and fallback | Yes: **MCP (Streamable HTTP)** | Dashboard/server and desktop apps | Not documented; audio speech/TTS is supported | Yes: Node/Docker server and desktop apps | MIT |
 
-FreeLLMAPI predates this project, and the overlap is independent convergence:
-both projects noticed that legitimate free tiers are useful when treated
-carefully. freellmpool's niche is the **keyless, pip-installable client** for
-squeezing hosted free tiers from a CLI, library, local proxy, and MCP server;
-OpenRouter is the polished hosted route; LiteLLM is the mature bring-your-own-key
-gateway.
-
-Table sources: freellmpool's catalog and proxy code in this repo; OpenRouter's
-quickstart, free-model, routing, and audio docs; LiteLLM's README, MCP docs, and
-audio transcription docs; FreeLLMAPI's README.
+FreeLLMAPI predates this project, and the overlap is independent convergence
+around legitimate free tiers. OmniRoute
+optimizes for an expansive control plane and many protocols; FreeLLMAPI for a
+dashboard-centric self-hosted router with encrypted key management; freellmpool
+for the smallest Python/CLI/library path with a keyless-capable first reply.
+Those are product-scope choices, not a claim that one tool is best for every
+deployment.
 
 ## FAQ
 

--- a/docs/ADOPTION_SPRINT_PLAN.md
+++ b/docs/ADOPTION_SPRINT_PLAN.md
@@ -1,0 +1,336 @@
+# Adoption Sprint Plan
+
+Status: implementation complete; merge and npm distribution rollout pending
+Owner: freellmpool maintainers
+Planned execution: 2026-07-19
+Branch: `codex/adoption-sprint-20260719`
+
+## Objective and completion boundary
+
+Reduce the time between discovering freellmpool and successfully using it from
+an agent or an automated deployment. This implementation sprint delivers:
+
+1. accurate positioning and a copy-pastable first run;
+2. a first-class Hermes Agent profile;
+3. tested, registry-ready OpenCode packages with corrected defaults; and
+4. stable machine-readable liveness, readiness, and provider inventory APIs.
+
+There are two intentionally separate completion states:
+
+- **Implementation complete:** the reviewed PR is merged, post-merge CI passes,
+  package tarballs pass clean-install/load smokes, and docs describe only
+  installation paths that are actually available.
+- **Distribution rollout complete:** both npm packages are published from the
+  exact merge commit, verified from the registry, and docs are updated to make
+  registry installation primary. If npm ownership credentials are unavailable,
+  implementation may complete but distribution rollout is explicitly
+  **blocked**, not reported as complete. Local-file instructions stay primary
+  and registry commands stay labelled pending until verification.
+
+## Evidence-to-work traceability
+
+| Evidence (snapshot 2026-07-19) | Observed adoption gap | Work unit |
+| --- | --- | --- |
+| FreeLLMAPI's current README no longer matches this repository's comparison claims | Prospective users receive stale capability data | WU4 |
+| OmniRoute exposes a broad CLI/MCP/agent surface | The comparison omits a close alternative and obscures freellmpool's narrower niche | WU4 |
+| Hermes documents OpenAI-compatible custom endpoints | freellmpool has no tested Hermes setup despite requiring no adapter | WU2 |
+| OpenCode packages exist only as repository directories; both npm names return `E404` | Installation requires repository paths and current defaults point to port 8765 instead of 8080 | WU3 |
+| The proxy has `/healthz`, `/status`, and `/v1/models` but no readiness or allow-listed provider API | Operators and integrations must scrape UI-oriented state | WU1 |
+
+Primary references:
+
+- <https://github.com/tashfeenahmed/freellmapi>
+- <https://github.com/diegosouzapw/OmniRoute>
+- <https://github.com/NousResearch/hermes-agent/blob/main/website/docs/integrations/providers.md>
+- <https://opencode.ai/docs/plugins/>
+- <https://docs.npmjs.com/trusted-publishers/>
+
+## Declared file scope
+
+Changes are restricted to this allow-list:
+
+- Plan/release notes: `docs/ADOPTION_SPRINT_PLAN.md`, `CHANGELOG.md`.
+- Operational APIs: `src/freellmpool/proxy.py`,
+  `src/freellmpool/readiness.py`, `tests/test_proxy.py`,
+  `tests/test_readiness.py`.
+- Hermes: `src/freellmpool/profiles.py`, `tests/test_profiles.py`,
+  `tests/test_agents.py`, `docs/INTEGRATIONS.md`, `README.md`.
+- OpenCode: `integrations/opencode/{package.json,README.md,freellmpool.js,LICENSE}`,
+  `integrations/opencode-tui/{package.json,README.md,index.tsx,LICENSE}`,
+  `scripts/check_opencode_packages.mjs`, `tests/test_opencode_packages.py`,
+  `.github/workflows/ci.yml`, `.github/workflows/publish-opencode.yml`,
+  `tests/test_ci_config.py`, `docs/run-opencode-on-free-models.html`.
+- Positioning/first run: `README.md`, `tests/test_release_metadata.py`.
+
+Explicitly out of scope: provider/catalog additions, router or failover behavior,
+dashboard/playground redesign, new protocol adapters, Python package publication,
+image/vision/fusion features, broad static-site/SEO rewrites, and unrelated
+cleanup. An all-catalog inventory is also out of scope; provider API totals mean
+only the `Pool` instance serving the request.
+
+## WU1: operational discovery APIs
+
+Add these standard-library proxy routes:
+
+- `/livez`: public liveness; `/healthz` remains a byte-for-byte JSON alias;
+- `/readyz`: public advisory local-capacity readiness;
+- `/v1/providers`: protected by the existing `/v1/models` auth policy; and
+- `/v1/models?ready=true`: existing model shape filtered by local readiness.
+
+No route performs an upstream request or changes logical quota counts, metrics,
+or cooldown transitions.
+The implementation takes one quota snapshot, one cooldown snapshot, and uses an
+explicit output allow-list. Readiness is conservative and advisory: the router
+may still try cooled or locally exhausted targets as a last resort, but the probe
+reports them unavailable until their local condition clears.
+
+Overlapping provider conditions use this stable precedence:
+`unconfigured` > `no_enabled_models` > `cooldown` > `quota_exhausted` >
+`ready`. Model status uses the same applicable order. Combination tests cover
+each precedence boundary. Reading the quota snapshot may flush increments that
+were already recorded by prior requests, but probes add no record, do not change
+logical counts, and do not create a routing/cooldown transition.
+
+### Stable schema v1
+
+`GET /livez` and `GET /healthz` return HTTP 200 and preserve the legacy body:
+
+```json
+{"status": "ok"}
+```
+
+`GET /readyz` returns HTTP 200 when `ready_providers > 0`, otherwise HTTP 503:
+
+```json
+{
+  "schema_version": 1,
+  "status": "ready",
+  "reason": "ready_providers_available",
+  "ready_providers": 1,
+  "total_providers": 2,
+  "summary": {
+    "ready": 1,
+    "unconfigured": 0,
+    "no_enabled_models": 0,
+    "cooldown": 0,
+    "quota_exhausted": 1
+  }
+}
+```
+
+When none are ready, `status` is `not_ready` and `reason` is
+`no_ready_providers`. The stable provider/model status enum is `ready`,
+`unconfigured`, `no_enabled_models`, `cooldown`, or `quota_exhausted`.
+
+`GET /v1/providers` returns:
+
+```json
+{
+  "schema_version": 1,
+  "object": "list",
+  "data": [{
+    "id": "provider-id",
+    "configured": true,
+    "ready": true,
+    "status": "ready",
+    "enabled_models": 1,
+    "ready_models": 1,
+    "cooldown_remaining_s": 0.0,
+    "models": [{
+      "id": "provider-id/model-id",
+      "name": "model-id",
+      "ready": true,
+      "status": "ready",
+      "daily_limit": 1000,
+      "used_today": 0,
+      "remaining": 1000
+    }]
+  }]
+}
+```
+
+Only those fields are emitted. `total_providers` and `data` mean the active
+`Pool` inventory, including an unconfigured provider only when a caller
+explicitly constructed such a Pool. `rpd == 0` means unknown/unmetered;
+`daily_limit` and `remaining` are then `null`, and the model is not
+considered exhausted. Missing credentials make `configured=false` and status
+`unconfigured`. Disabled models are omitted.
+
+For `/v1/models`, absent `ready` and exactly one `ready=false` or `ready=0`
+preserve current behavior. Exactly one `ready=true` or `ready=1` filters the
+list. Other values and repeated parameters return HTTP 400 with the existing
+OpenAI error envelope. The filtered response preserves OpenAI-versus-Anthropic
+content negotiation; routing aliases appear only when at least one backend model
+is ready. Trailing slashes behave like existing routes.
+
+Acceptance tests cover ready, unconfigured, no-enabled-model, exhausted,
+unknown-quota, and cooldown states; both auth header styles; query parsing;
+OpenAI/Anthropic shapes; empty filtered inventory; and assert that probes make no
+upstream request and leave quota/cooldown state unchanged.
+
+## WU2: Hermes Agent profile
+
+Add `hermes` to the profile registry and legacy `freellmpool code` surface
+using Hermes's documented custom-provider format:
+
+```yaml
+model:
+  provider: custom
+  default: quality
+  base_url: http://localhost:8080/v1
+  api_key: anything
+```
+
+The profile checks `hermes`, `freellmpool`, and `/v1/models`; installation
+is print-only and points to `hermes model` as the interactive alternative.
+
+Acceptance criteria:
+
+- `profile list/show/install`, `profile doctor hermes --dry-run`, and
+  `code hermes` expose the new profile;
+- a non-dry-run doctor passes against a fake authenticated proxy;
+- `--base-url` preserves Hermes's `/v1` custom endpoint contract; and
+- registry/list/integration-guide parity tests cover Hermes automatically.
+
+No Hermes files are edited and no claim is made that freellmpool is a native
+Hermes provider.
+
+## WU3: OpenCode distribution and default repair
+
+Harden `opencode-freellmpool` and `opencode-freellmpool-tui` as independent
+npm packages. Both use the actual proxy default `http://localhost:8080`; stale
+`8765` and `freellmpool-proxy` references are removed. Manifests receive
+public package metadata, root exports, `repository.directory`, issue/homepage
+links, runtime/peer contracts, explicit file lists, and packaged licenses.
+Lifecycle scripts are forbidden.
+
+### Package validation contract
+
+A dedicated Node 24 CI job installs npm 11.5.1 or newer and, for each package:
+
+1. runs `npm pack --json` and asserts the exact tarball file set;
+2. creates a clean temporary project and installs the tarball with scripts
+   disabled;
+3. resolves the declared root/subpath exports;
+4. imports and invokes the server plugin far enough to validate its OpenCode
+   contract with a stub API; and
+5. uses Bun/OpenCode's runtime path to compile/load the TUI `./tui` export with
+   its declared peers.
+
+The same script is runnable locally. Python policy tests validate manifests, the
+8080 default, absence of lifecycle hooks, workflow triggers/permissions, and docs
+parity without making normal pytest perform network installs.
+
+Until both registry versions are verified, local-file installation stays the
+primary documented path and npm examples are explicitly marked pending.
+
+### Publishing contract
+
+`.github/workflows/publish-opencode.yml` is `workflow_dispatch` only, uses a
+GitHub-hosted runner, Node 24/npm >=11.5.1, `contents: read` and
+`id-token: write`, and the protected `npm` GitHub environment. Its required
+inputs are package, version, and immutable merge SHA. It fetches `origin/main`,
+checks out that SHA, verifies it is the current `origin/main` tip, verifies the
+selected manifest version equals the input version, rejects a version already in
+the registry, runs the package smoke, publishes only the selected package with
+provenance, and verifies `npm view` plus the registry tarball. Per-package
+dispatch makes partial rollout idempotently recoverable and avoids the existing
+`v*` Docker-release trigger.
+
+Because trusted publishing cannot bootstrap absent package names, the same
+protected hosted workflow supports a one-time bootstrap secret. Rollout is:
+
+1. after post-merge `main` CI, an npm owner creates a short-lived write token
+   authorized to create the two unscoped packages and stores it only as the
+   protected `npm` environment's `NPM_TOKEN` secret;
+2. an environment approver dispatches the hosted workflow for each `0.1.0`
+   package and exact merge SHA; `npm publish --provenance` uses that token while
+   GitHub's hosted OIDC context supplies provenance;
+3. verify each registry tarball before attempting the other package;
+4. configure each package's trusted publisher for the exact repository and
+   `publish-opencode.yml` workflow, then remove/revoke the bootstrap token; and
+5. verify a later release through the approved `npm` environment/OIDC workflow.
+
+If package one succeeds and package two fails, do not republish package one;
+preserve its verified state and resume package two. A bad immutable version is
+deprecated, corrected with a patch release, and reflected honestly in docs.
+After both initial packages and trusted-publisher settings are verified, open a
+second, docs-only PR from the verified registry state. That PR changes npm
+installation from pending to primary, passes review and the full required CI,
+merges, and has green post-merge `main` CI. Distribution rollout is not complete
+before that second merge.
+
+## WU4: positioning and first-run documentation
+
+Correct the competitor table from commit-pinned primary sources, add OmniRoute,
+show a 2026-07-19 snapshot date, and describe scope choices rather than vague
+superiority. Stale FreeLLMAPI provider/MCP/audio claims are removed. Positioning
+stays focused on freellmpool's small Python install, keyless-capable first run,
+legitimate pooled free tiers, and agent-friendly OpenAI/MCP surfaces.
+
+Add a no-checkout `uvx freellmpool ...` command alongside the portable virtual
+environment path. Validate a clean local artifact with `uvx --from .` and run
+the existing isolated live quickstart smoke
+`FREELLMPOOL_QUICKSTART_PACKAGE=. scripts/quickstart-test.sh`; provider outage
+is reported separately from packaging/CLI failure. New Hermes/API behavior is
+identified as unreleased until the Python release containing it exists.
+
+Update the README, integration guide, both package READMEs, and static OpenCode
+guide in parity. Limitations remain prominent: upstream data handling, free-tier
+volatility, local-readiness versus live-health semantics, and no rate-limit
+bypass.
+
+## Test-first execution and deterministic gates
+
+1. Add and run failing proxy contract tests, then implement WU1.
+2. Add and run failing Hermes tests, then implement WU2.
+3. Add and run failing package/workflow tests, then implement WU3.
+4. Add and run failing documentation assertions, then implement WU4.
+5. Run targeted tests after each unit, then the full matrix.
+
+The coverage gate uses the exact `.coverage-thresholds.json` command:
+
+```bash
+pytest --cov=freellmpool --cov-branch --cov-report=term-missing --cov-report=json:.coverage.json && python scripts/check_coverage.py .coverage.json
+```
+
+Additional deterministic gates:
+
+```bash
+ruff check .
+mypy --follow-imports=skip src/freellmpool/routing_modes.py src/freellmpool/catalog_validation.py src/freellmpool/_version.py src/freellmpool/readiness.py
+node scripts/check_opencode_packages.mjs
+python scripts/check-counts
+git diff --check
+```
+
+The complete `pytest` suite, build/release metadata checks, and existing Docker
+smoke remain required through CI. New typed operational logic lives in the
+strictly checked `readiness.py`; `proxy.py` and `profiles.py` have existing
+full-module strict-mypy debt, so this sprint must not add errors outside that
+typed helper. The explicit `--follow-imports=skip` still applies strict mode to
+every named helper while isolating the gate from that known recursive debt.
+
+## Security, review, merge, and rollout gates
+
+- Health/provider payloads use explicit field construction; process environment,
+  key names, values, and raw provider objects are never serialized.
+- Public endpoints expose aggregate liveness/readiness only; named inventory is
+  protected like `/v1/models`.
+- Package installs disable scripts during validation, manifests cannot declare
+  lifecycle hooks, publishing is never triggered by a PR, and future releases
+  use environment-approved OIDC with least privilege.
+- Existing `/healthz`, unfiltered `/v1/models`, and local OpenCode install
+  paths remain backward compatible. No data migration is introduced.
+
+Before implementation, independent feasibility, completeness, and
+scope/alignment reviewers must all pass this plan. Before PR creation, final
+adversarial review runs on the latest diff. Every blocking plan, code, security,
+or PR-review finding must be fixed and retested before merge; only explicitly
+non-blocking debt may be deferred.
+
+PR completion requires all review comments resolved, all required and npm
+validation checks green, merge, and post-merge `main` CI green. Distribution
+then starts from the exact merge commit under the publishing contract above.
+The final report states implementation and rollout status separately and never
+describes an unpublished package as installable from npm.

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -63,6 +63,13 @@ Anthropic bridge, `/v1/models` for concrete `provider/model` ids, `/dashboard`
 for operations, `/playground` for browser-side battle runs, and
 `/freellmpool/battle` for JSON/Markdown comparison results.
 
+For automation, `/healthz` and `/livez` are public liveness aliases;
+`/readyz` is a public advisory local-capacity probe (200 or 503), and
+`/v1/providers` is the authenticated secret-free inventory. Use
+`/v1/models?ready=true` to keep the normal OpenAI/Anthropic model-list shape
+while filtering out locally exhausted or cooling-down targets. These are local
+snapshots and never live-probe an upstream provider.
+
 ### opencode
 `opencode.json` (project or `~/.config/opencode/`):
 ```json
@@ -88,6 +95,11 @@ spread quota). Full guide: <https://0xzr.github.io/freellmpool/run-opencode-on-f
   sparkline, last-served model). Install: `opencode plugin -g file:<repo>/integrations/opencode-tui`.
 - [`integrations/opencode`](../integrations/opencode) — a server plugin adding
   `freellmpool_status` and `freellmpool_models` tools and a served-model toast.
+
+**Registry publication status: pending.** The intended package names are
+`opencode-freellmpool` and `opencode-freellmpool-tui`; CI packs, clean-installs,
+and loads both, but do not use an npm install command until the registry versions
+are verified. The local-file commands above are the current working path.
 
 ### metaswarm
 [`integrations/metaswarm`](../integrations/metaswarm) contains an experimental
@@ -120,6 +132,32 @@ freellmpool profile doctor metaswarm --dry-run
 It includes Tailnet setup for remote agents, a free/cheap worker lane, a larger
 freellmpool reviewer lane, and Codex/Opus lanes only as explicit user-owned paid
 escalation/final-review tools.
+
+### Hermes Agent
+
+Hermes supports OpenAI-compatible custom endpoints. Start the proxy, then either
+run `hermes model` and choose **Custom endpoint**, or inspect the print-only
+profile:
+
+```bash
+freellmpool profile install hermes
+freellmpool profile doctor hermes --dry-run
+```
+
+The rendered `~/.hermes/config.yaml` block is:
+
+```yaml
+model:
+  provider: custom
+  default: quality
+  base_url: http://localhost:8080/v1
+  api_key: anything
+```
+
+`quality` selects freellmpool's capability-aware routing alias. Hermes still
+sees a custom endpoint rather than a native provider, and freellmpool does not
+edit `~/.hermes/config.yaml`. Upstream reference:
+<https://github.com/NousResearch/hermes-agent/blob/a7d7c02cb6db071eced4ac82e24f878588619600/website/docs/integrations/providers.md#custom--self-hosted-llm-providers>.
 
 ### aider
 ```bash

--- a/docs/run-opencode-on-free-models.html
+++ b/docs/run-opencode-on-free-models.html
@@ -87,6 +87,10 @@ sparkline, and which provider/model just answered. It updates as you code. Setup
 <a href="https://github.com/0xzr/freellmpool/tree/main/integrations/opencode-tui">integrations/opencode-tui</a>
 folder; a companion server plugin adds <code>freellmpool_status</code> and <code>freellmpool_models</code>
 tools you can ask for in any session.</p>
+<p><strong>Registry publication status: pending.</strong>
+The planned packages are <code>opencode-freellmpool</code> and
+<code>opencode-freellmpool-tui</code>. Their tarballs are clean-install/load-tested,
+but use the linked local-file setup until both npm versions are verified.</p>
 
 <div class="note">Free-tier models are smaller than frontier models. They're great for scaffolding,
 refactors, tests, commit messages, and everyday edits — not a substitute for a frontier model on the

--- a/integrations/opencode-tui/LICENSE
+++ b/integrations/opencode-tui/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 0xzr (github.com/0xzr)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/integrations/opencode-tui/README.md
+++ b/integrations/opencode-tui/README.md
@@ -46,6 +46,11 @@ your editor and lives alongside OpenCode's own Context / MCP / LSP panels.
 
 ## Install
 
+> **Registry publication status: pending.** `opencode-freellmpool-tui` and the
+> companion `opencode-freellmpool` server plugin are pack/install/load-tested
+> in CI, but are not yet verified on npm. Use the local-file command below until
+> that status changes.
+
 OpenCode TUI plugins are installed with the built-in installer (which wires the OpenTUI
 runtime for you — there are no `node_modules` to manage):
 
@@ -55,7 +60,7 @@ opencode plugin -g file:/absolute/path/to/integrations/opencode-tui
 ```
 
 That records the plugin in `~/.config/opencode/tui.json`. Start the proxy
-(`freellmpool-proxy`) and launch `opencode` — the panel appears on the home screen and in
+(`freellmpool proxy`) and launch `opencode` — the panel appears on the home screen and in
 the session sidebar.
 
 > TUI plugins are configured in `tui.json`, **not** the `plugin` array in `opencode.json`
@@ -68,7 +73,7 @@ To remove it, delete the entry from `~/.config/opencode/tui.json`.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `FREELLMPOOL_PROXY_URL` | `http://localhost:8765` | proxy base URL the dashboard polls |
+| `FREELLMPOOL_PROXY_URL` | `http://localhost:8080` | proxy base URL the dashboard polls |
 | `FREELLMPOOL_PROXY_KEY` | _(none)_ | sent as `Authorization: Bearer <key>` if your proxy requires one |
 
 ## Controlling routing

--- a/integrations/opencode-tui/index.tsx
+++ b/integrations/opencode-tui/index.tsx
@@ -8,11 +8,11 @@
 // latency sparkline, and the most-recently-served provider/model.
 //
 // Install:  opencode plugin -g file:/path/to/integrations/opencode-tui
-// Config:   FREELLMPOOL_PROXY_URL (default http://localhost:8765)
+// Config:   FREELLMPOOL_PROXY_URL (default http://localhost:8080)
 //
 import { createEffect, createSignal, onCleanup, For, Show } from "solid-js"
 
-const PROXY = (process.env.FREELLMPOOL_PROXY_URL || "http://localhost:8765").replace(/\/+$/, "")
+const PROXY = (process.env.FREELLMPOOL_PROXY_URL || "http://localhost:8080").replace(/\/+$/, "")
 const PROXY_KEY = process.env.FREELLMPOOL_PROXY_KEY || ""
 const AUTH = PROXY_KEY ? { Authorization: `Bearer ${PROXY_KEY}` } : {}
 const POLL_MS = 1500
@@ -201,7 +201,7 @@ const plugin = async (api) => {
         fallback={
           <box border borderColor={theme.error} paddingLeft={1} paddingRight={1} flexDirection="column">
             <text fg={theme.error}>● freellmpool</text>
-            <text fg={theme.textMuted}>proxy offline — start `freellmpool-proxy`</text>
+            <text fg={theme.textMuted}>proxy offline — start `freellmpool proxy`</text>
           </box>
         }
       >

--- a/integrations/opencode-tui/package.json
+++ b/integrations/opencode-tui/package.json
@@ -1,8 +1,30 @@
 {
   "name": "opencode-freellmpool-tui",
   "version": "0.1.0",
+  "description": "Embedded freellmpool quota, routing, latency, and savings dashboard for the OpenCode TUI.",
+  "private": false,
   "type": "module",
+  "license": "MIT",
+  "keywords": ["opencode", "opencode-plugin", "freellmpool", "tui", "dashboard"],
+  "homepage": "https://github.com/0xzr/freellmpool/tree/main/integrations/opencode-tui#readme",
+  "bugs": {
+    "url": "https://github.com/0xzr/freellmpool/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/0xzr/freellmpool.git",
+    "directory": "integrations/opencode-tui"
+  },
+  "engines": {
+    "node": ">=20"
+  },
   "exports": {
+    ".": "./index.tsx",
     "./tui": "./index.tsx"
-  }
+  },
+  "peerDependencies": {
+    "@opentui/solid": ">=0.4.5",
+    "solid-js": ">=1.9.12"
+  },
+  "files": ["LICENSE", "README.md", "index.tsx"]
 }

--- a/integrations/opencode/LICENSE
+++ b/integrations/opencode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 0xzr (github.com/0xzr)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -4,7 +4,7 @@ See which free provider/model is actually serving you, check usage and rate-limi
 and control routing quality — all from inside [OpenCode](https://opencode.ai).
 
 It talks to a running [freellmpool](https://github.com/0xzr/freellmpool) proxy
-(`freellmpool proxy`, default `http://localhost:8765`).
+(`freellmpool proxy`, default `http://localhost:8080`).
 
 ## What it adds
 
@@ -43,6 +43,11 @@ across all of them while still preferring the quick/healthy ones.
 
 ## Install
 
+> **Registry publication status: pending.** `opencode-freellmpool` and its
+> companion `opencode-freellmpool-tui` are pack/install/load-tested in CI, but
+> are not yet verified on npm. Use the local-file path below until that status
+> changes.
+
 **Option A — drop-in (no build):**
 
 ```sh
@@ -59,7 +64,7 @@ cp freellmpool.js ~/.config/opencode/plugin/
 ```
 
 Then make sure the proxy is running (`freellmpool proxy`) and that OpenCode has a
-`freellmpool` provider pointed at it (`baseURL: http://localhost:8765/v1`). Add the
+`freellmpool` provider pointed at it (`baseURL: http://localhost:8080/v1`). Add the
 routing aliases as models so you can pick them:
 
 ```jsonc
@@ -67,7 +72,7 @@ routing aliases as models so you can pick them:
   "provider": {
     "freellmpool": {
       "npm": "@ai-sdk/openai-compatible",
-      "options": { "baseURL": "http://localhost:8765/v1" },
+      "options": { "baseURL": "http://localhost:8080/v1" },
       "models": {
         "spread": {},
         "auto": {},
@@ -84,7 +89,7 @@ routing aliases as models so you can pick them:
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `FREELLMPOOL_PROXY_URL` | `http://localhost:8765` | proxy base URL |
+| `FREELLMPOOL_PROXY_URL` | `http://localhost:8080` | proxy base URL |
 | `FREELLMPOOL_PROXY_KEY` | _(none)_ | sent as `Authorization: Bearer <key>` if your proxy requires one |
 | `FREELLMPOOL_TOAST` | on | set to `0`/`false`/`off` to silence the served-model toast |
 

--- a/integrations/opencode/freellmpool.js
+++ b/integrations/opencode/freellmpool.js
@@ -14,14 +14,14 @@
 //
 // Zero build step, zero extra deps: drop this file in ~/.config/opencode/plugin/ or
 // reference it from opencode.json `plugin`. Config:
-//   FREELLMPOOL_PROXY_URL   base URL (default http://localhost:8765)
+//   FREELLMPOOL_PROXY_URL   base URL (default http://localhost:8080)
 //   FREELLMPOOL_PROXY_KEY   sent as `Authorization: Bearer <key>` if the proxy needs one
 //   FREELLMPOOL_TOAST       set to 0/false/off to silence the served-model toast
 
 import { tool } from "@opencode-ai/plugin";
 
 const BASE_URL = (
-  process.env.FREELLMPOOL_PROXY_URL || "http://localhost:8765"
+  process.env.FREELLMPOOL_PROXY_URL || "http://localhost:8080"
 ).replace(/\/+$/, "");
 const PROXY_KEY = process.env.FREELLMPOOL_PROXY_KEY || "";
 const TOAST = !/^(0|false|off|no)$/i.test(process.env.FREELLMPOOL_TOAST || "");

--- a/integrations/opencode/package.json
+++ b/integrations/opencode/package.json
@@ -2,13 +2,28 @@
   "name": "opencode-freellmpool",
   "version": "0.1.0",
   "description": "OpenCode plugin for freellmpool: see the serving provider/model, usage & rate-limits, and control routing quality.",
+  "private": false,
   "type": "module",
   "main": "freellmpool.js",
-  "exports": "./freellmpool.js",
+  "exports": {
+    ".": "./freellmpool.js"
+  },
   "keywords": ["opencode", "opencode-plugin", "freellmpool", "llm", "proxy"],
   "license": "MIT",
+  "homepage": "https://github.com/0xzr/freellmpool/tree/main/integrations/opencode#readme",
+  "bugs": {
+    "url": "https://github.com/0xzr/freellmpool/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/0xzr/freellmpool.git",
+    "directory": "integrations/opencode"
+  },
+  "engines": {
+    "node": ">=20"
+  },
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.14.0"
   },
-  "files": ["freellmpool.js", "README.md"]
+  "files": ["LICENSE", "README.md", "freellmpool.js"]
 }

--- a/scripts/check_opencode_packages.mjs
+++ b/scripts/check_opencode_packages.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { spawnSync } from "node:child_process"
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const work = mkdtempSync(join(tmpdir(), "freellmpool-opencode-packages-"))
+const bun = process.env.BUN_BIN || "bun"
+
+const packages = [
+  {
+    directory: "opencode",
+    name: "opencode-freellmpool",
+    files: ["LICENSE", "README.md", "freellmpool.js", "package.json"],
+  },
+  {
+    directory: "opencode-tui",
+    name: "opencode-freellmpool-tui",
+    files: ["LICENSE", "README.md", "index.tsx", "package.json"],
+  },
+]
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || root,
+    encoding: "utf8",
+    env: { ...process.env, ...(options.env || {}) },
+  })
+  if (result.status !== 0) {
+    throw new Error(
+      [`command failed: ${command} ${args.join(" ")}`, result.stdout, result.stderr]
+        .filter(Boolean)
+        .join("\n"),
+    )
+  }
+  return result.stdout
+}
+
+function writePackage(directory, name, source) {
+  const packageDir = join(directory, "node_modules", ...name.split("/"))
+  mkdirSync(packageDir, { recursive: true })
+  writeFileSync(
+    join(packageDir, "package.json"),
+    JSON.stringify({ name, version: "0.0.0-smoke", type: "module", exports: "./index.js" }),
+  )
+  writeFileSync(join(packageDir, "index.js"), source)
+}
+
+function smokeServer(installDir) {
+  writePackage(
+    installDir,
+    "@opencode-ai/plugin",
+    [
+      "const chain = new Proxy(function () { return chain }, {",
+      "  get() { return chain },",
+      "  apply() { return chain },",
+      "})",
+      "export const tool = { schema: chain }",
+    ].join("\n"),
+  )
+  run(
+    process.execPath,
+    [
+      "--input-type=module",
+      "-e",
+      [
+        'const mod = await import("opencode-freellmpool")',
+        "const loaded = await mod.default({ client: { tui: { showToast: async () => {} } } })",
+        'if (!loaded?.tool?.freellmpool_status) throw new Error("server plugin did not load")',
+      ].join(";"),
+    ],
+    { cwd: installDir },
+  )
+}
+
+function smokeTui(installDir) {
+  writePackage(
+    installDir,
+    "solid-js",
+    [
+      "export const createEffect = () => {}",
+      "export const createSignal = (value) => [() => value, () => {}]",
+      "export const onCleanup = () => {}",
+      "export const For = () => null",
+      "export const Show = () => null",
+    ].join("\n"),
+  )
+  const openTuiDir = join(installDir, "node_modules", "@opentui", "solid")
+  mkdirSync(openTuiDir, { recursive: true })
+  writeFileSync(
+    join(openTuiDir, "package.json"),
+    JSON.stringify({
+      name: "@opentui/solid",
+      version: "0.0.0-smoke",
+      type: "module",
+      exports: {
+        ".": "./index.js",
+        "./jsx-runtime": "./jsx-runtime.js",
+        "./jsx-dev-runtime": "./jsx-runtime.js",
+      },
+    }),
+  )
+  writeFileSync(join(openTuiDir, "index.js"), "export {}\n")
+  writeFileSync(
+    join(openTuiDir, "jsx-runtime.js"),
+    [
+      "export const Fragment = Symbol.for('fragment')",
+      "export const jsx = (type, props) => ({ type, props })",
+      "export const jsxs = jsx",
+      "export const jsxDEV = jsx",
+    ].join("\n"),
+  )
+  run(
+    bun,
+    [
+      "--eval",
+      [
+        'import plugin from "opencode-freellmpool-tui/tui"',
+        'if (plugin?.id !== "freellmpool-tui" || typeof plugin?.tui !== "function") throw new Error("TUI plugin did not load")',
+      ].join(";"),
+    ],
+    { cwd: installDir },
+  )
+}
+
+try {
+  for (const spec of packages) {
+    const packageDir = join(root, "integrations", spec.directory)
+    // Contract: npm pack --json, followed by a clean npm install --ignore-scripts --omit=peer.
+    const packed = JSON.parse(
+      run("npm", ["pack", "--json", "--pack-destination", work], { cwd: packageDir }),
+    )
+    if (!Array.isArray(packed) || packed.length !== 1) {
+      throw new Error(`${spec.name}: npm pack returned an unexpected result`)
+    }
+    const actualFiles = packed[0].files.map((entry) => entry.path).sort()
+    const expectedFiles = [...spec.files].sort()
+    if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+      throw new Error(
+        `${spec.name}: packed files ${JSON.stringify(actualFiles)} != ${JSON.stringify(expectedFiles)}`,
+      )
+    }
+    const tarball = join(work, packed[0].filename)
+    const installDir = join(work, `install-${spec.directory}`)
+    mkdirSync(installDir)
+    writeFileSync(
+      join(installDir, "package.json"),
+      JSON.stringify({ name: "freellmpool-package-smoke", private: true, type: "module" }),
+    )
+    run(
+      "npm",
+      ["install", "--ignore-scripts", "--omit=peer", "--no-audit", "--no-fund", tarball],
+      { cwd: installDir },
+    )
+    const installed = JSON.parse(
+      readFileSync(join(installDir, "node_modules", spec.name, "package.json"), "utf8"),
+    )
+    if (installed.name !== spec.name) throw new Error(`${spec.name}: clean install failed`)
+    if (spec.directory === "opencode") smokeServer(installDir)
+    else smokeTui(installDir)
+    process.stdout.write(`validated ${spec.name}@${installed.version}\n`)
+  }
+} finally {
+  rmSync(work, { recursive: true, force: true })
+}

--- a/src/freellmpool/profiles.py
+++ b/src/freellmpool/profiles.py
@@ -138,6 +138,35 @@ _PROFILES: tuple[Profile, ...] = (
         notes="Pick freellmpool/spread for agentic work — it fans requests across the whole pool.",
     ),
     Profile(
+        name="hermes",
+        label="Hermes Agent",
+        client_kind="openai",
+        base_url=f"{_DEFAULT_PROXY}/v1",
+        model_family="quality",
+        cost_class="free",
+        role_map={
+            "coder": "agentic custom-endpoint lane using capability-aware free routing",
+        },
+        config_snippets={
+            "~/.hermes/config.yaml": (
+                "model:\n"
+                "  provider: custom\n"
+                "  default: quality\n"
+                f"  base_url: {_DEFAULT_PROXY}/v1\n"
+                "  api_key: anything"
+            ),
+        },
+        doctor_checks=[
+            DoctorCheck("binary", "hermes CLI", "hermes"),
+            DoctorCheck("binary", "freellmpool CLI", "freellmpool"),
+            DoctorCheck("url", "proxy /v1/models", _DEFAULT_PROXY, path="/v1/models"),
+        ],
+        notes=(
+            "Hermes supports this as a custom OpenAI-compatible endpoint. "
+            "Run 'hermes model' for the interactive setup instead."
+        ),
+    ),
+    Profile(
         name="codex",
         label="OpenAI Codex CLI",
         client_kind="openai",

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -12,6 +12,7 @@ freellmpool pulls in nothing beyond httpx.
 
 Supported routes:
     GET  /v1/models                 list available (provider/model) ids
+    GET  /v1/providers              secret-free provider readiness inventory
     POST /v1/chat/completions       route a chat completion (true token streaming)
     POST /v1/embeddings             pooled free embeddings
     POST /v1/audio/transcriptions   pooled free audio transcription (Whisper, multipart)
@@ -20,6 +21,8 @@ Supported routes:
     GET  /playground                local comparison playground
     POST /freellmpool/battle        bounded local model battle
     GET  /healthz                   liveness probe
+    GET  /livez                     liveness probe alias
+    GET  /readyz                    advisory local-capacity readiness probe
 """
 
 from __future__ import annotations
@@ -43,6 +46,7 @@ from .errors import (
     FreeLLMPoolError,
     NoProvidersConfigured,
 )
+from .readiness import ReadinessSnapshot, readiness_snapshot
 from .router import Pool
 from .routing_modes import PUBLIC_ROUTING_ALIASES, routing_override
 from .savings import usd_saved
@@ -56,28 +60,36 @@ _MAX_AUDIO_BODY = 25 * 1024 * 1024
 _TRANSCRIPTION_FORMATS = ("json", "text", "verbose_json")
 
 
-def _model_ids(pool: Pool) -> list[str]:
+def _model_ids(pool: Pool, ready_model_ids: frozenset[str] | None = None) -> list[str]:
     # "auto" + per-request routing aliases (mapped to a routing mode by the proxy),
     # then every enabled provider/model id.
-    # INVARIANT: always non-empty (the routing aliases are unconditional). _anthropic_models_payload
-    # relies on this for first_id/last_id = ids[0]/ids[-1] without a guard — keep these seeds
-    # unconditional, or restore that guard.
-    ids = list(PUBLIC_ROUTING_ALIASES)
+    # Unfiltered discovery always includes routing aliases. A readiness-filtered
+    # empty pool returns an empty list (the Anthropic payload handles null bounds).
+    ids = list(PUBLIC_ROUTING_ALIASES) if ready_model_ids is None or ready_model_ids else []
     for provider in pool.providers:
         for m in provider.models:
-            if m.enabled:
-                ids.append(f"{provider.id}/{m.name}")
+            model_id = f"{provider.id}/{m.name}"
+            if m.enabled and (ready_model_ids is None or model_id in ready_model_ids):
+                ids.append(model_id)
     return ids
 
 
-def _openai_models_payload(pool: Pool) -> dict:
-    data = [{"id": mid, "object": "model", "owned_by": "freellmpool"} for mid in _model_ids(pool)]
+def _openai_models_payload(
+    pool: Pool, ready_model_ids: frozenset[str] | None = None
+) -> dict:
+    data = [
+        {"id": mid, "object": "model", "owned_by": "freellmpool"}
+        for mid in _model_ids(pool, ready_model_ids)
+    ]
     return {"object": "list", "data": data}
 
 
-def _anthropic_models_payload(pool: Pool) -> dict:
-    ids = _model_ids(pool)
-    ids.extend(a for a in known_aliases(pool.env) if a.startswith("claude-") and a not in ids)
+def _anthropic_models_payload(
+    pool: Pool, ready_model_ids: frozenset[str] | None = None
+) -> dict:
+    ids = _model_ids(pool, ready_model_ids)
+    if ready_model_ids is None:
+        ids.extend(a for a in known_aliases(pool.env) if a.startswith("claude-") and a not in ids)
     data = [
         {
             "type": "model",
@@ -90,9 +102,34 @@ def _anthropic_models_payload(pool: Pool) -> dict:
     return {
         "data": data,
         "has_more": False,
-        "first_id": ids[0],
-        "last_id": ids[-1],
+        "first_id": ids[0] if ids else None,
+        "last_id": ids[-1] if ids else None,
     }
+
+
+def _readiness_snapshot(pool: Pool) -> ReadinessSnapshot:
+    """Take one quota/cooldown snapshot without probing an upstream."""
+    now = pool._clock()
+    return readiness_snapshot(
+        pool.providers,
+        env=pool.env,
+        quota=pool.quota.snapshot(),
+        cooldowns=pool.cooldown_snapshot(now),
+    )
+
+
+def _ready_filter(query: str) -> bool | None:
+    values = parse_qs(query, keep_blank_values=True).get("ready")
+    if values is None:
+        return None
+    if len(values) != 1:
+        raise ValueError("ready must be specified once")
+    value = values[0].casefold()
+    if value in {"true", "1"}:
+        return True
+    if value in {"false", "0"}:
+        return False
+    raise ValueError("ready must be true, false, 1, or 0")
 
 
 def _provider_leaderboard(pool: Pool, limit: int = 5) -> list[tuple[str, float]]:
@@ -293,8 +330,15 @@ def make_handler(pool: Pool, api_key: str | None = None):
 
         def _do_get(self) -> None:
             path = urlsplit(self.path).path.rstrip("/") or "/"
-            if path == "/healthz":
+            if path in ("/healthz", "/livez"):
                 self._send(200, {"status": "ok"})
+                return
+            if path == "/readyz":
+                snapshot = _readiness_snapshot(pool)
+                self._send(
+                    200 if snapshot.ready_providers else 503,
+                    snapshot.readiness_payload(),
+                )
                 return
             # Shareable SVG badge/card of lifetime "served free" totals. Embeddable
             # (e.g. in a README) only when FREELLMPOOL_PUBLIC_BADGE is set, so a
@@ -348,12 +392,23 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 self.wfile.write(html)
                 return
             if path.endswith("/v1/models") or path == "/models":
+                try:
+                    ready = _ready_filter(urlsplit(self.path).query)
+                except ValueError as exc:
+                    self._error(400, str(exc), "invalid_request_error")
+                    return
+                ready_ids = None
+                if ready:
+                    ready_ids = frozenset(_readiness_snapshot(pool).ready_model_ids)
                 payload = (
-                    _anthropic_models_payload(pool)
+                    _anthropic_models_payload(pool, ready_ids)
                     if self._wants_anthropic_models()
-                    else _openai_models_payload(pool)
+                    else _openai_models_payload(pool, ready_ids)
                 )
                 self._send(200, payload)
+                return
+            if path == "/v1/providers":
+                self._send(200, _readiness_snapshot(pool).provider_payload())
                 return
             if path in ("/status", "/v1/status"):
                 with recent_lock:

--- a/src/freellmpool/readiness.py
+++ b/src/freellmpool/readiness.py
@@ -1,0 +1,244 @@
+"""Secret-free, read-only readiness snapshots for the proxy.
+
+The router intentionally still tries cooled or locally exhausted targets as a
+last resort. This module provides a more conservative advisory view for
+orchestrators and integrations without making provider calls or changing
+routing state.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+ReadinessStatus = Literal[
+    "ready",
+    "unconfigured",
+    "no_enabled_models",
+    "cooldown",
+    "quota_exhausted",
+]
+
+_STATUSES: tuple[ReadinessStatus, ...] = (
+    "ready",
+    "unconfigured",
+    "no_enabled_models",
+    "cooldown",
+    "quota_exhausted",
+)
+
+
+class ModelLike(Protocol):
+    """Structural model fields needed for readiness."""
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def rpd(self) -> int: ...
+
+    @property
+    def enabled(self) -> bool: ...
+
+
+class ProviderLike(Protocol):
+    """Structural provider fields needed for readiness."""
+
+    @property
+    def id(self) -> str: ...
+
+    @property
+    def models(self) -> Sequence[ModelLike]: ...
+
+    def is_configured(self, env: dict[str, str] | None = None) -> bool: ...
+
+
+@dataclass(frozen=True)
+class ModelReadiness:
+    """One enabled model's local readiness state."""
+
+    id: str
+    name: str
+    ready: bool
+    status: ReadinessStatus
+    daily_limit: int | None
+    used_today: int
+    remaining: int | None
+
+    def payload(self) -> dict[str, object]:
+        """Return the public, explicitly allow-listed model schema."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "ready": self.ready,
+            "status": self.status,
+            "daily_limit": self.daily_limit,
+            "used_today": self.used_today,
+            "remaining": self.remaining,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderReadiness:
+    """One active Pool provider's local readiness state."""
+
+    id: str
+    configured: bool
+    ready: bool
+    status: ReadinessStatus
+    enabled_models: int
+    ready_models: int
+    cooldown_remaining_s: float
+    models: tuple[ModelReadiness, ...]
+
+    def payload(self) -> dict[str, object]:
+        """Return the public, explicitly allow-listed provider schema."""
+        return {
+            "id": self.id,
+            "configured": self.configured,
+            "ready": self.ready,
+            "status": self.status,
+            "enabled_models": self.enabled_models,
+            "ready_models": self.ready_models,
+            "cooldown_remaining_s": self.cooldown_remaining_s,
+            "models": [model.payload() for model in self.models],
+        }
+
+
+@dataclass(frozen=True)
+class ReadinessSnapshot:
+    """A consistent local-capacity snapshot."""
+
+    providers: tuple[ProviderReadiness, ...]
+
+    @property
+    def ready_providers(self) -> int:
+        return sum(provider.ready for provider in self.providers)
+
+    @property
+    def total_providers(self) -> int:
+        return len(self.providers)
+
+    @property
+    def ready_model_ids(self) -> tuple[str, ...]:
+        return tuple(
+            model.id
+            for provider in self.providers
+            for model in provider.models
+            if model.ready
+        )
+
+    @property
+    def summary(self) -> dict[str, int]:
+        counts: dict[str, int] = {status: 0 for status in _STATUSES}
+        for provider in self.providers:
+            counts[provider.status] += 1
+        return counts
+
+    def readiness_payload(self) -> dict[str, object]:
+        ready = self.ready_providers > 0
+        return {
+            "schema_version": 1,
+            "status": "ready" if ready else "not_ready",
+            "reason": "ready_providers_available" if ready else "no_ready_providers",
+            "ready_providers": self.ready_providers,
+            "total_providers": self.total_providers,
+            "summary": self.summary,
+        }
+
+    def provider_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "object": "list",
+            "data": [provider.payload() for provider in self.providers],
+        }
+
+
+def readiness_snapshot(
+    providers: Sequence[ProviderLike],
+    *,
+    env: Mapping[str, str],
+    quota: Mapping[str, int],
+    cooldowns: Mapping[str, float],
+) -> ReadinessSnapshot:
+    """Build a deterministic snapshot without calling an upstream provider."""
+    env_copy = dict(env)
+    rows: list[ProviderReadiness] = []
+    for provider in providers:
+        configured = provider.is_configured(env_copy)
+        enabled = [model for model in provider.models if model.enabled]
+        cooldown = max(0.0, float(cooldowns.get(provider.id, 0.0)))
+        models = tuple(
+            _model_readiness(
+                provider.id,
+                model,
+                configured=configured,
+                cooled=cooldown > 0,
+                used=int(quota.get(f"{provider.id}::{model.name}", 0)),
+            )
+            for model in enabled
+        )
+
+        if not configured:
+            status: ReadinessStatus = "unconfigured"
+        elif not enabled:
+            status = "no_enabled_models"
+        elif cooldown > 0:
+            status = "cooldown"
+        elif all(model.status == "quota_exhausted" for model in models):
+            status = "quota_exhausted"
+        else:
+            status = "ready"
+        ready_models = sum(model.ready for model in models)
+        rows.append(
+            ProviderReadiness(
+                id=provider.id,
+                configured=configured,
+                ready=status == "ready",
+                status=status,
+                enabled_models=len(enabled),
+                ready_models=ready_models,
+                cooldown_remaining_s=cooldown,
+                models=models,
+            )
+        )
+    return ReadinessSnapshot(tuple(rows))
+
+
+def _model_readiness(
+    provider_id: str,
+    model: ModelLike,
+    *,
+    configured: bool,
+    cooled: bool,
+    used: int,
+) -> ModelReadiness:
+    daily_limit = model.rpd if model.rpd > 0 else None
+    remaining = max(0, daily_limit - used) if daily_limit is not None else None
+    if not configured:
+        status: ReadinessStatus = "unconfigured"
+    elif cooled:
+        status = "cooldown"
+    elif remaining == 0:
+        status = "quota_exhausted"
+    else:
+        status = "ready"
+    return ModelReadiness(
+        id=f"{provider_id}/{model.name}",
+        name=model.name,
+        ready=status == "ready",
+        status=status,
+        daily_limit=daily_limit,
+        used_today=used,
+        remaining=remaining,
+    )
+
+
+__all__ = [
+    "ModelReadiness",
+    "ProviderReadiness",
+    "ReadinessSnapshot",
+    "ReadinessStatus",
+    "readiness_snapshot",
+]

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -10,8 +10,16 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def test_list_agents():
     out = list_agents()
-    for a in ("codex", "aider", "cline", "continue", "cursor", "opencode"):
+    for a in ("codex", "aider", "cline", "continue", "cursor", "opencode", "hermes"):
         assert a in out
+
+
+def test_render_hermes_custom_endpoint():
+    out = render("hermes")
+    assert out is not None
+    assert "provider: custom" in out
+    assert "default: quality" in out
+    assert "http://localhost:8080/v1" in out
 
 
 def test_render_known():

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -67,6 +67,64 @@ def test_ci_builds_and_smoke_tests_container() -> None:
     assert "push: true" not in docker_job
 
 
+def test_ci_validates_opencode_packages_with_current_runtimes() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert workflow.count("\n  opencode-packages:\n") == 1
+    job = workflow.split("\n  opencode-packages:\n", maxsplit=1)[1].split(
+        "\n  docker-smoke:\n", maxsplit=1
+    )[0]
+    for required in (
+        "permissions:\n      contents: read",
+        "actions/setup-node@v6",
+        'node-version: "24"',
+        "oven-sh/setup-bun@v2",
+        "npm@11.5.1",
+        "node scripts/check_opencode_packages.mjs",
+    ):
+        assert required in job
+
+
+def test_ci_strictly_checks_focused_helpers_without_recursive_debt() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+    assert (
+        "mypy --follow-imports=skip src/freellmpool/routing_modes.py "
+        "src/freellmpool/catalog_validation.py src/freellmpool/_version.py "
+        "src/freellmpool/readiness.py"
+    ) in workflow
+
+
+def test_opencode_publish_workflow_is_manual_protected_and_exact_sha() -> None:
+    workflow = (
+        ROOT / ".github" / "workflows" / "publish-opencode.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "pull_request:" not in workflow
+    assert "push:" not in workflow
+    for required in (
+        "package:",
+        "version:",
+        "commit:",
+        "environment: npm",
+        "contents: read",
+        "id-token: write",
+        "runs-on: ubuntu-latest",
+        "actions/checkout@v7",
+        "actions/setup-node@v6",
+        'node-version: "24"',
+        "oven-sh/setup-bun@v2",
+        "npm@11.5.1",
+        "git rev-parse origin/main",
+        "node scripts/check_opencode_packages.mjs",
+        "secrets.NPM_TOKEN",
+        "npm publish --access public --provenance",
+        "npm view",
+    ):
+        assert required in workflow
+
+
 def test_dependabot_covers_project_supply_chains() -> None:
     config = (ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8")
 

--- a/tests/test_opencode_packages.py
+++ b/tests/test_opencode_packages.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGES = {
+    "opencode": {
+        "name": "opencode-freellmpool",
+        "entry": "freellmpool.js",
+        "files": {"freellmpool.js", "README.md", "LICENSE"},
+    },
+    "opencode-tui": {
+        "name": "opencode-freellmpool-tui",
+        "entry": "index.tsx",
+        "files": {"index.tsx", "README.md", "LICENSE"},
+    },
+}
+
+
+def _manifest(directory: str) -> dict[str, object]:
+    return json.loads(
+        (ROOT / "integrations" / directory / "package.json").read_text(encoding="utf-8")
+    )
+
+
+def test_opencode_package_manifests_are_publishable_and_explicit() -> None:
+    names: set[str] = set()
+    for directory, expected in PACKAGES.items():
+        manifest = _manifest(directory)
+        names.add(str(manifest["name"]))
+        assert manifest["name"] == expected["name"]
+        assert manifest["version"] == "0.1.0"
+        assert manifest["private"] is False
+        assert manifest["type"] == "module"
+        assert manifest["license"] == "MIT"
+        assert manifest["files"] == sorted(expected["files"])
+        assert manifest["engines"] == {"node": ">=20"}
+        assert manifest["repository"] == {
+            "type": "git",
+            "url": "git+https://github.com/0xzr/freellmpool.git",
+            "directory": f"integrations/{directory}",
+        }
+        assert manifest["homepage"] == (
+            f"https://github.com/0xzr/freellmpool/tree/main/integrations/{directory}#readme"
+        )
+        assert manifest["bugs"] == {
+            "url": "https://github.com/0xzr/freellmpool/issues"
+        }
+        assert "scripts" not in manifest
+        assert manifest["exports"]["."] == f"./{expected['entry']}"
+        assert (ROOT / "integrations" / directory / "LICENSE").is_file()
+
+    assert names == {"opencode-freellmpool", "opencode-freellmpool-tui"}
+    assert _manifest("opencode")["peerDependencies"] == {
+        "@opencode-ai/plugin": ">=1.14.0"
+    }
+    assert _manifest("opencode-tui")["exports"]["./tui"] == "./index.tsx"
+    assert _manifest("opencode-tui")["peerDependencies"] == {
+        "@opentui/solid": ">=0.4.5",
+        "solid-js": ">=1.9.12",
+    }
+
+
+def test_opencode_packages_use_the_proxy_default_and_current_command() -> None:
+    paths = [
+        ROOT / "integrations" / "opencode" / "freellmpool.js",
+        ROOT / "integrations" / "opencode" / "README.md",
+        ROOT / "integrations" / "opencode-tui" / "index.tsx",
+        ROOT / "integrations" / "opencode-tui" / "README.md",
+    ]
+    combined = "\n".join(path.read_text(encoding="utf-8") for path in paths)
+    assert "http://localhost:8080" in combined
+    assert "localhost:8765" not in combined
+    assert "freellmpool-proxy" not in combined
+    assert "freellmpool proxy" in combined
+
+
+def test_package_smoke_script_checks_tarballs_clean_installs_and_loads() -> None:
+    script = (ROOT / "scripts" / "check_opencode_packages.mjs").read_text(
+        encoding="utf-8"
+    )
+    for required in (
+        "npm pack --json",
+        "--ignore-scripts",
+        "--omit=peer",
+        "opencode-freellmpool",
+        "opencode-freellmpool-tui/tui",
+        "bun",
+        "LICENSE",
+    ):
+        assert required in script
+
+
+def test_unpublished_registry_install_is_labelled_pending_everywhere() -> None:
+    paths = [
+        ROOT / "docs" / "INTEGRATIONS.md",
+        ROOT / "docs" / "run-opencode-on-free-models.html",
+        ROOT / "integrations" / "opencode" / "README.md",
+        ROOT / "integrations" / "opencode-tui" / "README.md",
+    ]
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        assert "Registry publication status: pending" in text
+        assert "opencode-freellmpool" in text
+        assert "opencode-freellmpool-tui" in text

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -25,6 +25,7 @@ def test_builtin_profiles_cover_supported_agents():
         "claude",
         "aider",
         "continue",
+        "hermes",
     }
     assert expected.issubset(PROFILES)
     for profile in PROFILES.values():
@@ -64,6 +65,32 @@ def test_profile_install_prints_quickstart_and_snippets(capsys):
     assert "freellmpool proxy --port 8080" in out
     assert "opencode.json" in out
     assert '"freellmpool"' in out
+
+
+def test_hermes_profile_uses_supported_custom_endpoint(capsys):
+    profile = PROFILES["hermes"]
+    assert profile.client_kind == "openai"
+    assert profile.model_family == "quality"
+    assert profile.base_url == "http://localhost:8080/v1"
+    config = profile.config_snippets["~/.hermes/config.yaml"]
+    assert "provider: custom" in config
+    assert "default: quality" in config
+    assert "base_url: http://localhost:8080/v1" in config
+    assert "api_key: anything" in config
+    assert "hermes model" in profile.notes
+
+    assert main(["profile", "install", "hermes"]) == 0
+    out = capsys.readouterr().out
+    assert "~/.hermes/config.yaml" in out
+    assert "hermes model" in out
+
+
+def test_profile_doctor_hermes_dry_run(capsys):
+    assert main(["profile", "doctor", "hermes", "--dry-run"]) == 0
+    out = capsys.readouterr().out
+    assert "hermes CLI" in out
+    assert "freellmpool CLI" in out
+    assert "http://localhost:8080/v1/models" in out
 
 
 def test_unknown_profile_returns_error(capsys):
@@ -149,6 +176,37 @@ def test_profile_doctor_opencode_fake_proxy(monkeypatch, capsys):
     assert "doctor results for 'opencode'" in out
     assert "proxy /v1/models" in out
     assert "All required checks passed" in out
+
+
+def test_profile_doctor_hermes_accepts_authenticated_proxy(monkeypatch, capsys):
+    monkeypatch.setattr("freellmpool.profiles.shutil.which", lambda name: f"/fake/{name}")
+
+    class _LockedModelsHandler(_ModelsHandler):
+        def do_GET(self):  # noqa: N802
+            self.send_response(401)
+            self.end_headers()
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _LockedModelsHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        assert main(["profile", "doctor", "hermes", "--base-url", base_url]) == 0
+    finally:
+        server.shutdown()
+        server.server_close()
+    out = capsys.readouterr().out
+    assert "doctor results for 'hermes'" in out
+    assert "responded HTTP 401" in out
+    assert "All required checks passed" in out
+
+
+def test_hermes_base_url_override_preserves_v1_contract():
+    profile = profile_with_base_url(PROFILES["hermes"], "http://example.test:9000")
+    assert profile.base_url == "http://example.test:9000/v1"
+    assert [check.url() for check in profile.doctor_checks if check.kind == "url"] == [
+        "http://example.test:9000/v1/models"
+    ]
 
 
 def test_profile_with_base_url_normalizes_openai_url():

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -175,6 +175,129 @@ def test_dashboard(server):
 def test_healthz(server):
     with urllib.request.urlopen(server + "/healthz") as resp:  # noqa: S310
         assert resp.status == 200
+        assert json.load(resp) == {"status": "ok"}
+    with urllib.request.urlopen(server + "/livez/") as resp:  # noqa: S310
+        assert resp.status == 200
+        assert json.load(resp) == {"status": "ok"}
+
+
+def test_readyz_and_provider_inventory(server):
+    with urllib.request.urlopen(server + "/readyz") as resp:  # noqa: S310
+        assert resp.status == 200
+        body = json.load(resp)
+    assert body["schema_version"] == 1
+    assert body["status"] == "ready"
+    assert body["reason"] == "ready_providers_available"
+    assert body["ready_providers"] == 4
+    assert body["total_providers"] == 4
+
+    with urllib.request.urlopen(server + "/v1/providers/") as resp:  # noqa: S310
+        providers = json.load(resp)
+    assert providers["schema_version"] == 1
+    assert providers["object"] == "list"
+    alpha = next(item for item in providers["data"] if item["id"] == "alpha")
+    assert set(alpha) == {
+        "id",
+        "configured",
+        "ready",
+        "status",
+        "enabled_models",
+        "ready_models",
+        "cooldown_remaining_s",
+        "models",
+    }
+    assert set(alpha["models"][0]) == {
+        "id",
+        "name",
+        "ready",
+        "status",
+        "daily_limit",
+        "used_today",
+        "remaining",
+    }
+    assert "ALPHA_KEY" not in json.dumps(providers)
+    assert "https://alpha.test" not in json.dumps(providers)
+
+
+@pytest.mark.parametrize("value", ["wat", "", "true&ready=false"])
+def test_models_ready_query_rejects_invalid_or_repeated_values(server, value):
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        urllib.request.urlopen(server + f"/v1/models?ready={value}")  # noqa: S310
+    assert exc.value.code == 400
+    assert json.load(exc.value)["error"]["type"] == "invalid_request_error"
+
+
+def test_models_ready_filter_preserves_content_negotiation(providers, env, quota):
+    pool = Pool(providers, quota=quota, env=env, post=make_post({}))
+    pool._mark_cooldown("alpha", pool._clock())
+    pool._mark_cooldown("beta", pool._clock())
+    pool._mark_cooldown("gee", pool._clock())
+    httpd, base = _serve(pool)
+    try:
+        with urllib.request.urlopen(base + "/v1/models?ready=1") as resp:  # noqa: S310
+            openai_body = json.load(resp)
+        ids = {item["id"] for item in openai_body["data"]}
+        assert "auto" in ids
+        assert "free/free-1" in ids
+        assert not any(item.startswith("alpha/") for item in ids)
+
+        req = urllib.request.Request(
+            base + "/v1/models/?ready=true",
+            headers={"anthropic-version": "2023-06-01"},
+        )
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            anthropic_body = json.load(resp)
+        assert anthropic_body["data"][0]["type"] == "model"
+        anthropic_ids = {item["id"] for item in anthropic_body["data"]}
+        assert anthropic_ids == ids
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def test_readyz_503_is_public_and_does_not_call_or_mutate(providers, quota):
+    def fail_post(*_args, **_kwargs):
+        raise AssertionError("readiness must not call upstream")
+
+    pool = Pool(providers[:1], quota=quota, env={}, post=fail_post)
+    before_quota = quota.snapshot()
+    before_cooldown = pool.cooldown_snapshot(pool._clock())
+    httpd, base = _serve(pool, api_key="secret")
+    try:
+        for path in ("/healthz", "/livez", "/readyz"):
+            try:
+                response = urllib.request.urlopen(base + path)  # noqa: S310
+            except urllib.error.HTTPError as exc:
+                response = exc
+            with response:
+                body = json.load(response)
+            if path == "/readyz":
+                assert response.status == 503
+                assert body["status"] == "not_ready"
+                assert body["reason"] == "no_ready_providers"
+            else:
+                assert response.status == 200
+
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            urllib.request.urlopen(base + "/v1/providers")  # noqa: S310
+        assert exc.value.code == 401
+        req = urllib.request.Request(
+            base + "/v1/providers",
+            headers={"x-api-key": "secret"},
+        )
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            assert json.load(resp)["data"][0]["status"] == "unconfigured"
+        req = urllib.request.Request(
+            base + "/v1/models?ready=true",
+            headers={"Authorization": "Bearer secret"},
+        )
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            assert json.load(resp) == {"object": "list", "data": []}
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+    assert quota.snapshot() == before_quota
+    assert pool.cooldown_snapshot(pool._clock()) == before_cooldown
 
 
 def test_tokenmax_route(server):

--- a/tests/test_readiness.py
+++ b/tests/test_readiness.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+from freellmpool.models import Model, Provider
+from freellmpool.readiness import readiness_snapshot
+
+
+def _provider(
+    *,
+    provider_id: str = "alpha",
+    key_env: str | None = "ALPHA_KEY",
+    auth: str = "bearer",
+    models: tuple[Model, ...] = (Model("small", rpd=2),),
+) -> Provider:
+    return Provider(
+        id=provider_id,
+        label=provider_id.title(),
+        adapter="openai",
+        base_url=f"https://{provider_id}.test/v1",
+        key_env=key_env,
+        auth=auth,
+        models=models,
+    )
+
+
+def test_readiness_snapshot_ready_schema_and_unknown_quota() -> None:
+    limited = _provider()
+    unmetered = _provider(
+        provider_id="free",
+        key_env=None,
+        auth="none",
+        models=(Model("unknown", rpd=0),),
+    )
+
+    snapshot = readiness_snapshot(
+        [limited, unmetered],
+        env={"ALPHA_KEY": "secret"},
+        quota={"alpha::small": 1},
+        cooldowns={},
+    )
+
+    assert snapshot.ready_providers == 2
+    assert snapshot.total_providers == 2
+    assert snapshot.summary == {
+        "ready": 2,
+        "unconfigured": 0,
+        "no_enabled_models": 0,
+        "cooldown": 0,
+        "quota_exhausted": 0,
+    }
+    payload = snapshot.provider_payload()
+    assert payload["schema_version"] == 1
+    assert payload["object"] == "list"
+    assert payload["data"] == [
+        {
+            "id": "alpha",
+            "configured": True,
+            "ready": True,
+            "status": "ready",
+            "enabled_models": 1,
+            "ready_models": 1,
+            "cooldown_remaining_s": 0.0,
+            "models": [
+                {
+                    "id": "alpha/small",
+                    "name": "small",
+                    "ready": True,
+                    "status": "ready",
+                    "daily_limit": 2,
+                    "used_today": 1,
+                    "remaining": 1,
+                }
+            ],
+        },
+        {
+            "id": "free",
+            "configured": True,
+            "ready": True,
+            "status": "ready",
+            "enabled_models": 1,
+            "ready_models": 1,
+            "cooldown_remaining_s": 0.0,
+            "models": [
+                {
+                    "id": "free/unknown",
+                    "name": "unknown",
+                    "ready": True,
+                    "status": "ready",
+                    "daily_limit": None,
+                    "used_today": 0,
+                    "remaining": None,
+                }
+            ],
+        },
+    ]
+    assert snapshot.ready_model_ids == ("alpha/small", "free/unknown")
+
+
+def test_readiness_status_precedence_and_disabled_models() -> None:
+    unconfigured_empty = _provider(models=())
+    no_models = _provider(
+        provider_id="empty",
+        key_env=None,
+        auth="none",
+        models=(Model("off", enabled=False),),
+    )
+    cooled_exhausted = _provider(provider_id="cooled", key_env="COOLED_KEY")
+    exhausted = _provider(provider_id="spent", key_env="SPENT_KEY")
+
+    snapshot = readiness_snapshot(
+        [unconfigured_empty, no_models, cooled_exhausted, exhausted],
+        env={"COOLED_KEY": "c", "SPENT_KEY": "s"},
+        quota={"cooled::small": 2, "spent::small": 2},
+        cooldowns={"cooled": 12.345},
+    )
+
+    assert [provider.status for provider in snapshot.providers] == [
+        "unconfigured",
+        "no_enabled_models",
+        "cooldown",
+        "quota_exhausted",
+    ]
+    assert snapshot.ready_providers == 0
+    assert snapshot.ready_model_ids == ()
+    assert snapshot.providers[2].cooldown_remaining_s == 12.345
+    assert snapshot.readiness_payload() == {
+        "schema_version": 1,
+        "status": "not_ready",
+        "reason": "no_ready_providers",
+        "ready_providers": 0,
+        "total_providers": 4,
+        "summary": {
+            "ready": 0,
+            "unconfigured": 1,
+            "no_enabled_models": 1,
+            "cooldown": 1,
+            "quota_exhausted": 1,
+        },
+    }
+
+
+def test_readiness_model_statuses_follow_provider_precedence() -> None:
+    provider = _provider(models=(Model("spent", rpd=1), Model("open", rpd=3)))
+
+    exhausted = readiness_snapshot(
+        [provider],
+        env={"ALPHA_KEY": "a"},
+        quota={"alpha::spent": 1, "alpha::open": 3},
+        cooldowns={},
+    ).providers[0]
+    assert [model.status for model in exhausted.models] == [
+        "quota_exhausted",
+        "quota_exhausted",
+    ]
+
+    cooled = readiness_snapshot(
+        [provider],
+        env={"ALPHA_KEY": "a"},
+        quota={"alpha::spent": 1},
+        cooldowns={"alpha": 1.0},
+    ).providers[0]
+    assert [model.status for model in cooled.models] == ["cooldown", "cooldown"]
+
+    mixed = readiness_snapshot(
+        [provider],
+        env={"ALPHA_KEY": "a"},
+        quota={"alpha::spent": 1},
+        cooldowns={},
+    ).providers[0]
+    assert mixed.status == "ready"
+    assert [model.status for model in mixed.models] == ["quota_exhausted", "ready"]
+    assert mixed.ready_models == 1

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -57,6 +57,35 @@ def test_readme_has_copy_pastable_tailnet_and_metaswarm_paths() -> None:
     assert "freellmpool profile doctor metaswarm --dry-run" in readme
 
 
+def test_readme_has_current_adoption_paths_and_pinned_comparison_sources() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    integrations = (ROOT / "docs" / "INTEGRATIONS.md").read_text(encoding="utf-8")
+
+    assert 'uvx freellmpool ask --max-tokens 32' in readme
+    assert "Comparison snapshot: 2026-07-19" in readme
+    assert (
+        "tashfeenahmed/freellmapi/blob/"
+        "759de8e7ed1edc1cd513c9777cd0a807fb5ceee3/README.md"
+    ) in readme
+    assert (
+        "diegosouzapw/OmniRoute/blob/"
+        "d8ff51874c8add566d43225988b9bc67e0542d65/README.md"
+    ) in readme
+    assert "28 free LLM providers" in readme
+    assert "MCP (Streamable HTTP)" in readme
+    assert "OmniRoute" in readme
+
+    for text in (readme, integrations):
+        assert "freellmpool profile install hermes" in text
+        assert "provider: custom" in text
+        assert "default: quality" in text
+        assert "http://localhost:8080/v1" in text
+        assert "/livez" in text
+        assert "/readyz" in text
+        assert "/v1/providers" in text
+        assert "/v1/models?ready=true" in text
+
+
 def test_roadmap_reflects_kimi_m3_addendum() -> None:
     roadmap = (ROOT / "docs/ROADMAP.md").read_text(encoding="utf-8")
     assert "Top 10 feature map" in roadmap


### PR DESCRIPTION
## Summary

- add a reviewed adoption-sprint plan with completion, rollout, security, and rollback gates
- add public liveness/readiness endpoints, authenticated provider inventory, and ready-model filtering
- add a print-only Hermes integration profile and doctor checks
- harden both OpenCode packages for npm, add clean tarball/runtime smoke tests, and add a protected manual publication workflow
- update quickstart, integration, OpenCode, and dated competitor-positioning documentation

## Validation

- `745 passed`
- coverage: `85.22%` lines, `72.75%` branches
- Ruff: passed
- focused strict mypy: passed with mypy 2.1.0
- provider/model count check: 22 providers, 239 enabled routes, 397 cataloged models
- release metadata check: passed for 0.11.4
- OpenCode package clean-install/load smoke: passed with npm 11.5.1 and Bun 1.3.14
- both `npm publish --dry-run` checks: passed, exactly four intended files per package
- independent adversarial review: passed with no release-blocking findings

## Rollout note

The package names are available, but npm authentication is not present in this environment. Documentation therefore keeps local-path installation as the primary supported flow and labels the registry packages as pending. After a protected bootstrap publication and registry verification, the plan calls for a separate docs-only PR to make npm installation primary.

## Summary by Sourcery

Introduce advisory readiness and provider inventory APIs, a Hermes Agent integration profile, and hardened OpenCode plugin packages, alongside refreshed docs and CI to support smoother agent and deployment adoption.

New Features:
- Expose public liveness/readiness endpoints plus an authenticated provider readiness inventory and ready-only model listing.
- Add a Hermes Agent custom-endpoint profile and CLI helpers for print-only configuration and doctor checks.
- Provide npm-ready OpenCode server and TUI packages for freellmpool with explicit metadata and compatibility contracts.

Enhancements:
- Align OpenCode integration defaults with the proxy’s actual port and improve comparative positioning docs with dated, source-pinned claims.
- Add a typed readiness helper module and stricter mypy coverage for operational readiness logic.

CI:
- Introduce a dedicated CI job to pack, clean-install, and load-test the OpenCode npm packages, and a protected manual workflow for publishing them via trusted npm provenance.

Documentation:
- Update quickstart, integrations, agent setup, OpenCode, and comparison documentation to describe the new readiness APIs, Hermes integration, OpenCode distribution status, and adoption paths.

Tests:
- Extend proxy, profile, agent, release-metadata, CI-config, readiness, and package smoke tests to cover the new endpoints, profiles, docs, and npm validation flows.