### PR TITLE
docs: reconcile release and main status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ All notable changes to this project are documented here. The format is based on
   degraded, or repeat-timeout Ollama, GitHub, and NVIDIA routes.
 
 ### Fixed
+- Public README, integration, agent, and Pages documentation now distinguishes
+  released 0.11.4 from post-tag changes on `main`; the jailed OpenCode launcher
+  also uses the proxy's actual port 8080 default.
 - The catalog vetter now filters paid Kilo/OpenRouter/OpenCode discovery rows,
   requires non-empty completion text, gives reasoning models enough output
   budget to answer, and classifies 410/retirement responses correctly.

--- a/README.es.md
+++ b/README.es.md
@@ -21,6 +21,24 @@ claves de API cuando hay un proveedor sin clave disponible.
 [FAQ](FAQ.md): a dónde van los prompts, postura de ToS, failover, bloqueos y
 comparaciones.
 
+## Estado de versión y distribución
+
+- **Última versión: 0.11.4.** La versión de GitHub y el paquete de PyPI son
+  0.11.4; incluyen el enrutamiento `spread`.
+- **main contiene cambios aún no publicados**, entre ellos el perfil de
+  Hermes, las APIs operativas `/livez`, `/readyz`, `/v1/providers` y
+  `/v1/models?ready=true`, el catálogo actualizado y la preparación para
+  publicar los plugins de OpenCode que ya existen en 0.11.4. Para probar esos
+  cambios antes de la próxima versión, reemplaza el paquete en tu entorno:
+
+  ```bash
+  python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'
+  ```
+
+- **Estado de publicación en npm: pendiente.** `opencode-freellmpool` y
+  `opencode-freellmpool-tui` están probados, pero no publicados en npm al
+  2026-07-19. Por ahora usa las instrucciones de instalación local del repo.
+
 ## Inicio rápido en 30 segundos
 
 Una instalación nueva hasta la primera respuesta de un modelo gratuito toma unos
@@ -60,7 +78,8 @@ código: basta con apuntarlos al proxy.
 ```bash
 freellmpool proxy                       # starts http://localhost:8080
 freellmpool code claude                 # prints the one-line setup for Claude Code
-# (also: codex, aider, cline, continue, cursor, opencode)
+freellmpool profile install hermes       # solo en main; imprime la configuración
+# (also: codex, aider, cline, continue, cursor, hermes, opencode)
 ```
 
 El modo gateway de Claude Code también puede lanzarse directamente:
@@ -80,7 +99,7 @@ Tus aplicaciones OpenAI/Anthropic existentes funcionan igual: define
 **OpenCode** tiene una integración más profunda: un **dashboard** en vivo dentro
 del editor (modo de enrutamiento, $ ahorrados, tokens servidos gratis, carrera
 de proveedores, latencia), **enrutamiento por calidad** por solicitud desde el
-selector de modelos (`freellmpool/auto|fast|quality|fair`) y herramientas
+selector de modelos (`freellmpool/spread|auto|fast|quality|fair`) y herramientas
 `freellmpool_status` / `freellmpool_models`. Consulta
 [integrations/opencode-tui](integrations/opencode-tui) y la
 [guía](https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html).

--- a/README.md
+++ b/README.md
@@ -17,6 +17,25 @@ proxy. Can start without API keys when a keyless provider is up.
 
 [FAQ](FAQ.md): where prompts go, ToS posture, failover, bans, and comparisons.
 
+## Release and distribution status
+
+- **Latest release: 0.11.4.** The GitHub release and PyPI package are both
+  0.11.4; `pip install freellmpool` and `uvx freellmpool` install that released
+  artifact. It includes `spread` routing.
+- **Current main includes unreleased changes**, including the Hermes profile,
+  proxy readiness/provider APIs, refreshed provider catalog, and
+  registry-readiness hardening for the existing repository-local OpenCode
+  plugins. To exercise those before the next release, replace the released
+  package in your environment with current `main`:
+
+  ```bash
+  python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'
+  ```
+
+- **Registry publication status: pending.** `opencode-freellmpool` and
+  `opencode-freellmpool-tui` are tested but not published on npm as of
+  2026-07-19. Use their repository-local installation instructions for now.
+
 ## 30-second quickstart
 
 Fresh install to first free-model reply is measured at about 19 seconds under
@@ -118,7 +137,7 @@ freellmpool proxy                       # starts http://localhost:8080
 freellmpool code claude                 # prints the one-line setup for Claude Code
 freellmpool profile list                # richer installable profiles
 freellmpool profile show metaswarm      # Tailnet-aware Metaswarm profile
-freellmpool profile install hermes       # Hermes custom-endpoint config
+freellmpool profile install hermes       # Hermes config (current main; unreleased)
 # (also: codex, aider, cline, continue, cursor, hermes, opencode, metaswarm)
 ```
 
@@ -150,14 +169,13 @@ Existing OpenAI-compatible apps work the same way: set
 Anthropic-compatible tools can use the experimental bridge with
 `ANTHROPIC_BASE_URL=http://localhost:8080`.
 
