### PR TITLE
Fix freellmpool tool registration in OpenCode

### DIFF
--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -51,20 +51,23 @@ aggregate quota matters more than keeping every turn in the strongest tier.
 > and corrected defaults. Use the local-file path below until verified registry
 > versions exist.
 
-**Option A — drop-in (no build):**
+**Option A — local package (recommended until registry publication):**
 
 ```sh
-mkdir -p ~/.config/opencode/plugin
-cp freellmpool.js ~/.config/opencode/plugin/
+cd /absolute/path/to/integrations/opencode
+npm pack
+npm install --prefix ~/.config/opencode ./opencode-freellmpool-0.1.0.tgz
+mkdir -p ~/.config/opencode/plugin ~/.config/opencode/tools
+cp plugin/freellmpool.js ~/.config/opencode/plugin/
+cp tools/*.js ~/.config/opencode/tools/
 ```
 
-**Option B — reference from your `opencode.json` / `opencode.jsonc`:**
-
-```jsonc
-{
-  "plugin": ["/absolute/path/to/integrations/opencode/freellmpool.js"]
-}
-```
+OpenCode auto-discovers the shim in `~/.config/opencode/plugin`; do not add the
+unpublished package name to the `plugin` array, because that can trigger a
+registry lookup. The files copied into `~/.config/opencode/tools` are required for OpenCode
+versions that discover custom tools from that directory rather than from a
+plugin's `tool` hook. Keeping both paths configured preserves the served-model
+toast and exposes all three tools across supported OpenCode versions.
 
 Then make sure the proxy is running (`freellmpool proxy`) and that OpenCode has a
 `freellmpool` provider pointed at it (`baseURL: http://localhost:8080/v1`). Add the

--- a/integrations/opencode/freellmpool.js
+++ b/integrations/opencode/freellmpool.js
@@ -167,7 +167,7 @@ export const FreellmpoolPlugin = async ({ client }) => {
 
   return {
     tool: {
-      freellmpool_status: {
+      freellmpool_status: tool({
         description:
           "Show freellmpool proxy status: usage, estimated $ saved, per-provider " +
           "quota/rate-limits/cooldown/latency, current routing mode, and the most " +
@@ -184,9 +184,9 @@ export const FreellmpoolPlugin = async ({ client }) => {
           if (!ok) return `freellmpool status unavailable: ${error}`;
           return renderStatus(data, { verbose: !!args.verbose });
         },
-      },
+      }),
 
-      freellmpool_models: {
+      freellmpool_models: tool({
         description:
           "List the model ids the freellmpool proxy currently exposes (including the " +
           "routing aliases agent/auto/spread/fast/quality/fair). Use to discover what to set as the model.",
@@ -198,9 +198,9 @@ export const FreellmpoolPlugin = async ({ client }) => {
           if (!ids.length) return "freellmpool: no models reported.";
           return `freellmpool exposes ${ids.length} models:\n` + ids.map((id) => `  ${id}`).join("\n");
         },
-      },
+      }),
 
-      freellmpool_tokenmax: {
+      freellmpool_tokenmax: tool({
         description:
           "🌈 TOKENMAX: blast the SAME prompt to EVERY free model the proxy can reach at " +
           "once, then YOU synthesize the single best answer from all of them. While it runs, " +
@@ -239,7 +239,7 @@ export const FreellmpoolPlugin = async ({ client }) => {
           }
           return lines.join("\n");
         },
-      },
+      }),
     },
 
     // Best-effort: when an assistant reply completes, read which provider+model the

--- a/integrations/opencode/package.json
+++ b/integrations/opencode/package.json
@@ -6,7 +6,9 @@
   "type": "module",
   "main": "freellmpool.js",
   "exports": {
-    ".": "./freellmpool.js"
+    ".": "./freellmpool.js",
+    "./plugin/*": "./plugin/*",
+    "./tools/*": "./tools/*"
   },
   "keywords": ["opencode", "opencode-plugin", "freellmpool", "llm", "proxy"],
   "license": "MIT",
@@ -25,5 +27,5 @@
   "peerDependencies": {
     "@opencode-ai/plugin": ">=1.14.0"
   },
-  "files": ["LICENSE", "README.md", "freellmpool.js"]
+  "files": ["LICENSE", "README.md", "freellmpool.js", "plugin", "tools"]
 }

