### PR TITLE
Fix validated agent-audit findings

### DIFF
--- a/src/freellmpool/aio.py
+++ b/src/freellmpool/aio.py
@@ -123,7 +123,10 @@ class AsyncPool:
                     limits=httpx.Limits(
                         max_keepalive_connections=20, max_connections=100, keepalive_expiry=30.0
                     ),
-                    follow_redirects=True,
+                    # Keep provider credentials on the validated origin. A public
+                    # provider URL could otherwise redirect to a loopback/private
+                    # target and receive the Authorization header.
+                    follow_redirects=False,
                 )
                 self._aclient_loop = running
             return self._aclient

--- a/src/freellmpool/mcp_server.py
+++ b/src/freellmpool/mcp_server.py
@@ -32,6 +32,7 @@ Implemented on the standard library only — no MCP SDK required.
 from __future__ import annotations
 
 import json
+import logging
 import sys
 import threading
 import time
@@ -67,6 +68,7 @@ from .tokenmax import HARD_CAP, RAINBOW_BANNER, fan_out, select_targets
 
 _DEFAULT_PROTOCOL = "2025-06-18"
 _MAX_PANEL = MAX_PANEL_COUNT
+_log = logging.getLogger(__name__)
 
 # Returned in the `initialize` handshake (MCP's standard `instructions` field) so the
 # calling agent learns HOW to invoke these tools — chiefly: call them directly instead
@@ -910,8 +912,9 @@ def handle_message(
             notify = _make_notify(params, send_notification)
             return _result(mid, _call_tool(pool, params, notify=notify))
         return _error(mid, -32601, f"method not found: {method}")
-    except Exception as exc:  # noqa: BLE001 — never crash the loop
-        return _error(mid, -32603, f"{type(exc).__name__}: {exc}")
+    except Exception:  # noqa: BLE001 — never crash the loop
+        _log.exception("unexpected MCP request failure")
+        return _error(mid, -32603, "internal error")
 
 
 def serve_stdio(pool: Pool, version: str = "0.0.0") -> None:

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -30,11 +30,14 @@ from __future__ import annotations
 import collections
 import hmac
 import json
+import logging
 import os
 import re
 import threading
+import time
 from collections.abc import Sequence
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
 from urllib.parse import parse_qs, urlsplit
 
 from . import __version__
@@ -63,6 +66,15 @@ _AGENT_UPSTREAM_TIMEOUT = 540.0  # leave one minute for proxy/client handoff
 # response_format values we forward. srt/vtt aren't accepted by Groq/Mistral's transcription
 # endpoints (they'd fail upstream and surface as a confusing 502), so reject them up front.
 _TRANSCRIPTION_FORMATS = ("json", "text", "verbose_json")
+_log = logging.getLogger(__name__)
+
+
+def _max_tokens_value(req: dict[str, Any], default: int) -> Any:
+    """Return the first supported OpenAI-compatible output-token budget."""
+    for field in ("max_tokens", "max_completion_tokens", "max_output_tokens"):
+        if field in req and req[field] is not None:
+            return req[field]
+    return default
 
 
 def _model_ids(pool: Pool, ready_model_ids: frozenset[str] | None = None) -> list[str]:
@@ -270,6 +282,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
 
     class Handler(BaseHTTPRequestHandler):
         server_version = f"freellmpool/{__version__}"
+        _response_started = False
         # Socket read timeout: a slow/stalled client can't pin a worker thread + fd
         # indefinitely. setup() applies this to the connection via settimeout().
         timeout = 75
@@ -277,6 +290,13 @@ def make_handler(pool: Pool, api_key: str | None = None):
         # quiet by default; the server prints its own concise log line
         def log_message(self, format, *args):  # noqa: A002
             return
+
+        def end_headers(self) -> None:
+            # Committing starts when the header buffer is flushed. A socket write
+            # may transmit a prefix and then raise, so mark this before delegating:
+            # the outer handler must never append a second HTTP response afterward.
+            self._response_started = True
+            super().end_headers()
 
         def _send(self, status: int, payload: dict, headers: dict | None = None) -> None:
             data = json.dumps(payload).encode("utf-8")
@@ -322,16 +342,26 @@ def make_handler(pool: Pool, api_key: str | None = None):
             )
 
         def do_GET(self) -> None:  # noqa: N802