-**OpenCode** gets a deeper integration: a live in-editor **dashboard** (routing mode,
+**OpenCode** gets a deeper integration on current `main`: a live in-editor **dashboard** (routing mode,
 estimated savings, tokens served free, provider race, latency), per-request
-**quality routing** via the model picker (`freellmpool/auto|fast|quality|fair`), and `freellmpool_status`
+**quality routing** via the model picker (`freellmpool/spread|auto|fast|quality|fair`), and `freellmpool_status`
 / `freellmpool_models` tools — see [integrations/opencode-tui](integrations/opencode-tui)
 and the [guide](https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html).
-The `opencode-freellmpool` and `opencode-freellmpool-tui` npm tarballs are
-validated in CI; registry publication is still pending, so the linked local-file
-instructions remain the working install path.
+The package tarballs are validated in CI, but npm publication remains pending;
+the linked local-file instructions remain the working install path.
 
 **New in 0.11:** capacity tools — `freellmpool capacity status` shows which free
 tiers are usable right now, `freellmpool providers health` live-probes them, and
@@ -267,7 +285,7 @@ freellmpool profile show opencode
 freellmpool profile doctor opencode --dry-run
 ```
 
-Main proxy surfaces:
+Current `main` proxy surfaces (the readiness/provider additions are unreleased):
 
 - `/v1/chat/completions` — OpenAI-compatible chat, token streaming, tool calling.
 - `/v1/responses` — minimal Responses API shim for Codex-style agents.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -5,6 +5,24 @@ Most agent frameworks and coding agents speak the **OpenAI API**. Because
 and they'll run on pooled free-tier inference — with failover when one provider
 rate-limits you mid-run (exactly when long agent loops tend to die).
 
+## Release status
+
+- **Latest release: 0.11.4.** GitHub and PyPI both provide 0.11.4, including
+  `freellmpool/spread` routing.
+- **Current main includes unreleased changes**: the Hermes profile, public
+  `/livez` and `/readyz`, authenticated `/v1/providers`,
+  `/v1/models?ready=true`, and registry-readiness hardening for the existing
+  repository-local OpenCode plugins. Replace the released package in your agent
+  environment to test that source:
+
+  ```bash
+  python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'
+  ```
+
+- **Registry publication status: pending.** `opencode-freellmpool` and
+  `opencode-freellmpool-tui` were not published on npm as of 2026-07-19; use
+  their local-file install paths.
+
 Start the gateway once:
 
 ```bash
@@ -14,6 +32,11 @@ export OPENAI_API_KEY=anything   # ignored by freellmpool
 ```
 
 Then wire up your tool of choice.
+
+On current `main`, orchestrators can use `/livez` for liveness, `/readyz` for an
+advisory local quota/cooldown snapshot, authenticated `/v1/providers` for
+secret-free provider readiness, and `/v1/models?ready=true` for ready targets.
+These endpoints do not probe upstream providers.
 
 For structured setup, use profiles:
 
@@ -74,6 +97,21 @@ codex --config model_provider=openai   # or set base URL in ~/.codex/config.toml
 > The Responses shim is minimal (text in/out, streaming events). It's great for
 > running Codex/agents on free inference for everyday coding; tool-calling and
 > richer Responses features are a work in progress.
+
+## Hermes Agent (current main; unreleased)
+
+Hermes supports an OpenAI-compatible custom endpoint. The first-class profile
+prints the supported config and never edits `~/.hermes/config.yaml`:
+
+```bash
+freellmpool profile install hermes
+freellmpool profile doctor hermes --dry-run
+# Interactive equivalent: hermes model → Custom endpoint → http://localhost:8080/v1
+```
+
+Use model alias `quality` in Hermes. For long OpenCode or other OpenAI-compatible
+agent loops, start with `freellmpool/spread` to rotate across the least-used
+provider tier before using latency/health as a tie-break.
 
 ## Metaswarm external-tools review
 

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -15,6 +15,20 @@ Because freellmpool **aliases common model names** (`gpt-4o-mini`, `gpt-4o`,
 `claude-3-5-sonnet`, …) to free models, most tools work with their *default*
 model setting untouched — just set the base URL and any API key.
 
+## Release status
+
+The latest GitHub and PyPI release is 0.11.4. Current `main` includes unreleased
+changes documented below: the Hermes profile, the readiness/provider operations
+APIs, and registry-readiness hardening for the existing repository-local
+OpenCode plugins. To test those additions before the next release, replace the
+released package in your integration environment with `main`:
+
+```bash
+python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'
+```
+
+Released 0.11.4 already includes `spread` routing.
+
 ---
 
 ## Coding agents & editors
@@ -63,7 +77,7 @@ Anthropic bridge, `/v1/models` for concrete `provider/model` ids, `/dashboard`
 for operations, `/playground` for browser-side battle runs, and
 `/freellmpool/battle` for JSON/Markdown comparison results.
 
-For automation, `/healthz` and `/livez` are public liveness aliases;
+On current `main`, automation can use `/healthz` and `/livez` as public liveness aliases;
 `/readyz` is a public advisory local-capacity probe (200 or 503), and
 `/v1/providers` is the authenticated secret-free inventory. Use
 `/v1/models?ready=true` to keep the normal OpenAI/Anthropic model-list shape
@@ -80,14 +94,16 @@ snapshots and never live-probe an upstream provider.
     "freellmpool": {
       "npm": "@ai-sdk/openai-compatible",
       "options": { "baseURL": "http://localhost:8080/v1" },
-      "models": { "auto": {}, "fast": {}, "quality": {}, "fair": {} }
+      "models": { "spread": {}, "auto": {}, "fast": {}, "quality": {}, "fair": {} }
     }
   }
 }
 ```
-Pick `freellmpool/auto|fast|quality|fair` in the model picker to control routing
-(`quality` = capability-matched + latency-aware; `fast` = lowest latency; `fair` =
-spread quota). Full guide: <https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html>.
+Pick `freellmpool/spread|auto|fast|quality|fair` in the model picker to control
+routing (`spread` = least-used tier first with a latency/health tie-break;
+`quality` = capability-matched + latency-aware; `fast` = lowest latency; `fair`
+= spread quota without the latency tie-break). Full guide:
+<https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html>.
 
 **Embedded dashboard + tools (optional).** Two OpenCode plugins live in the repo:
 - [`integrations/opencode-tui`](../integrations/opencode-tui) — a live in-editor TUI
@@ -98,8 +114,9 @@ spread quota). Full guide: <https://0xzr.github.io/freellmpool/run-opencode-on-f
 
 **Registry publication status: pending.** The intended package names are
 `opencode-freellmpool` and `opencode-freellmpool-tui`; CI packs, clean-installs,
