### PR TITLE
fix: match current provider model aliases to capability scores

### DIFF
--- a/src/freellmpool/capability.py
+++ b/src/freellmpool/capability.py
@@ -46,7 +46,8 @@ _PROVIDER_PREFIX_RE = re.compile(r"^[^/]+/")
 _VENDOR_PREFIX_RE = re.compile(
     r"^(?:meta|mistralai|nvidia|google|microsoft|nousresearch|cognitivecomputations|"
     r"deepseek-ai|cohere|c4ai|ai21|aisingapore|ibm-granite|ibm|zai-org|zai|"
-    r"moonshotai|opengvlab|sarvamai|01-ai|openai)[-_]",
+    r"moonshotai|cf-moonshotai|minimaxai|xiaomimimo|opengvlab|sarvamai|01-ai|"
+    r"openai|z-ai)[-_]",
     re.IGNORECASE,
 )
 # A doubled family token, e.g. "qwen-qwen3-30b" → "qwen3-30b",

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -19,6 +19,20 @@ def test_normalize_collapses_variants_and_strips_vendor():
     assert c.normalize_model_name("Meta-Llama-3.3-70B-Instruct").startswith("llama-3.3-70b")
 
 
+@pytest.mark.parametrize(
+    ("catalog_name", "benchmark_name"),
+    [
+        ("cloudflare/@cf/moonshotai/kimi-k2.6", "kimi-k2.6"),
+        ("huggingface/MiniMaxAI/MiniMax-M3", "minimax-m3"),
+        ("nvidia/minimaxai/minimax-m3", "minimax-m3"),
+        ("huggingface/XiaomiMiMo/MiMo-V2.5-Pro", "mimo-v2.5-pro"),
+        ("nvidia/z-ai/glm-5.2", "glm-5.2"),
+    ],
+)
+def test_normalize_current_provider_vendor_aliases(catalog_name, benchmark_name):
+    assert c.normalize_model_name(catalog_name) == c.normalize_model_name(benchmark_name)
+
+
 def test_heuristic_orders_by_size_and_keywords():
     assert c._heuristic_score("llama-3.1-405b") > c._heuristic_score("llama-3.1-8b-instant")
     assert c._heuristic_score("foo-flash") <= 0.40  # downweight keyword


### PR DESCRIPTION
## Summary
- normalize current Cloudflare, Hugging Face, and NVIDIA vendor-qualified model names
- ensure GLM-5.2, MiniMax M3, Kimi K2.6, and MiMo V2.5 Pro receive their benchmark capability scores instead of the neutral fallback
- cover each live catalog form with regression tests

## Verification
- `pytest -q tests/test_capability.py`
- `pytest -q`

## Summary by Sourcery

Align model name normalization with current provider-specific aliases so benchmark capabilities apply to the correct models.

Bug Fixes:
- Map current Cloudflare, Hugging Face, and NVIDIA vendor-qualified model names to their canonical benchmark model names so they receive non-fallback capability scores.

Enhancements:
- Extend vendor prefix normalization to cover additional provider namespaces such as cf-moonshotai, minimaxai, xiaomimimo, and z-ai.

Tests:
- Add parametrized regression tests to ensure live catalog model names normalize to the same form as their benchmark counterparts.