+            self._response_started = False
             try:
                 self._do_get()
             except Exception as exc:  # never let a request kill the thread
-                self._error(500, f"internal error: {type(exc).__name__}", "internal_error")
+                _log.exception("unexpected GET handler failure")
+                if self._response_started:
+                    self.close_connection = True
+                else:
+                    self._error(500, f"internal error: {type(exc).__name__}", "internal_error")
 
         def do_POST(self) -> None:  # noqa: N802
+            self._response_started = False
             try:
                 self._do_post()
             except Exception as exc:  # never let a request kill the thread
-                self._error(500, f"internal error: {type(exc).__name__}", "internal_error")
+                _log.exception("unexpected POST handler failure")
+                if self._response_started:
+                    self.close_connection = True
+                else:
+                    self._error(500, f"internal error: {type(exc).__name__}", "internal_error")
 
         def _do_get(self) -> None:
             path = urlsplit(self.path).path.rstrip("/") or "/"
@@ -511,7 +541,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 pool,
                 prompt.strip(),
                 n=req.get("n", req.get("models", 3)),
-                max_tokens=req.get("max_tokens", 512),
+                max_tokens=_max_tokens_value(req, 512),
                 timeout=90.0,
                 routing=str(req.get("routing") or "quality"),
                 synthesize=bool(req.get("synthesize")),
@@ -537,7 +567,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 msgs.append({"role": "system", "content": system})
             msgs.append({"role": "user", "content": prompt})
             try:
-                max_tokens = max(1, min(8192, int(req.get("max_tokens", 350))))
+                max_tokens = max(1, min(8192, int(_max_tokens_value(req, 350))))
             except (TypeError, ValueError):
                 max_tokens = 350
 
@@ -776,12 +806,15 @@ def make_handler(pool: Pool, api_key: str | None = None):
             requested = resolve_alias(requested, pool.env)  # gpt-4o-mini → free target
             provider_filter, model_filter = _parse_model(requested, {p.id for p in pool.providers})
             try:
-                max_tokens = int(req.get("max_tokens") or req.get("max_output_tokens") or 1024)
+                max_tokens = int(_max_tokens_value(req, 1024))
                 temp_raw = req.get("temperature")
                 temperature = 0.0 if temp_raw is None else float(temp_raw)
             except (TypeError, ValueError):
                 self._error(
-                    400, "'max_tokens'/'temperature' must be numbers", "invalid_request_error"
+                    400,
+                    "'max_tokens'/'max_completion_tokens'/'max_output_tokens'/"
+                    "'temperature' must be numbers",
+                    "invalid_request_error",
                 )
                 return None
             upstream_timeout = (
@@ -862,12 +895,15 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 resolve_alias(requested, pool.env), {p.id for p in pool.providers}
             )
             try:
-                max_tokens = int(req.get("max_tokens") or 1024)
+                max_tokens = int(_max_tokens_value(req, 1024))
                 temp_raw = req.get("temperature")
                 temperature = 0.0 if temp_raw is None else float(temp_raw)
             except (TypeError, ValueError):
                 self._error(
-                    400, "'max_tokens'/'temperature' must be numbers", "invalid_request_error"
+                    400,
+                    "'max_tokens'/'max_completion_tokens'/'max_output_tokens'/"
+                    "'temperature' must be numbers",
+                    "invalid_request_error",
                 )
                 return
             upstream_timeout = (
@@ -923,18 +959,26 @@ def make_handler(pool: Pool, api_key: str | None = None):
 
             provider_id = meta["provider"] if isinstance(meta, dict) else "auto"
             model_name = meta["model"] if isinstance(meta, dict) else "auto"
+            attempts = meta.get("attempts", 1) if isinstance(meta, dict) else 1
             cid = f"chatcmpl-freellmpool-{provider_id}"
             model_id = f"{provider_id}/{model_name}"
+            created = int(time.time())
             self.send_response(200)
             self.send_header("Content-Type", "text/event-stream")
             self.send_header("Cache-Control", "no-cache")
             self.send_header("Connection", "close")
             self.end_headers()
             try:
-                self.wfile.write(_chunk_block(cid, model_id, role="assistant").encode())
+                self.wfile.write(
+                    _chunk_block(cid, model_id, role="assistant", created=created).encode()
+                )
                 for delta in gen:
-                    self.wfile.write(_chunk_block(cid, model_id, content=delta).encode())
-                self.wfile.write(_chunk_block(cid, model_id, finish="stop").encode())
+                    self.wfile.write(
+                        _chunk_block(cid, model_id, content=delta, created=created).encode()
+                    )
+                self.wfile.write(
+                    _chunk_block(cid, model_id, finish="stop", created=created).encode()
+                )
                 self.wfile.write(b"data: [DONE]\n\n")
                 self.wfile.flush()
             except (BrokenPipeError, ConnectionResetError):  # pragma: no cover
@@ -966,7 +1010,9 @@ def make_handler(pool: Pool, api_key: str | None = None):
             finally:
                 gen.close()  # release the upstream stream even on early disconnect
             # Record recent served (stream)
-            record_recent({"provider": provider_id, "model": model_name, "attempts": 1})
+            record_recent(
+                {"provider": provider_id, "model": model_name, "attempts": int(attempts)}
+            )
 
         def _handle_responses(self, req: dict) -> None:
             """Minimal OpenAI Responses API (/v1/responses) shim for Codex CLI
@@ -1017,7 +1063,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
     return Handler
 
 
-def _parse_model(requested: str, provider_ids: set[str]):
+def _parse_model(requested: object, provider_ids: set[str]):
     """Map an OpenAI 'model' field to (provider_filter, model_filter).
 
     "auto"                  -> (None, None)        any provider/model
@@ -1027,7 +1073,7 @@ def _parse_model(requested: str, provider_ids: set[str]):
                                it's a catalog model name that happens to contain '/')
     "llama-3.3-70b"         -> (None, "llama-3.3-70b")  model on any provider
     """
-    if not requested or requested == "auto":
+    if not isinstance(requested, str) or not requested or requested == "auto":
         return None, None
     if "/" in requested:
         provider, _, model = requested.partition("/")
@@ -1308,7 +1354,15 @@ if(data.synthesis&&data.synthesis.text){out.appendChild(card('synthesis',data.sy
 </script></body></html>"""
 
 
-def _chunk_block(cid: str, model_id: str, *, role=None, content=None, finish=None) -> str:
+def _chunk_block(
+    cid: str,
+    model_id: str,
+    *,
+    role=None,
+    content=None,
+    finish=None,
+    created: int | None = None,
+) -> str:
     delta: dict = {}
     if role is not None:
         delta["role"] = role
@@ -1317,6 +1371,7 @@ def _chunk_block(cid: str, model_id: str, *, role=None, content=None, finish=Non
     chunk = {
         "id": cid,
         "object": "chat.completion.chunk",
+        "created": int(time.time()) if created is None else created,
         "model": model_id,
         "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
     }
@@ -1331,7 +1386,12 @@ def _sse_chunks(reply):
     """
     cid = f"chatcmpl-freellmpool-{reply.provider_id}"
     model = f"{reply.provider_id}/{reply.model}"
-    base = {"id": cid, "object": "chat.completion.chunk", "model": model}
+    base = {
+        "id": cid,
+        "object": "chat.completion.chunk",
+        "created": int(time.time()),
+        "model": model,
+    }
     tool_calls = reply.message.get("tool_calls") if reply.message else None
 
     def block(chunk):

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -1081,7 +1081,11 @@ class Pool:
             )
             self.quota.record(target.provider.id, target.model)
             self._bump_stats(requests=1)
-            yield {"provider": target.provider.id, "model": target.model}
+            yield {
+                "provider": target.provider.id,
+                "model": target.model,
+                "attempts": len(attempts) + 1,
+            }
             # Accumulate the streamed text so we can record token usage when the stream
             # ends. Providers rarely send a usage block on a stream, so without this the
             # session + lifetime token / savings totals — and the dashboard's tok/s — never

--- a/tests/test_aio.py
+++ b/tests/test_aio.py
@@ -134,6 +134,29 @@ def test_async_context_manager_closes(providers, env, quota):
     assert reply.text == "ok"
 
 
+def test_async_client_disables_redirects(providers, env, quota, monkeypatch):
+    import httpx
+
+    seen = {}
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            seen.update(kwargs)
+
+        async def aclose(self):
+            return None
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+    pool = AsyncPool(Pool(providers, quota=quota, env=env))
+
+    async def run():
+        await pool._client_obj()
+        await pool.aclose()
+
+    asyncio.run(run())
+    assert seen["follow_redirects"] is False
+
+
 def test_async_no_providers_raises(quota):
     from freellmpool.errors import NoProvidersConfigured
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -398,6 +398,35 @@ def test_unknown_method_errors(providers, env, quota):
     assert resp["error"]["code"] == -32601
 
 
+def test_unexpected_dispatch_error_is_redacted_and_logged(
+    providers, env, quota, monkeypatch, caplog
+):
+    from freellmpool import mcp_server
+
+    secret = "sentinel-secret-value"
+
+    def boom(*args, **kwargs):
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(mcp_server, "_call_tool", boom)
+    pool = _pool(providers, env, quota)
+    with caplog.at_level("ERROR", logger="freellmpool.mcp_server"):
+        resp = handle_message(
+            pool,
+            {
+                "jsonrpc": "2.0",
+                "id": 99,
+                "method": "tools/call",
+                "params": {"name": "free_llm_models"},
+            },
+        )
+
+    assert resp["error"]["code"] == -32603
+    assert resp["error"]["message"] == "internal error"
+    assert secret not in str(resp)
+    assert secret in caplog.text
+
+
 def test_ask_failover_in_tool(providers, env, quota):
     post = make_post({"alpha.test": (500, {}), "beta.test": (200, openai_body("from beta"))})
     pool = _pool(providers, env, quota, post=post)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -10,6 +10,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
+from http.server import BaseHTTPRequestHandler
 
 import pytest
 from helpers import gemini_body, make_post, make_stream_post, openai_body
@@ -22,6 +23,7 @@ from freellmpool.proxy import (
     _MAX_CONNECTIONS,
     _BoundedThreadingHTTPServer,
     _parse_model,
+    make_handler,
     serve,
 )
 from freellmpool.router import Pool
@@ -1505,3 +1507,226 @@ def test_badge_public_when_opted_in(providers, env, quota, monkeypatch):
     finally:
         httpd.shutdown()
         httpd.server_close()
+
+
+def test_max_completion_tokens_reaches_buffered_chat_and_responses(providers, env, quota):
+    post = make_post({})
+    pool = Pool(providers[:1], quota=quota, env=env, post=post)
+    httpd, base = _serve(pool)
+    try:
+        status, _ = _post_json(
+            base + "/v1/chat/completions",
+            {
+                "model": "auto",
+                "max_completion_tokens": 37,
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        assert status == 200
+        status, _ = _post_json(
+            base + "/v1/responses",
+            {"model": "auto", "max_completion_tokens": 38, "input": "hi"},
+        )
+        assert status == 200
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    assert [call["body"]["max_tokens"] for call in post.calls] == [37, 38]
+
+
+def test_max_completion_tokens_reaches_live_stream(providers, env, quota):
+    stream_post = make_stream_post({})
+    pool = Pool(providers[:1], quota=quota, env=env, stream_post=stream_post)
+    httpd, base = _serve(pool)
+    try:
+        req = urllib.request.Request(
+            base + "/v1/chat/completions",
+            data=json.dumps(
+                {
+                    "model": "auto",
+                    "stream": True,
+                    "max_completion_tokens": 39,
+                    "messages": [{"role": "user", "content": "hi"}],
+                }
+            ).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            assert resp.status == 200
+            resp.read()
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    assert stream_post.calls[0]["body"]["max_tokens"] == 39
+
+
+def test_max_completion_tokens_reaches_battle_and_tokenmax(providers, env, quota):
+    post = make_post({})
+    pool = Pool(providers[:2], quota=quota, env=env, post=post)
+    httpd, base = _serve(pool)
+    try:
+        status, _ = _post_json(
+            base + "/freellmpool/battle",
+            {"prompt": "compare", "n": 2, "max_completion_tokens": 40},
+        )
+        assert status == 200
+        battle_calls = list(post.calls)
+        post.calls.clear()
+        status, _ = _post_json(
+            base + "/tokenmax",
+            {"prompt": "compare", "max_models": 1, "max_completion_tokens": 41},
+        )
+        assert status == 200
+        tokenmax_calls = list(post.calls)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    assert battle_calls
+    assert {call["body"]["max_tokens"] for call in battle_calls} == {40}
+    assert tokenmax_calls
+    assert {call["body"]["max_tokens"] for call in tokenmax_calls} == {41}
+
+
+@pytest.mark.parametrize("requested", [{"bad": "model"}, ["bad"], 123, None])
+def test_parse_model_rejects_non_string_input(requested):
+    assert _parse_model(requested, {"groq"}) == (None, None)
+
+
+def test_live_stream_records_real_failover_attempts(providers, env, quota):
+    stream_post = make_stream_post(
+        {"alpha.test": (500, []), "beta.test": (200, ["ok"])}
+    )
+    pool = Pool(providers[:2], quota=quota, env=env, stream_post=stream_post)
+    httpd, base = _serve(pool)
+    try:
+        req = urllib.request.Request(
+            base + "/v1/chat/completions",
+            data=json.dumps(
+                {
+                    "model": "auto",
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "hi"}],
+                }
+            ).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            resp.read()
+        _, status = _get_json(base + "/status")
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    assert status["recent"][0]["provider"] == "beta"
+    assert status["recent"][0]["attempts"] == len(stream_post.calls)
+    assert status["recent"][0]["attempts"] > 1
+
+
+def test_handler_logs_but_does_not_double_write_after_response_start(
+    providers, env, quota, caplog
+):
+    pool = Pool(providers[:1], quota=quota, env=env, post=make_post({}))
+    handler_type = make_handler(pool)
+    handler = object.__new__(handler_type)
+    handler._response_started = True
+    errors = []
+
+    def boom():
+        handler._response_started = True
+        raise RuntimeError("after headers")
+
+    handler._do_get = boom
+    handler._error = lambda *args: errors.append(args)
+
+    with caplog.at_level("ERROR", logger="freellmpool.proxy"):
+        handler.do_GET()
+
+    assert errors == []
+    assert "unexpected GET handler failure" in caplog.text
+
+
+def test_header_flush_failure_is_committed_and_closes_connection(
+    providers, env, quota, monkeypatch
+):
+    pool = Pool(providers[:1], quota=quota, env=env, post=make_post({}))
+    handler_type = make_handler(pool)
+    handler = object.__new__(handler_type)
+    handler._response_started = False
+    handler.close_connection = False
+    errors = []
+
+    def fail_during_flush(_handler):
+        raise OSError("socket failed after a partial header write")
+
+    monkeypatch.setattr(BaseHTTPRequestHandler, "end_headers", fail_during_flush)
+    handler._do_get = handler.end_headers
+    handler._error = lambda *args: errors.append(args)
+
+    handler.do_GET()
+
+    assert handler._response_started is True
+    assert handler.close_connection is True
+    assert errors == []
+
+
+def test_handler_still_sends_redacted_500_before_response_start(providers, env, quota):
+    pool = Pool(providers[:1], quota=quota, env=env, post=make_post({}))
+    handler_type = make_handler(pool)
+    handler = object.__new__(handler_type)
+    handler._response_started = False
+    errors = []
+
+    def boom():
+        raise RuntimeError("before headers")
+
+    handler._do_post = boom
+    handler._error = lambda *args: errors.append(args)
+    handler.do_POST()
+
+    assert errors == [(500, "internal error: RuntimeError", "internal_error")]
+
+
+@pytest.mark.parametrize("with_tools", [False, True])
+def test_chat_sse_chunks_include_integer_created_timestamp(
+    providers, env, quota, with_tools
+):
+    post = make_post({})
+    stream_post = make_stream_post({})
+    pool = Pool(
+        providers[:1],
+        quota=quota,
+        env=env,
+        post=post,
+        stream_post=stream_post,
+    )
+    httpd, base = _serve(pool)
+    try:
+        payload = {
+            "model": "auto",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        }
+        if with_tools:
+            payload["tools"] = [{"type": "function", "function": {"name": "f"}}]
+        req = urllib.request.Request(
+            base + "/v1/chat/completions",
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            raw = resp.read().decode()
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    chunks = [
+        json.loads(line.removeprefix("data: "))
+        for line in raw.splitlines()
+        if line.startswith("data: ") and line != "data: [DONE]"
+    ]
+    assert chunks
+    assert all(isinstance(chunk["created"], int) for chunk in chunks)
+    assert len({chunk["created"] for chunk in chunks}) == 1

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -154,6 +154,8 @@ def test_stream_chat_failover_before_first_byte(providers, env, quota):
     gen = pool.stream_chat([{"role": "user", "content": "hi"}], providers=["alpha", "beta"])
     meta = next(gen)
     assert meta["provider"] == "beta"  # alpha 500 → failed over before streaming
+    assert meta["attempts"] == len(sp.calls)
+    assert meta["attempts"] > 1
     assert "".join(gen) == "ok"
 
 


### PR DESCRIPTION
## Summary

- prevent async provider clients from following credential-bearing redirects
- honor OpenAI-compatible output-token fields across proxy paths and harden model parsing
- report actual live-stream failover attempts and add stable SSE `created` timestamps
- prevent second HTTP responses after commitment, close failed connections, and log handler failures
- redact unexpected MCP exception details from JSON-RPC clients while retaining local diagnostics

## Audit disposition

Seven actionable defects from `AUDIT_REPORT.md` were reproduced, filed, and fixed here. Issue #91 was closed separately as not planned after tracing proved upstream stream iterators are already closed in all exit paths. The remaining report items were verified as already-correct behavior, non-bugs, or out-of-scope observations rather than papered over.

## Verification

- full `pytest -q` suite
- `ruff check .`
- focused CI mypy gate
- catalog/count/release-readiness validators
- CI proxy stress profile
- isolated sdist and wheel build
- pre-commit Codex Sol 5.6 xhigh review: approved after one blocker was fixed and re-reviewed

Closes #87
Closes #88
Closes #89
Closes #90
Closes #92
Closes #93
Closes #94

## Summary by Sourcery

Harden proxy, router, async client, and MCP server behavior around streaming, errors, and OpenAI-compatible token limits based on audit findings.

New Features:
- Support OpenAI-compatible max_completion_tokens and max_output_tokens fields across chat, responses, battle, tokenmax, and streaming APIs, including SSE responses with stable created timestamps.

Bug Fixes:
- Prevent async HTTP provider clients from following credential-bearing redirects.
- Ensure live chat streaming status records actual failover attempts instead of a fixed value.
- Avoid double-writing HTTP responses after headers are sent and close connections when header flushes fail.
- Reject non-string model identifiers in model parsing to avoid misrouting.
- Redact unexpected MCP server exceptions from JSON-RPC error responses while retaining diagnostics in logs.

Enhancements:
- Log unexpected proxy GET/POST handler failures and MCP request failures via module loggers for better observability.
- Include consistent created timestamps on SSE chat completion chunks, and propagate attempt counts through streaming metadata.

Tests:
- Add coverage for OpenAI-compatible token limit propagation, redirect-disabled async client behavior, streaming failover attempt accounting, SSE created timestamps, handler error handling, and MCP internal error redaction.