-and loads both, but do not use an npm install command until the registry versions
-are verified. The local-file commands above are the current working path.
+and loads both, but neither name is published on npm as of 2026-07-19. Do not use
+an npm install command until the registry versions are verified. The local-file
+commands above are the current working path.
 
 ### metaswarm
 [`integrations/metaswarm`](../integrations/metaswarm) contains an experimental
@@ -135,6 +152,7 @@ escalation/final-review tools.
 
 ### Hermes Agent
 
+The Hermes profile is on current `main` and is not part of released 0.11.4.
 Hermes supports OpenAI-compatible custom endpoints. Start the proxy, then either
 run `hermes model` and choose **Custom endpoint**, or inspect the print-only
 profile:

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,6 +29,7 @@
  th,td{padding:9px 12px;text-align:left;border-bottom:1px solid var(--bd)}
  th{color:var(--mut);font-weight:600}
  .badges a{margin-right:6px}
+ .note{background:var(--card);border:1px solid var(--bd);border-left:3px solid var(--ac);border-radius:6px;padding:10px 14px;font-size:14px;margin:14px 0}
  .faq h3{color:#cdd6e4}
  .meta{color:var(--mut);font-size:13px;margin-top:34px;border-top:1px solid var(--bd);padding-top:14px}
  ul{padding-left:20px}
@@ -62,6 +63,16 @@ freellmpool ask "Explain the CAP theorem in one sentence."   # keyless when rout
 MIT license
 </p>
 
+<div class="note"><strong>Release status.</strong> Latest release: 0.11.4, available from both
+GitHub and PyPI. <strong>Current main includes unreleased changes</strong>, including the Hermes profile,
+the readiness/provider operations APIs, refreshed catalog data, and registry-readiness hardening for
+the existing repository-local OpenCode plugins.
+Released 0.11.4 already includes <code>spread</code> routing. To test the main-only additions explicitly:
+<pre><code>python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'</code></pre>
+<strong>Registry publication status: pending.</strong> <code>opencode-freellmpool</code> and
+<code>opencode-freellmpool-tui</code> are CI-tested but were not published on npm as of 2026-07-19;
+use their repository-local installation paths.</div>
+
 <h2>How it compares</h2>
 <table>
 <tr><th>Tool</th><th>What it is</th><th>Install</th><th>Keyless start</th><th>CLI / library / proxy / MCP</th></tr>
@@ -77,7 +88,9 @@ tiers — not a server you deploy and not a paid aggregator.</p>
 <ul>
 <li><strong>Use free LLMs from the command line:</strong> <code>freellmpool ask "..."</code>, pipe stdin, pin a provider/model.</li>
 <li><strong>OpenAI-compatible proxy:</strong> point <code>OPENAI_BASE_URL</code> at <code>freellmpool proxy</code> for most text, embedding, and transcription calls.</li>
-<li><strong>Run coding agents for free:</strong> <code>freellmpool code claude</code> (also codex, aider, cline, continue, cursor, opencode) routes them to pooled free models — see the <a href="run-coding-agents-on-free-models.html">step-by-step guide</a>.</li>
+<li><strong>Run coding agents for free:</strong> <code>freellmpool code claude</code> (also codex, aider, cline, continue, cursor, Hermes, and OpenCode) routes them to pooled free models — see the <a href="run-coding-agents-on-free-models.html">step-by-step guide</a>. The Hermes profile is currently main-only.</li>
+<li><strong>Automate proxy operations:</strong> current <code>main</code> adds public <code>/livez</code> and <code>/readyz</code> probes, authenticated <code>/v1/providers</code>, and <code>/v1/models?ready=true</code> for locally ready targets.</li>
+<li><strong>Use OpenCode deeply:</strong> choose <code>freellmpool/spread</code> for quota-aware agent loops and add the repository-local dashboard/tools plugins while npm publication is pending.</li>
 <li><strong>Add model-pool review to metaswarm:</strong> use the experimental <a href="https://github.com/0xzr/freellmpool/tree/main/integrations/metaswarm">metaswarm adapter</a> as a review-only external tool.</li>
 <li><strong>Async + library:</strong> <code>from freellmpool import Pool, AsyncPool</code>.</li>
 <li><strong>MCP server:</strong> <code>freellmpool mcp</code> lets Claude Desktop/Code/Cursor offload subtasks to free models.</li>
@@ -168,7 +181,7 @@ for provider routing, ToS, and privacy notes.</p>
 
 </div>
 
-<p class="meta">Free and open source (MIT). Latest release: 0.11.4. Page updated 2026-07-17.
+<p class="meta">Free and open source (MIT). Latest release: 0.11.4. Page updated 2026-07-19.
 Project: <a href="https://github.com/0xzr/freellmpool">github.com/0xzr/freellmpool</a></p>
 
 </div>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -9,13 +9,21 @@
 > Capacity tools (`freellmpool capacity status`, `providers health`, `keys add`) show which
 > free tiers are usable right now and help configure more.
 
+## Release status
+- Latest GitHub and PyPI release: 0.11.4. Released 0.11.4 includes `spread` routing.
+- Current main includes unreleased changes: the Hermes profile, `/livez`, `/readyz`,
+  `/v1/providers`, `/v1/models?ready=true`, refreshed catalog data, and registry-readiness hardening for the existing repository-local OpenCode plugins. Persistent source install:
+  `python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'`.
+- OpenCode npm registry publication is pending; `opencode-freellmpool` and
+  `opencode-freellmpool-tui` were not published as of 2026-07-19.
+
 ## Docs
 - [README](https://github.com/0xzr/freellmpool/blob/main/README.md): install, CLI, library, proxy, MCP, provider keys, routing.
 - [Landing page / FAQ](https://0xzr.github.io/freellmpool/): what it is, how it compares, frequently asked questions.
 - [Capacity & provider health](https://github.com/0xzr/freellmpool/blob/main/docs/CAPACITY.md): capacity status, health checks, key inventory, external catalog. Guide: https://0xzr.github.io/freellmpool/capacity-management.html
 - [CHANGELOG](https://github.com/0xzr/freellmpool/blob/main/CHANGELOG.md): release history.
-- [Integrations](https://github.com/0xzr/freellmpool/blob/main/docs/INTEGRATIONS.md): opencode, metaswarm review adapter, aider, Continue, Cline, Cursor, Open WebUI, LangChain, LlamaIndex, and more.
-- [Run OpenCode on free models](https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html): OpenCode setup with an embedded TUI dashboard, quality routing (auto/fast/quality/fair), and usage tools.
+- [Integrations](https://github.com/0xzr/freellmpool/blob/main/docs/INTEGRATIONS.md): OpenCode, Hermes, metaswarm review adapter, aider, Continue, Cline, Cursor, Open WebUI, LangChain, LlamaIndex, and more.
+- [Run OpenCode on free models](https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html): OpenCode setup with an embedded TUI dashboard, quality routing (spread/auto/fast/quality/fair), and usage tools.
 - [MCP server](https://github.com/0xzr/freellmpool/blob/main/docs/MCP.md): use free models from Claude Desktop/Code/Cursor.
 
 ## Install

--- a/docs/run-coding-agents-on-free-models.html
+++ b/docs/run-coding-agents-on-free-models.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>How to run Claude Code, Codex, or Aider on free LLM models (no API bill)</title>
-<meta name="description" content="A step-by-step guide to running Claude Code, OpenAI Codex, Aider, Cline, and Cursor on free LLM tiers using freellmpool — a local OpenAI-compatible proxy with an experimental Anthropic-compatible path that pools 22 free providers. Keyless start when routes are available.">
+<title>How to run Claude Code, Codex, Hermes, or Aider on free LLM models</title>
+<meta name="description" content="A step-by-step guide to running Claude Code, OpenAI Codex, Hermes, Aider, Cline, and Cursor on free LLM tiers using freellmpool — a local OpenAI-compatible proxy with an experimental Anthropic-compatible path that pools 22 free providers. Keyless start when routes are available.">
 <link rel="canonical" href="https://0xzr.github.io/freellmpool/run-coding-agents-on-free-models.html">
 <meta property="og:title" content="Run Claude Code, Codex, or Aider on free LLM models">
 <meta property="og:description" content="Point your coding agent at one local proxy and run it on pooled free LLM tiers — keyless start when routes are available.">
@@ -36,17 +36,27 @@
 <div class="wrap">
 
 <p class="tag"><a href="https://0xzr.github.io/freellmpool/">freellmpool</a> › guide</p>
-<h1>How to run Claude Code, Codex, or Aider on free LLM models</h1>
+<h1>How to run Claude Code, Codex, Hermes, or Aider on free LLM models</h1>
 
-<p class="lead"><strong>You can run Claude Code, OpenAI Codex, Aider, Cline, Continue, or Cursor on
+<p class="lead"><strong>You can run Claude Code, OpenAI Codex, Hermes, Aider, Cline, Continue, or Cursor on
 free LLM tiers by pointing them at a local proxy that speaks the OpenAI API and has an experimental Anthropic-compatible path. The
 open-source tool <a href="https://github.com/0xzr/freellmpool">freellmpool</a> is that proxy: it pools
 the free tiers of 22 providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Mistral, Cohere
 and more) behind one endpoint, with automatic failover. Several providers need no API key, so you can
 start for free in under a minute and change no code in the agent.</strong></p>
 
-<h2>1. Install and start the proxy</h2>
-<pre><code>pip install freellmpool
+<div class="note"><strong>Release status:</strong> GitHub and PyPI both provide 0.11.4.
+Released 0.11.4 includes <code>spread</code> routing. The Hermes profile and the operational endpoints
+below are newer, unreleased additions on current <code>main</code>. Replace the released package in
+your agent environment to use them:
+<pre><code>python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'</code></pre></div>
+
+<h2>1. Choose a release or current-main install, then start the proxy</h2>
+<pre><code># Released 0.11.4:
+python -m pip install freellmpool
+# Or replace it with current main for Hermes and the operational endpoints:
+python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'
+
 freellmpool proxy            # serves http://localhost:8080</code></pre>
 <p>That's all the setup. The proxy now accepts both OpenAI (<code>/v1/chat/completions</code>) and
 Anthropic (<code>/v1/messages</code>) requests and routes each to a free provider, failing over when one
@@ -71,6 +81,13 @@ codex</code></pre>
 export OPENAI_API_KEY=anything
 aider --model gpt-4o-mini      # alias resolves to a free model</code></pre>
 
+<h3>Hermes Agent (current main; unreleased)</h3>
+<p>Hermes supports a custom OpenAI-compatible endpoint. The print-only profile
+shows the supported config without editing <code>~/.hermes/config.yaml</code>:</p>
+<pre><code>freellmpool profile install hermes
+freellmpool profile doctor hermes --dry-run
+# Or run: hermes model → Custom endpoint → http://localhost:8080/v1</code></pre>
+
 <p class="tag">Cline, Continue, and Cursor work the same way — set the OpenAI base URL to the proxy.
 Run <code>freellmpool code &lt;agent&gt;</code> for the exact per-agent setup.</p>
 
@@ -78,7 +95,14 @@ Run <code>freellmpool code &lt;agent&gt;</code> for the exact per-agent setup.</
 refactors, tests, commit messages, and everyday edits — not a substitute for a frontier model on the
 hardest reasoning. Limits reset at UTC midnight.</div>
 
-<h2>3. (Optional) add free keys for more capacity</h2>
+<h2>3. Operational checks for agents and orchestrators (current main)</h2>
+<p>The current-main proxy exposes public <code>/livez</code> liveness and advisory
+<code>/readyz</code> readiness. Authenticated automation can inspect the secret-free
+<code>/v1/providers</code> inventory or request only locally ready models with
+<code>/v1/models?ready=true</code>. Readiness is a local quota/cooldown snapshot; it does not
+probe upstream providers.</p>
+
+<h2>4. (Optional) add free keys for more capacity</h2>
 <p>The keyless providers get you started; adding free API keys for Groq, Cerebras, Gemini and others
 unlocks more models and higher daily limits. Each provider's free signup is listed in the
 <a href="https://github.com/0xzr/freellmpool/blob/main/docs/ACCOUNTS.md">accounts guide</a>. freellmpool
@@ -94,13 +118,14 @@ bounded by the free-tier models, and there's no vision support yet.</p>
 those tools officially support for custom base URLs and local models. You're using the LLM providers'
 own free tiers; don't abuse them.</p>
 <h3>Which coding agents are supported?</h3>
-<p>Any tool that lets you set an OpenAI or Anthropic base URL: Claude Code, OpenAI Codex CLI, Aider,
-Cline, Continue, Cursor, OpenCode, and more.</p>
+<p>Any tool that lets you set an OpenAI or Anthropic base URL: Claude Code, OpenAI Codex CLI, Hermes,
+Aider, Cline, Continue, Cursor, OpenCode, and more. Hermes' first-class profile is currently on
+<code>main</code> rather than in released 0.11.4.</p>
 
 <p class="meta">Part of <a href="https://github.com/0xzr/freellmpool">freellmpool</a> (MIT, free, open
-source). Updated 2026-07-16.</p>
+source). Updated 2026-07-19.</p>
 
 </div>
-<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "freellmpool", "item": "https://0xzr.github.io/freellmpool/"}, {"@type": "ListItem", "position": 2, "name": "How to run Claude Code, Codex, or Aider on free LLM models (no API bill)", "item": "https://0xzr.github.io/freellmpool/run-coding-agents-on-free-models.html"}]}</script>
+<script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "freellmpool", "item": "https://0xzr.github.io/freellmpool/"}, {"@type": "ListItem", "position": 2, "name": "How to run Claude Code, Codex, Hermes, or Aider on free LLM models", "item": "https://0xzr.github.io/freellmpool/run-coding-agents-on-free-models.html"}]}</script>
 </body>
 </html>

