### PR TITLE
docs: record adoption sprint completion

### DIFF
--- a/docs/ADOPTION_SPRINT_PLAN.md
+++ b/docs/ADOPTION_SPRINT_PLAN.md
@@ -1,6 +1,7 @@
 # Adoption Sprint Plan
 
-Status: implementation complete; merge and npm distribution rollout pending
+Status: implementation merged; npm distribution rollout blocked on registry authentication
+Implementation merge: PR #74 (`3ef19305450b02b7277e9a605d8c89352b5ec445`)
 Owner: freellmpool maintainers
 Planned execution: 2026-07-19
 Branch: `codex/adoption-sprint-20260719`


### PR DESCRIPTION
## Summary

- record the merged implementation PR and exact squash SHA in the formal sprint plan
- mark the remaining npm distribution rollout as blocked on registry authentication
- trigger a fresh Pages deployment after GitHub's initial 503 and artifact-duplicating rerun

## Validation

- `PYTHONPATH=src pytest -q tests/test_release_metadata.py tests/test_faq.py`
- `git diff --check`
- independently verified PR #74 and npm registry/auth state
- independent review: passed

## Summary by Sourcery

Documentation:
- Record the merged implementation PR and squash commit SHA in the adoption sprint plan and note that npm distribution rollout is blocked on registry authentication.