### PR TITLE
Add capacity status edge fixture

### DIFF
--- a/src/freellmpool/key_inventory.py
+++ b/src/freellmpool/key_inventory.py
@@ -134,6 +134,17 @@ def default_config_path() -> Path:
     return Path.home() / ".config" / "freellmpool" / "config.toml"
 
 
+def _restrict_owner_read_write(fd: int) -> None:
+    """Best-effort 0600 permission narrowing for an open secret file descriptor."""
+    fchmod = getattr(os, "fchmod", None)
+    if not callable(fchmod):
+        return
+    try:
+        fchmod(fd, 0o600)
+    except OSError:
+        pass
+
+
 def upsert_config_key(env_var: str, value: str, path: Path | None = None) -> Path:
     """Write one [keys] value to config.toml and return the path.
 
@@ -162,12 +173,7 @@ def upsert_config_key(env_var: str, value: str, path: Path | None = None) -> Pat
         os.close(fd)  # fdopen failed — close the raw fd ourselves
         raise
     with fh:  # closes fd on exit
-        fchmod = getattr(os, "fchmod", None)
-        if fchmod is not None:
-            try:
-                fchmod(fd, 0o600)  # narrow an already-existing file too
-            except OSError:
-                pass
+        _restrict_owner_read_write(fd)  # narrow an already-existing file too
         fh.write(dump_simple_toml(data))
     return path
 

--- a/src/freellmpool/key_inventory.py
+++ b/src/freellmpool/key_inventory.py
@@ -162,10 +162,12 @@ def upsert_config_key(env_var: str, value: str, path: Path | None = None) -> Pat
         os.close(fd)  # fdopen failed — close the raw fd ourselves
         raise
     with fh:  # closes fd on exit
-        try:
-            os.fchmod(fd, 0o600)  # narrow an already-existing file too
-        except OSError:
-            pass
+        fchmod = getattr(os, "fchmod", None)
+        if fchmod is not None:
+            try:
+                fchmod(fd, 0o600)  # narrow an already-existing file too
+            except OSError:
+                pass
         fh.write(dump_simple_toml(data))
     return path
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from freellmpool.cli import _strip_fences
-from freellmpool.models import Reply
+from freellmpool.models import Model, Provider, Reply
 
 
 def test_strip_plain_json():
@@ -351,6 +351,71 @@ def test_cli_capacity_status_smoke(monkeypatch, capsys):
     assert main(["capacity", "status", "--target", "1", "--no-catalog-sync"]) == 0
     out = capsys.readouterr().out
     assert "LLM capacity:" in out
+
+
+def test_cli_capacity_status_all_reports_quota_edges_without_local_state(
+    tmp_path, monkeypatch, capsys
+):
+    from freellmpool.cli import main
+
+    catalog = [
+        Provider(
+            id="keyless",
+            label="Keyless",
+            adapter="openai",
+            base_url="https://keyless.test/v1",
+            auth="none",
+            models=(Model("free-model", rpd=25),),
+        ),
+        Provider(
+            id="low",
+            label="Low Quota",
+            adapter="openai",
+            base_url="https://low.test/v1",
+            key_env="LOW_KEY",
+            models=(Model("low-model", rpd=10),),
+        ),
+        Provider(
+            id="needskey",
+            label="Needs Key",
+            adapter="openai",
+            base_url="https://needs-key.test/v1",
+            key_env="NEEDS_KEY",
+            models=(Model("paid-model", rpd=50),),
+        ),
+    ]
+
+    class FakeQuota:
+        def snapshot(self):
+            return {"low::low-model": 8}
+
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "home"))
+    monkeypatch.setenv("FREELLMPOOL_CONFIG_FILE", str(tmp_path / "config.toml"))
+    monkeypatch.setenv("FREELLMPOOL_KEYS_PATH", str(tmp_path / "keys.toml"))
+    monkeypatch.setenv("FREELLMPOOL_QUOTA_PATH", str(tmp_path / "quota.json"))
+    monkeypatch.setenv("FREELLMPOOL_EXTERNAL_CATALOG_PATH", str(tmp_path / "provider_catalog.json"))
+    monkeypatch.setattr("freellmpool.cli.load_catalog", lambda: catalog)
+    monkeypatch.setattr("freellmpool.catalog.load_external_catalog", lambda: [])
+    monkeypatch.setattr("freellmpool.key_inventory.load_inventory", lambda path=None: [])
+    monkeypatch.setattr("freellmpool.capacity.QuotaStore", lambda: FakeQuota())
+    monkeypatch.setattr("freellmpool.capacity.effective_env", lambda env=None: {"LOW_KEY": "set"})
+
+    assert main(["capacity", "status", "--all", "--target", "3", "--no-catalog-sync"]) == 0
+
+    out = capsys.readouterr().out
+    assert "LLM capacity: 1/3 healthy providers" in out
+    assert "External catalog cache: 0 providers" in out
+    assert "Warning: 1 provider(s) are near quota." in out
+    assert "Action recommended: add 2 provider(s)." in out
+    assert "healthy     keyless" in out
+    assert "low_quota   low" in out
+    assert "missing     needskey" in out
+    assert "used=0/25" in out
+    assert "used=8/10" in out
+    assert "key=keyless" in out
+    assert "key=LOW_KEY" in out
+    assert "key=NEEDS_KEY" in out
 
 
 def test_cli_doctor_smoke(tmp_path, monkeypatch, capsys):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -353,11 +353,7 @@ def test_cli_capacity_status_smoke(monkeypatch, capsys):
     assert "LLM capacity:" in out
 
 
-def test_cli_capacity_status_all_reports_quota_edges_without_local_state(
-    tmp_path, monkeypatch, capsys
-):
-    from freellmpool.cli import main
-
+def _install_capacity_status_edge_fixture(tmp_path, monkeypatch):
     catalog = [
         Provider(
             id="keyless",
@@ -394,12 +390,26 @@ def test_cli_capacity_status_all_reports_quota_edges_without_local_state(
     monkeypatch.setenv("FREELLMPOOL_CONFIG_FILE", str(tmp_path / "config.toml"))
     monkeypatch.setenv("FREELLMPOOL_KEYS_PATH", str(tmp_path / "keys.toml"))
     monkeypatch.setenv("FREELLMPOOL_QUOTA_PATH", str(tmp_path / "quota.json"))
-    monkeypatch.setenv("FREELLMPOOL_EXTERNAL_CATALOG_PATH", str(tmp_path / "provider_catalog.json"))
+    monkeypatch.setenv(
+        "FREELLMPOOL_EXTERNAL_CATALOG_PATH",
+        str(tmp_path / "provider_catalog.json"),
+    )
     monkeypatch.setattr("freellmpool.cli.load_catalog", lambda: catalog)
     monkeypatch.setattr("freellmpool.catalog.load_external_catalog", lambda: [])
     monkeypatch.setattr("freellmpool.key_inventory.load_inventory", lambda path=None: [])
     monkeypatch.setattr("freellmpool.capacity.QuotaStore", lambda: FakeQuota())
-    monkeypatch.setattr("freellmpool.capacity.effective_env", lambda env=None: {"LOW_KEY": "set"})
+    monkeypatch.setattr(
+        "freellmpool.capacity.effective_env",
+        lambda env=None: {"LOW_KEY": "set"},
+    )
+
+
+def test_cli_capacity_status_all_reports_quota_edges_without_local_state(
+    tmp_path, monkeypatch, capsys
+):
+    from freellmpool.cli import main
+
+    _install_capacity_status_edge_fixture(tmp_path, monkeypatch)
 
     assert main(["capacity", "status", "--all", "--target", "3", "--no-catalog-sync"]) == 0
 

--- a/tests/test_key_inventory.py
+++ b/tests/test_key_inventory.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from freellmpool.key_inventory import (
     KeyRecord,
     append_inventory_record,
@@ -55,7 +57,8 @@ def test_upsert_config_key_creates_new_file(tmp_path):
     upsert_config_key("GROQ_API_KEY", "secret", path)
 
     assert path.read_text() == '[keys]\nGROQ_API_KEY = "secret"\n'
-    assert oct(path.stat().st_mode & 0o777) == "0o600"
+    if hasattr(os, "fchmod"):
+        assert oct(path.stat().st_mode & 0o777) == "0o600"
 
 
 def test_upsert_config_key_updates_keys_without_touching_other_tables(tmp_path):

--- a/tests/test_robustness.py
+++ b/tests/test_robustness.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import stat
 
 import pytest
@@ -141,7 +142,8 @@ def test_upsert_config_key_is_0600(tmp_path):
     from freellmpool.key_inventory import upsert_config_key
 
     p = upsert_config_key("GROQ_API_KEY", "secret", tmp_path / "config.toml")
-    assert stat.S_IMODE(p.stat().st_mode) == 0o600
+    if hasattr(os, "fchmod"):
+        assert stat.S_IMODE(p.stat().st_mode) == 0o600
     assert 'GROQ_API_KEY = "secret"' in p.read_text()
 
 


### PR DESCRIPTION
## Summary

- Add a deterministic `capacity status --all --no-catalog-sync` CLI fixture for issue #54.
- Isolate config, cache, quota, home, key-inventory, catalog, and environment lookups under `tmp_path` / monkeypatches so local developer credentials cannot affect the result.
- Assert the semantic capacity output: healthy keyless provider, low-quota configured provider, missing-key provider, summary, warning, and action recommendation without depending on full table whitespace.
- Add a small Windows guard around `os.fchmod` in `upsert_config_key`; the focused Windows test command otherwise crashed in unrelated `keys add` tests before this PR's fixture could be validated. POSIX still enforces `0600`; Windows asserts successful write/content without pretending POSIX mode bits apply.

Closes #54.

## Validation

Passed:

- `PYTHONPATH=src python -m pytest tests/test_cli.py::test_cli_capacity_status_all_reports_quota_edges_without_local_state -q`
- `PYTHONPATH=src python -m pytest tests/test_capacity.py tests/test_cli.py -q`
- `PYTHONPATH=src python -m pytest tests/test_capacity.py tests/test_cli.py tests/test_key_inventory.py tests/test_robustness.py -q`
- `PYTHONPATH=src python -m ruff check .`

Full coverage gate attempted but not green in this Windows checkout:

- Native Windows initially exposed unrelated platform assumptions outside this PR's requested scope.
- WSL/Linux run reached 748 pass / 10 fail; the remaining failures are all `tests/test_metaswarm_integration.py` caused by the Windows checkout materializing `integrations/metaswarm/freellmpool-review-adapter.sh` with CRLF, producing `/usr/bin/env: bash\r` and `case ... in\r` shell parse failures.

I left those metaswarm line-ending policy issues untouched to keep this PR focused.

## Summary by Sourcery

Add a deterministic CLI capacity status fixture that isolates local state and adjust key config permissions handling for cross-platform compatibility.

New Features:
- Add a CLI test fixture that exercises `capacity status --all --no-catalog-sync` across keyless, low-quota, and missing-key providers without relying on local configuration.

Bug Fixes:
- Prevent crashes on platforms without `os.fchmod` by guarding key config permission changes in `upsert_config_key`.

Tests:
- Add a capacity status edge-case test that asserts semantic output for provider health, quota warnings, and action recommendations while remaining robust to formatting differences.
- Relax key permission tests to only enforce 0600 mode when `os.fchmod` is available, aligning expectations with platform behavior.