--- a/docs/run-opencode-on-free-models.html
+++ b/docs/run-opencode-on-free-models.html
@@ -46,8 +46,18 @@ and more) behind one endpoint, with automatic failover. Several providers need n
 start for free in under a minute. It also ships an OpenCode plugin with a <strong>live dashboard, quality
 routing, and usage tools</strong> built in.</strong></p>
 
-<h2>1. Install and start the proxy</h2>
-<pre><code>pip install freellmpool
+<div class="note"><strong>Release status:</strong> GitHub and PyPI both provide 0.11.4,
+including <code>spread</code> routing. Repository-local OpenCode plugin sources are included in 0.11.4;
+current <code>main</code> adds registry-readiness hardening, corrected defaults, and the operations APIs
+described below. Replace the released package to test that source explicitly:
+<pre><code>python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'</code></pre></div>
+
+<h2>1. Choose a release or current-main install, then start the proxy</h2>
+<pre><code># Released 0.11.4:
+python -m pip install freellmpool
+# Or replace it with current main for the latest plugin support and operations APIs:
+python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'
+
 freellmpool proxy            # serves http://localhost:8080</code></pre>
 <p>The proxy now routes OpenAI-style requests to a free provider and fails over when one is
 rate-limited.</p>
@@ -63,7 +73,7 @@ routed:</p>
       "npm": "@ai-sdk/openai-compatible",
       "options": { "baseURL": "http://localhost:8080/v1" },
       "models": {
-        "auto": {}, "fast": {}, "quality": {}, "fair": {}
+        "spread": {}, "auto": {}, "fast": {}, "quality": {}, "fair": {}
       }
     }
   }