--- a/integrations/opencode/plugin/freellmpool.js
+++ b/integrations/opencode/plugin/freellmpool.js
@@ -1,0 +1,1 @@
+export { default } from "opencode-freellmpool"

--- a/integrations/opencode/tools/freellmpool_models.js
+++ b/integrations/opencode/tools/freellmpool_models.js
@@ -1,0 +1,5 @@
+import plugin from "opencode-freellmpool"
+
+const loaded = await plugin({ client: { tui: { showToast: async () => {} } } })
+
+export default loaded.tool.freellmpool_models

--- a/integrations/opencode/tools/freellmpool_status.js
+++ b/integrations/opencode/tools/freellmpool_status.js
@@ -1,0 +1,5 @@
+import plugin from "opencode-freellmpool"
+
+const loaded = await plugin({ client: { tui: { showToast: async () => {} } } })
+
+export default loaded.tool.freellmpool_status

--- a/integrations/opencode/tools/freellmpool_tokenmax.js
+++ b/integrations/opencode/tools/freellmpool_tokenmax.js
@@ -1,0 +1,5 @@
+import plugin from "opencode-freellmpool"
+
+const loaded = await plugin({ client: { tui: { showToast: async () => {} } } })
+
+export default loaded.tool.freellmpool_tokenmax