@@ -73,6 +83,8 @@ routed:</p>
 <h2>3. Control routing quality from the model picker</h2>
 <p>Switch the model in OpenCode's picker to choose how freellmpool routes — no extra config:</p>
 <ul>
+<li><code>freellmpool/spread</code> — best starting point for long agent loops: use the least-used
+provider tier first, then prefer the faster/healthier target within that tier.</li>
 <li><code>freellmpool/auto</code> — the proxy's default routing.</li>
 <li><code>freellmpool/quality</code> — match each prompt's difficulty to the best <em>and fastest</em>
 capable free model (benchmark-scored, latency-aware).</li>
@@ -90,14 +102,22 @@ tools you can ask for in any session.</p>
 <p><strong>Registry publication status: pending.</strong>
 The planned packages are <code>opencode-freellmpool</code> and
 <code>opencode-freellmpool-tui</code>. Their tarballs are clean-install/load-tested,
-but use the linked local-file setup until both npm versions are verified.</p>
+but neither package was published on npm as of 2026-07-19. Use the linked
+local-file setup until both registry versions are verified.</p>
+
+<h2>5. Operational checks (current main)</h2>
+<p>Before a long OpenCode run, automation can call public <code>/livez</code> for process
+liveness and <code>/readyz</code> for advisory local capacity. With proxy authentication,
+<code>/v1/providers</code> returns secret-free readiness details and
+<code>/v1/models?ready=true</code> returns only locally ready targets. These endpoints are
+current-main additions and readiness does not probe upstream providers.</p>
 
 <div class="note">Free-tier models are smaller than frontier models. They're great for scaffolding,
 refactors, tests, commit messages, and everyday edits — not a substitute for a frontier model on the
 hardest reasoning. Limits reset at UTC midnight; <code>freellmpool/quality</code> keeps effective quality
 high as caps fill.</div>
 
-<h2>5. (Optional) add free keys for more capacity</h2>
+<h2>6. (Optional) add free keys for more capacity</h2>
 <p>The keyless providers get you started; adding free API keys for Groq, Cerebras, Gemini and others
 unlocks more models and higher daily limits — see the
 <a href="https://github.com/0xzr/freellmpool/blob/main/docs/ACCOUNTS.md">accounts guide</a>. freellmpool
@@ -120,7 +140,7 @@ for local and custom models. You're using the LLM providers' own free tiers; don
 <code>freellmpool_status</code> tool, or curl the proxy's <code>/status</code> endpoint.</p>
 
 <p class="meta">Part of <a href="https://github.com/0xzr/freellmpool">freellmpool</a> (MIT, free, open
-source). Updated 2026-07-16.</p>
+source). Updated 2026-07-19.</p>
 
 </div>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "freellmpool", "item": "https://0xzr.github.io/freellmpool/"}, {"@type": "ListItem", "position": 2, "name": "How to run OpenCode on free LLM models", "item": "https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html"}]}</script>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url><loc>https://0xzr.github.io/freellmpool/</loc><lastmod>2026-07-17</lastmod><priority>1.0</priority></url>
+  <url><loc>https://0xzr.github.io/freellmpool/</loc><lastmod>2026-07-19</lastmod><priority>1.0</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/best-free-llm-api-gateway.html</loc><lastmod>2026-07-16</lastmod><priority>0.9</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/free-llm-api-providers-list.html</loc><lastmod>2026-07-17</lastmod><priority>0.9</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/freellmpool-vs-litellm-vs-openrouter.html</loc><lastmod>2026-06-03</lastmod><priority>0.9</priority></url>
@@ -8,8 +8,8 @@
   <url><loc>https://0xzr.github.io/freellmpool/free-claude-api.html</loc><lastmod>2026-07-16</lastmod><priority>0.9</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/free-alternative-to-openrouter.html</loc><lastmod>2026-07-16</lastmod><priority>0.8</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/use-multiple-free-llm-apis.html</loc><lastmod>2026-07-16</lastmod><priority>0.8</priority></url>
-  <url><loc>https://0xzr.github.io/freellmpool/run-coding-agents-on-free-models.html</loc><lastmod>2026-07-16</lastmod><priority>0.8</priority></url>
-  <url><loc>https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html</loc><lastmod>2026-07-16</lastmod><priority>0.8</priority></url>
+  <url><loc>https://0xzr.github.io/freellmpool/run-coding-agents-on-free-models.html</loc><lastmod>2026-07-19</lastmod><priority>0.8</priority></url>
+  <url><loc>https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html</loc><lastmod>2026-07-19</lastmod><priority>0.8</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/capacity-management.html</loc><lastmod>2026-07-16</lastmod><priority>0.8</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/free-groq-api.html</loc><lastmod>2026-06-03</lastmod><priority>0.7</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/free-gemini-api.html</loc><lastmod>2026-06-03</lastmod><priority>0.7</priority></url>