--- a/scripts/check_opencode_packages.mjs
+++ b/scripts/check_opencode_packages.mjs
@@ -20,7 +20,16 @@ const packages = [
   {
     directory: "opencode",
     name: "opencode-freellmpool",
-    files: ["LICENSE", "README.md", "freellmpool.js", "package.json"],
+    files: [
+      "LICENSE",
+      "README.md",
+      "freellmpool.js",
+      "package.json",
+      "plugin/freellmpool.js",
+      "tools/freellmpool_models.js",
+      "tools/freellmpool_status.js",
+      "tools/freellmpool_tokenmax.js",
+    ],
   },
   {
     directory: "opencode-tui",
@@ -60,11 +69,11 @@ function smokeServer(installDir) {
     installDir,
     "@opencode-ai/plugin",
     [
-      "const chain = new Proxy(function () { return chain }, {",
-      "  get() { return chain },",
-      "  apply() { return chain },",
+      "const schema = new Proxy(function () { return schema }, {",
+      "  get() { return schema },",
+      "  apply() { return schema },",
       "})",
-      "export const tool = { schema: chain }",
+      "export const tool = Object.assign((definition) => definition, { schema })",
     ].join("\n"),
   )
   run(
@@ -75,7 +84,13 @@ function smokeServer(installDir) {
       [
         'const mod = await import("opencode-freellmpool")',
         "const loaded = await mod.default({ client: { tui: { showToast: async () => {} } } })",
-        'if (!loaded?.tool?.freellmpool_status) throw new Error("server plugin did not load")',
+        'if (loaded?.tool?.freellmpool_status?.description === undefined) throw new Error("server plugin did not register tools")',
+        'const localPlugin = await import("opencode-freellmpool/plugin/freellmpool.js")',
+        'if (typeof localPlugin.default !== "function") throw new Error("local plugin shim did not load")',
+        'for (const name of ["freellmpool_status", "freellmpool_models", "freellmpool_tokenmax"]) {',
+        '  const custom = await import(`opencode-freellmpool/tools/${name}.js`)',
+        '  if (custom.default?.description === undefined) throw new Error(`${name} custom tool did not load`)',
+        '}',
       ].join(";"),
     ],
     { cwd: installDir },

--- a/tests/test_opencode_packages.py
+++ b/tests/test_opencode_packages.py
@@ -8,7 +8,7 @@ PACKAGES = {
     "opencode": {
         "name": "opencode-freellmpool",
         "entry": "freellmpool.js",
-        "files": {"freellmpool.js", "README.md", "LICENSE"},
+        "files": {"freellmpool.js", "README.md", "LICENSE", "plugin", "tools"},
     },
     "opencode-tui": {
         "name": "opencode-freellmpool-tui",
@@ -114,6 +114,42 @@ def test_package_smoke_script_checks_tarballs_clean_installs_and_loads() -> None
         "LICENSE",
     ):
         assert required in script
+
+
+def test_opencode_server_plugin_registers_tools_with_sdk_helper() -> None:
+    source = (
+        ROOT / "integrations" / "opencode" / "freellmpool.js"
+    ).read_text(encoding="utf-8")
+    for name in (
+        "freellmpool_status",
+        "freellmpool_models",
+        "freellmpool_tokenmax",
+    ):
+        assert f"{name}: tool({{" in source
+
+    smoke = (ROOT / "scripts" / "check_opencode_packages.mjs").read_text(
+        encoding="utf-8"
+    )
+    assert "Object.assign((definition) => definition, { schema })" in smoke
+    assert "server plugin did not register tools" in smoke
+    assert "local plugin shim did not load" in smoke
+    assert "custom tool did not load" in smoke
+
+    for name in (
+        "freellmpool_status",
+        "freellmpool_models",
+        "freellmpool_tokenmax",
+    ):
+        shim = (
+            ROOT / "integrations" / "opencode" / "tools" / f"{name}.js"
+        ).read_text(encoding="utf-8")
+        assert 'import plugin from "opencode-freellmpool"' in shim
+        assert f"export default loaded.tool.{name}" in shim
+
+    plugin_shim = (
+        ROOT / "integrations" / "opencode" / "plugin" / "freellmpool.js"
+    ).read_text(encoding="utf-8")
+    assert plugin_shim.strip() == 'export { default } from "opencode-freellmpool"'
 
 
 def test_unpublished_registry_install_is_labelled_pending_everywhere() -> None:


### PR DESCRIPTION
## Summary
- register plugin tools through the OpenCode SDK helper
- ship auto-discovered local plugin and custom-tool shims for OpenCode 1.18.9
- document the unpublished-package install path without registry lookup
- strengthen package smoke and regression coverage

## Verification
- `PYTHONPATH=$PWD/src pytest -q`
- `PYTHONPATH=$PWD/src pytest -q tests/test_opencode_packages.py`
- JavaScript syntax checks and `git diff --check`
- package server/custom-tool smoke passed; TUI smoke unavailable locally because Bun is not installed
- live `opencode run -m freellmpool/agent` called `freellmpool_status` and `freellmpool_models` successfully

## Review gate
- Codex Sol 5.6, xhigh: approved with no findings before commit

## Summary by Sourcery

Ensure the freellmpool OpenCode integration correctly registers and exposes its tools across supported OpenCode versions and strengthen its packaging and smoke checks.

Enhancements:
- Wrap freellmpool_status, freellmpool_models, and freellmpool_tokenmax in the OpenCode SDK tool helper and expose them via plugin and custom-tool shims.
- Export plugin and tools subpaths from the OpenCode integration package and include them in the published files list for compatibility with OpenCode’s auto-discovery.

Build:
- Adjust OpenCode package metadata and smoke script to account for new plugin and tool shim files in the distribution.

Documentation:
- Update OpenCode integration documentation to describe installing the unpublished package via npm tarball and configuring auto-discovered plugin and tool shims without triggering registry lookups.

Tests:
- Extend OpenCode package smoke tests to verify the presence of plugin/tool shims and that the server plugin registers tools with the SDK helper.