--- a/integrations/opencode-jail/README.md
+++ b/integrations/opencode-jail/README.md
@@ -6,7 +6,7 @@ can let a model do **long agentic coding hands-off** without it touching anythin
 throwaway project — while it *believes* it's on a normal full Linux box.
 
 ```sh
-freellmpool-proxy                         # start the proxy first (or `freellmpool proxy --port 8765`)
+freellmpool proxy                         # starts the proxy on http://127.0.0.1:8080
 integrations/opencode-jail/opencode-freellmpool-jailed.sh            # interactive TUI in ~/project
 integrations/opencode-jail/opencode-freellmpool-jailed.sh --run "…"  # headless single turn
 integrations/opencode-jail/opencode-freellmpool-jailed.sh --serve     # opencode serve (basic-auth)

--- a/integrations/opencode-jail/opencode-freellmpool-jailed.sh
+++ b/integrations/opencode-jail/opencode-freellmpool-jailed.sh
@@ -45,7 +45,7 @@ case "${1:-}" in
 esac
 
 # ── tunables ────────────────────────────────────────────────────────────────────────
-PROXY_URL="${OPENCODE_FP_PROXY_URL:-http://127.0.0.1:8765}"
+PROXY_URL="${OPENCODE_FP_PROXY_URL:-http://127.0.0.1:8080}"
 MODEL="${OPENCODE_FP_MODEL:-freellmpool/spread}"  # spread = full-pool breadth (least-used tier first,
                                                   # anti-429) WITH a latency/health tie-break — the best
                                                   # mode for sustained agentic loops on free tiers
@@ -217,7 +217,7 @@ printf '{\n  "plugin": [ %s ]\n}\n' "$TUI_PLUGIN_LIST" > "$IMG_CFG/tui.json"
 # ── preflight: host proxy reachable (shared net) ──────────────────────────────────────
 if [ "$MODE" != "selftest" ] && ! curl -fsS --max-time 3 "$PROXY_URL/healthz" >/dev/null 2>&1; then
   echo "ERROR: freellmpool proxy not reachable at $PROXY_URL — start it on the host:" >&2
-  echo "         freellmpool proxy --port 8765   (or set OPENCODE_FP_PROXY_URL)" >&2
+  echo "         freellmpool proxy --port 8080   (or set OPENCODE_FP_PROXY_URL)" >&2
   exit 3
 fi
 

--- a/integrations/opencode-tui/README.md
+++ b/integrations/opencode-tui/README.md
@@ -48,8 +48,9 @@ your editor and lives alongside OpenCode's own Context / MCP / LSP panels.
 
 > **Registry publication status: pending.** `opencode-freellmpool-tui` and the
 > companion `opencode-freellmpool` server plugin are pack/install/load-tested
-> in CI, but are not yet verified on npm. Use the local-file command below until
-> that status changes.
+> in CI, but neither package was published on npm as of 2026-07-19.
+> Repository-local plugin sources are included in 0.11.4; current `main` adds registry-readiness hardening and corrected defaults. Use the local-file command
+> below until verified registry versions exist.
 
 OpenCode TUI plugins are installed with the built-in installer (which wires the OpenTUI
 runtime for you — there are no `node_modules` to manage):
@@ -78,7 +79,7 @@ To remove it, delete the entry from `~/.config/opencode/tui.json`.
 
 ## Controlling routing
 
-Switch OpenCode's model to `freellmpool/fast`, `/quality`, or `/fair` to change routing;
+Switch OpenCode's model to `freellmpool/spread`, `/fast`, `/quality`, or `/fair` to change routing;
 the dashboard's `routing` line reflects the active mode. See the proxy README for what each
 mode does.
 

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -45,8 +45,10 @@ across all of them while still preferring the quick/healthy ones.
 
 > **Registry publication status: pending.** `opencode-freellmpool` and its
 > companion `opencode-freellmpool-tui` are pack/install/load-tested in CI, but
-> are not yet verified on npm. Use the local-file path below until that status
-> changes.
+> neither package was published on npm as of 2026-07-19.
+> Repository-local plugin sources are included in 0.11.4; current `main` adds registry-readiness hardening
+> and corrected defaults. Use the local-file path below until verified registry
+> versions exist.
 
 **Option A — drop-in (no build):**
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -64,3 +64,23 @@ def test_all_agent_keys_appear_in_integrations_guide():
 
     for name in AGENTS:
         assert name.casefold() in coding_agents_section
+
+
+def test_agents_guide_tracks_current_release_and_main_surfaces():
+    guide = (ROOT / "docs" / "AGENTS.md").read_text(encoding="utf-8")
+
+    assert "Latest release: 0.11.4" in guide
+    assert "Current main includes unreleased changes" in guide
+    assert "git+https://github.com/0xzr/freellmpool.git@main" in guide
+    assert "Registry publication status: pending" in guide
+    for marker in (
+        "Hermes",
+        "freellmpool/spread",
+        "/livez",
+        "/readyz",
+        "/v1/providers",
+        "/v1/models?ready=true",
+        "opencode-freellmpool",
+        "opencode-freellmpool-tui",
+    ):
+        assert marker in guide

--- a/tests/test_opencode_packages.py
+++ b/tests/test_opencode_packages.py
@@ -68,10 +68,12 @@ def test_opencode_packages_use_the_proxy_default_and_current_command() -> None:
         ROOT / "integrations" / "opencode" / "README.md",
         ROOT / "integrations" / "opencode-tui" / "index.tsx",
         ROOT / "integrations" / "opencode-tui" / "README.md",
+        ROOT / "integrations" / "opencode-jail" / "opencode-freellmpool-jailed.sh",
+        ROOT / "integrations" / "opencode-jail" / "README.md",
     ]
     combined = "\n".join(path.read_text(encoding="utf-8") for path in paths)
     assert "http://localhost:8080" in combined
-    assert "localhost:8765" not in combined
+    assert ":8765" not in combined
     assert "freellmpool-proxy" not in combined
     assert "freellmpool proxy" in combined
 
@@ -94,6 +96,8 @@ def test_package_smoke_script_checks_tarballs_clean_installs_and_loads() -> None
 
 def test_unpublished_registry_install_is_labelled_pending_everywhere() -> None:
     paths = [
+        ROOT / "README.md",
+        ROOT / "docs" / "index.html",
         ROOT / "docs" / "INTEGRATIONS.md",
         ROOT / "docs" / "run-opencode-on-free-models.html",
         ROOT / "integrations" / "opencode" / "README.md",
@@ -104,3 +108,16 @@ def test_unpublished_registry_install_is_labelled_pending_everywhere() -> None:
         assert "Registry publication status: pending" in text
         assert "opencode-freellmpool" in text
         assert "opencode-freellmpool-tui" in text
+
+
+def test_opencode_docs_distinguish_released_sources_from_registry_hardening() -> None:
+    paths = [
+        ROOT / "docs" / "run-opencode-on-free-models.html",
+        ROOT / "integrations" / "opencode" / "README.md",
+        ROOT / "integrations" / "opencode-tui" / "README.md",
+    ]
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        assert "plugin sources are included in 0.11.4" in text
+        assert "registry-readiness hardening" in text
+        assert "unreleased repository additions" not in text

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -86,6 +86,87 @@ def test_readme_has_current_adoption_paths_and_pinned_comparison_sources() -> No
         assert "/v1/models?ready=true" in text
 
 
+def test_public_docs_separate_release_from_current_main() -> None:
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+    version = pyproject["project"]["version"]
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    index = (ROOT / "docs" / "index.html").read_text(encoding="utf-8")
+
+    source_docs = (
+        readme,
+        (ROOT / "README.es.md").read_text(encoding="utf-8"),
+        (ROOT / "docs" / "AGENTS.md").read_text(encoding="utf-8"),
+        (ROOT / "docs" / "INTEGRATIONS.md").read_text(encoding="utf-8"),
+        index,
+        (ROOT / "docs" / "llms.txt").read_text(encoding="utf-8"),
+        (ROOT / "docs" / "run-coding-agents-on-free-models.html").read_text(
+            encoding="utf-8"
+        ),
+        (ROOT / "docs" / "run-opencode-on-free-models.html").read_text(
+            encoding="utf-8"
+        ),
+    )
+
+    for text in (readme, index):
+        assert f"Latest release: {version}" in text
+        assert "Current main includes unreleased changes" in text
+
+    for text in source_docs:
+        assert "python -m pip install" in text
+        assert "git+https://github.com/0xzr/freellmpool.git@main" in text
+        assert (
+            "uvx --from git+https://github.com/0xzr/freellmpool.git@main "
+            "freellmpool --version"
+        ) not in text
+
+    assert f'"softwareVersion": "{version}"' in index
+
+    for text in (
+        readme,
+        (ROOT / "docs" / "AGENTS.md").read_text(encoding="utf-8"),
+        (ROOT / "docs" / "INTEGRATIONS.md").read_text(encoding="utf-8"),
+        index,
+        (ROOT / "docs" / "llms.txt").read_text(encoding="utf-8"),
+        (ROOT / "docs" / "run-opencode-on-free-models.html").read_text(
+            encoding="utf-8"
+        ),
+    ):
+        assert "registry-readiness hardening" in text
+
+
+def test_pages_describe_current_main_agent_and_operations_surfaces() -> None:
+    index = (ROOT / "docs" / "index.html").read_text(encoding="utf-8")
+    agents = (ROOT / "docs" / "run-coding-agents-on-free-models.html").read_text(
+        encoding="utf-8"
+    )
+    opencode = (ROOT / "docs" / "run-opencode-on-free-models.html").read_text(
+        encoding="utf-8"
+    )
+    llms = (ROOT / "docs" / "llms.txt").read_text(encoding="utf-8")
+
+    for marker in ("Hermes", "/livez", "/readyz", "/v1/providers", "/v1/models?ready=true"):
+        assert marker in index
+        assert marker in agents
+
+    for text in (index, opencode, llms):
+        assert "spread" in text
+
+    for text in (index, opencode):
+        assert "Registry publication status: pending" in text
+        assert "opencode-freellmpool" in text
+        assert "opencode-freellmpool-tui" in text
+
+
+def test_pages_dates_match_current_documentation_pass() -> None:
+    sitemap = (ROOT / "docs" / "sitemap.xml").read_text(encoding="utf-8")
+    for page in (
+        "https://0xzr.github.io/freellmpool/",
+        "https://0xzr.github.io/freellmpool/run-coding-agents-on-free-models.html",
+        "https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html",
+    ):
+        assert f"<loc>{page}</loc><lastmod>2026-07-19</lastmod>" in sitemap
+
+
 def test_roadmap_reflects_kimi_m3_addendum() -> None:
     roadmap = (ROOT / "docs/ROADMAP.md").read_text(encoding="utf-8")
     assert "Top 10 feature map" in roadmap

--- a/tests/test_spanish_readme.py
+++ b/tests/test_spanish_readme.py
@@ -29,6 +29,14 @@ def test_spanish_readme_tracks_current_launch_surface():
     assert "22 proveedores" in spanish
     assert "239 rutas de chat" in spanish
     assert "397 modelos de chat" in spanish
+    assert "Última versión: 0.11.4" in spanish
+    assert "main contiene cambios aún no publicados" in spanish
+    assert "git+https://github.com/0xzr/freellmpool.git@main" in spanish
+    assert "Estado de publicación en npm: pendiente" in spanish
+    assert "opencode-freellmpool" in spanish
+    assert "opencode-freellmpool-tui" in spanish
+    assert "freellmpool/spread" in spanish
+    assert "hermes" in spanish
 
     for heading in (
         "## Inicio rápido en 30 segundos",


### PR DESCRIPTION
## Summary

- distinguish released GitHub/PyPI 0.11.4 from post-tag changes currently on `main`
- label Hermes and readiness/provider APIs as current-main/unreleased and provide a persistent Git-source install path
- document released `spread` routing consistently across README, agent/OpenCode docs, Spanish README, and Pages
- keep both OpenCode npm packages truthfully marked unpublished while distinguishing released plugin sources from post-tag registry hardening
- align the jailed OpenCode integration with the proxy's port 8080 default
- refresh Pages metadata and sitemap dates

## Validation

- 750 tests passed
- coverage: 85.22% lines, 72.75% branches
- release metadata and provider/model count gates passed
- Ruff and focused strict mypy passed
- shell syntax and HTML/XML parsing passed
- OpenCode package smoke passed with npm 11.5.1 and Bun 1.3.14
- persistent current-main install tested in a fresh virtual environment with Hermes/readiness imports
- PyPI rechecked at 0.11.4; both npm package names rechecked as 404/unpublished
- independent final adversarial review passed after resolving two blocking documentation findings

## Summary by Sourcery

Clarify documentation and examples to distinguish the released 0.11.4 artifact from unreleased changes on main, and align OpenCode integration defaults with the proxy’s actual port and routing surfaces.

Enhancements:
- Align the jailed OpenCode launcher’s default proxy URL and guidance with the proxy’s standard port 8080 and spread routing mode to match the rest of the integration surface.

Documentation:
- Add explicit release vs current-main status sections across README (English and Spanish), agents/integrations guides, Pages index, and agent/OpenCode HTML guides, including a persistent Git-based install path for testing main-only features.
- Update agent and OpenCode guides to document Hermes support, readiness/provider operations endpoints, and the spread routing mode, while consistently marking OpenCode npm packages as pending registry publication and sourced from the repository.
- Refresh site metadata, structured data, and sitemap dates to reflect the current documentation pass and newly documented capabilities.

Tests:
- Extend release metadata and documentation tests to assert the new release/main separation messaging, Hermes/readiness/provider markers, OpenCode registry status, spread routing references, and updated sitemap dates.
- Broaden OpenCode package tests to cover the jailed integration scripts, ensure all materials use the proxy’s 8080 default instead of 8765, and verify the distinction between released plugin sources and registry-hardening changes.