### PR TITLE
feat: persist route health and circuit breakers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,3 +81,8 @@ SILICONFLOW_API_KEY=
 
 # LLM7 — optional key for higher limits: https://token.llm7.io
 LLM7_API_KEY=
+
+# Optional runtime state override. Recent per-route latency, normalized failure
+# class, and circuit reset times otherwise live at:
+# ~/.config/freellmpool/route_health.json
+FREELLMPOOL_HEALTH_FILE=

--- a/README.md
+++ b/README.md
@@ -519,14 +519,23 @@ batches up to `N` successful requests before flushing. Shutdown paths and
 `quota.snapshot()` flush pending counts, so dashboards and process exits still
 see current totals.
 
+Recent per-route health is persisted at
+`~/.config/freellmpool/route_health.json` (override with
+`FREELLMPOOL_HEALTH_FILE`). The bounded, atomic state contains route names,
+timings, counters, and normalized failure classes only—never prompts, responses,
+headers, or credentials. `/status` reports circuit state, sample age, and reset
+time for each enabled route.
+
 ## How routing works
 
 For each request, freellmpool builds the list of `(provider, model)` pairs you
 have access to, then orders providers least-used-first and picks a least-used
 model inside that provider. This keeps providers with large catalogs, like
 NVIDIA, from receiving more traffic only because they expose more models. A
-provider that returns a 429 is set aside for a cooldown window. Daily counts are
-kept in `~/.config/freellmpool/quota.json` and reset at UTC midnight.
+provider that returns a 429 is set aside for its advertised `Retry-After` or
+rate-limit reset window. Repeated availability failures open a per-route circuit;
+after cooldown, one half-open probe can restore the route. Daily counts are kept
+in `~/.config/freellmpool/quota.json` and reset at UTC midnight.
 
 Every call records latency and success per model target. A provider whose targets
 are currently failing sinks to the back automatically; with

--- a/src/freellmpool/aio.py
+++ b/src/freellmpool/aio.py
@@ -23,7 +23,6 @@ from .client import (
     _CONNECT_TIMEOUT,
     _THINKING_FLOOR,
     _USER_AGENT,
-    _err_message,
     _is_thinking,
     _retryable,
     _strip_think,
@@ -293,9 +292,7 @@ class AsyncPool:
                 body["tool_choice"] = tool_choice
         result = await self._apost(url, headers, body, timeout)
         if result.status != 200:
-            raise ProviderHTTPError(
-                result.status, _err_message(result), retryable=_retryable(result.status)
-            )
+            raise _client._provider_http_error(result)
         choices = result.body.get("choices") or []
         if not choices:
             raise ProviderHTTPError(502, "no choices in response", retryable=True)
@@ -334,9 +331,7 @@ class AsyncPool:
             body["systemInstruction"] = system_instruction
         result = await self._apost(url, headers, body, timeout)
         if result.status != 200:
-            raise ProviderHTTPError(
-                result.status, _err_message(result), retryable=_retryable(result.status)
-            )
+            raise _client._provider_http_error(result)
         candidates = result.body.get("candidates") or []
         if not candidates:
             raise ProviderHTTPError(502, "no candidates in response", retryable=True)
@@ -412,8 +407,11 @@ class AsyncPool:
             emit(p._on_event, "cache_miss", key=cache_key)
 
         difficulty = prompt_difficulty(messages, max_tokens, tools) if eff == "quality" else None
-        targets = p._order(
-            p._all_targets(include=provider_list, model=model), difficulty=difficulty, routing=eff
+        targets = await asyncio.to_thread(
+            p._order,
+            p._all_targets(include=provider_list, model=model),
+            difficulty,
+            eff,
         )
         if not targets:
             raise NoProvidersConfigured("no candidate (provider, model) matched the given filters")
@@ -458,6 +456,12 @@ class AsyncPool:
             if remaining <= 0:
                 attempts.append((target.name, "skipped (overall request timeout exhausted)"))
                 break
+            lease = await asyncio.to_thread(p._acquire_route, target)
+            if lease is None:
+                non_ctx_failure = True
+                attempts.append((target.name, "skipped (persistent circuit open)"))
+                emit(p._on_event, "circuit_skip", target=target.name)
+                continue
             emit(p._on_event, "attempt", target=target.name, n=len(attempts) + 1)
             try:
                 reply = await self._acall(
@@ -473,6 +477,9 @@ class AsyncPool:
             except ProviderHTTPError as exc:
                 is_ctx, limit = context_limit_from_error(exc.status, str(exc))
                 if is_ctx:
+                    await asyncio.to_thread(
+                        p._record_route_failure, target, exc, lease
+                    )
                     ctx_overflow = True
                     if limit is not None:
                         p._learn_context_limit(target.name, limit)
@@ -496,12 +503,18 @@ class AsyncPool:
                     client_error = exc
                 if _is_health_failure(exc):
                     p.metrics.record_failure(target.name, str(exc))
+                await asyncio.to_thread(
+                    p._record_route_failure, target, exc, lease
+                )
                 emit(p._on_event, "error", target=target.name, reason=str(exc))
                 attempts.append((target.name, str(exc)))
                 continue
             except Exception as exc:  # noqa: BLE001
                 non_ctx_failure = True
                 p.metrics.record_failure(target.name, f"{type(exc).__name__}: {exc}")
+                await asyncio.to_thread(
+                    p._record_route_failure, target, exc, lease
+                )
                 emit(p._on_event, "error", target=target.name, reason=f"{type(exc).__name__}")
                 attempts.append((target.name, f"{type(exc).__name__}: {exc}"))
                 continue
@@ -510,12 +523,16 @@ class AsyncPool:
             if not reply.text and not has_tool_calls:
                 non_ctx_failure = True
                 p.metrics.record_failure(target.name, "empty completion")
+                await asyncio.to_thread(p._record_route_empty, target, lease)
                 emit(p._on_event, "error", target=target.name, reason="empty completion")
                 attempts.append((target.name, "empty completion"))
                 continue
 
             latency_ms = max(0.0, (p._clock() - started) * 1000.0)
             p.metrics.record_success(target.name, latency_ms)
+            await asyncio.to_thread(
+                p._record_route_success, target, latency_ms, lease
+            )
             emit(
                 p._on_event,
                 "success",

--- a/src/freellmpool/client.py
+++ b/src/freellmpool/client.py
@@ -79,7 +79,10 @@ PostFn = Callable[[str, dict, dict, float], HTTPResult]
 # keeps the connection open until exhausted/closed.
 from collections.abc import Iterable, Iterator  # noqa: E402
 
-StreamPostFn = Callable[[str, dict, dict, float], "tuple[int, Iterable[str]]"]
+StreamPostFn = Callable[
+    [str, dict, dict, float],
+    "tuple[int, Iterable[str]] | tuple[int, dict, Iterable[str]]",
+]
 
 _USER_AGENT = f"freellmpool/{__version__} (+https://github.com/0xzr/freellmpool)"
 
@@ -222,17 +225,36 @@ def _header(headers: dict | None, name: str) -> str | None:
 
 def _retry_after_seconds(headers: dict | None) -> float | None:
     raw = _header(headers, "Retry-After")
-    if not raw:
-        return None
-    raw = raw.strip()
-    try:
-        return max(0.0, float(raw))
-    except ValueError:
-        pass
-    try:
-        return max(0.0, parsedate_to_datetime(raw).timestamp() - time.time())
-    except (TypeError, ValueError, OSError):
-        return None
+    if raw:
+        raw = raw.strip()
+        try:
+            return max(0.0, float(raw))
+        except ValueError:
+            pass
+        try:
+            return max(0.0, parsedate_to_datetime(raw).timestamp() - time.time())
+        except (TypeError, ValueError, OSError):
+            pass
+
+    # RFC RateLimit-Reset is a delay in seconds. The widespread legacy
+    # X-RateLimit-Reset convention is usually a Unix timestamp, though some
+    # providers return a delay; distinguish epoch-shaped values conservatively.
+    reset = _header(headers, "RateLimit-Reset")
+    if reset:
+        try:
+            return max(0.0, float(reset.strip()))
+        except ValueError:
+            pass
+    legacy = _header(headers, "X-RateLimit-Reset")
+    if legacy:
+        try:
+            value = float(legacy.strip())
+        except ValueError:
+            return None
+        if value >= 1_000_000_000:
+            return max(0.0, value - time.time())
+        return max(0.0, value)
+    return None
 
 
 def _retry_delay(result: HTTPResult | None, attempt: int, deadline: float) -> float | None:
@@ -300,7 +322,7 @@ class _StreamLines:
 
 
 def default_stream_post(url: str, headers: dict, json_body: dict, timeout: float):
-    """Open a streaming POST on the pooled client and return (status, line iter)."""
+    """Open a streaming POST and retain response headers for reset guidance."""
     deadline = time.monotonic() + timeout
     cm = _client().stream("POST", url, headers=headers, json=json_body, timeout=_timeout(timeout))
     try:
@@ -308,7 +330,11 @@ def default_stream_post(url: str, headers: dict, json_body: dict, timeout: float
     except BaseException:  # opening the stream failed — release the connection
         cm.__exit__(*sys.exc_info())
         raise
-    return resp.status_code, _StreamLines(cm, resp, deadline=deadline)
+    return (
+        resp.status_code,
+        dict(getattr(resp, "headers", {}) or {}),
+        _StreamLines(cm, resp, deadline=deadline),
+    )
 
 
 def stream_call(
@@ -343,7 +369,12 @@ def stream_call(
         "temperature": temperature,
         "stream": True,
     }
-    status, line_iter = stream_post(url, headers, body, timeout)
+    opened = stream_post(url, headers, body, timeout)
+    if len(opened) == 2:
+        status, line_iter = opened
+        response_headers = None
+    else:
+        status, response_headers, line_iter = opened
     close = getattr(line_iter, "close", lambda: None)
     if status != 200:
         # Drain a *bounded* prefix of the error body so the router can classify it
@@ -361,7 +392,15 @@ def stream_call(
         finally:
             close()
         err_body = "".join(parts)[:500]
-        raise ProviderHTTPError(status, err_body or f"HTTP {status}", retryable=_retryable(status))
+        raise _provider_http_error(
+            HTTPResult(
+                status=status,
+                body={},
+                text=err_body or f"HTTP {status}",
+                headers=response_headers,
+            )
+        )
+    done = False
     try:
         for line in line_iter:
             if not line:
@@ -371,6 +410,7 @@ def stream_call(
             line = line.strip()
             if not line or line == "[DONE]":
                 if line == "[DONE]":
+                    done = True
                     break
                 continue
             try:
@@ -381,6 +421,12 @@ def stream_call(
             delta = (choices[0].get("delta") or {}).get("content")
             if delta:
                 yield delta
+        if not done:
+            raise ProviderHTTPError(
+                502,
+                "stream ended before [DONE]",
+                retryable=True,
+            )
     finally:
         close()
 
@@ -399,6 +445,16 @@ def _err_message(result: HTTPResult) -> str:
     if isinstance(err, str):
         return err
     return (result.text or "").strip()[:200] or "no body"
+
+
+def _provider_http_error(result: HTTPResult) -> ProviderHTTPError:
+    """Build an HTTP error without discarding provider backoff guidance."""
+    return ProviderHTTPError(
+        result.status,
+        _err_message(result),
+        retryable=_retryable(result.status),
+        retry_after=_retry_after_seconds(result.headers),
+    )
 
 
 def _to_gemini_contents(messages: list[Message]) -> tuple[dict | None, list[dict]]:
@@ -569,9 +625,7 @@ def _call_openai(
             body["tool_choice"] = tool_choice
     result = post(url, headers, body, timeout)
     if result.status != 200:
-        raise ProviderHTTPError(
-            result.status, _err_message(result), retryable=_retryable(result.status)
-        )
+        raise _provider_http_error(result)
 
     choices = result.body.get("choices") or []
     if not choices:
@@ -620,9 +674,7 @@ def embed(
         body["input_type"] = "query"
     result = post(url, headers, body, timeout)
     if result.status != 200:
-        raise ProviderHTTPError(
-            result.status, _err_message(result), retryable=_retryable(result.status)
-        )
+        raise _provider_http_error(result)
     data = result.body.get("data") or []
     if not data:
         raise ProviderHTTPError(502, "no embeddings in response", retryable=True)
@@ -736,9 +788,7 @@ def transcribe(
         data["language"] = language
     result = post(url, headers, files, data, timeout)
     if result.status != 200:
-        raise ProviderHTTPError(
-            result.status, _err_message(result), retryable=_retryable(result.status)
-        )
+        raise _provider_http_error(result)
     body = result.body if isinstance(result.body, dict) else {}
     raw_text = body.get("text")
     # `default_multipart_post` always lands the transcript under body["text"] (plain-text
@@ -787,9 +837,7 @@ def _call_gemini(
 
     result = post(url, headers, body, timeout)
     if result.status != 200:
-        raise ProviderHTTPError(
-            result.status, _err_message(result), retryable=_retryable(result.status)
-        )
+        raise _provider_http_error(result)
 
     candidates = result.body.get("candidates") or []
     if not candidates:

--- a/src/freellmpool/errors.py
+++ b/src/freellmpool/errors.py
@@ -68,7 +68,15 @@ class ProviderHTTPError(FreeLLMPoolError):
     router should move on to another provider (True) or give up (False).
     """
 
-    def __init__(self, status: int, message: str, *, retryable: bool):
+    def __init__(
+        self,
+        status: int,
+        message: str,
+        *,
+        retryable: bool,
+        retry_after: float | None = None,
+    ):
         self.status = status
         self.retryable = retryable
+        self.retry_after = retry_after
         super().__init__(f"HTTP {status}: {message}")

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -132,6 +132,7 @@ def _readiness_snapshot(pool: Pool) -> ReadinessSnapshot:
         env=pool.env,
         quota=pool.quota.snapshot(),
         cooldowns=pool.cooldown_snapshot(now),
+        route_cooldowns=pool.route_cooldown_snapshot(),
     )
 
 
@@ -173,11 +174,52 @@ def _status_payload(pool: Pool, recent: Sequence[dict], tokenmax: dict | None = 
     now = pool._clock()
     quota_snap = pool.quota.snapshot()
     metrics_snap = pool.metrics.snapshot()
+    health_snap = pool.route_health_snapshot()
+    health_store = pool.route_health
     cooldown_snap = pool.cooldown_snapshot(now)  # locked read; no torn cooldown state
+
+    def modality_routes(providers) -> list[dict]:
+        rows = []
+        for provider in providers:
+            for model in provider.models:
+                if not model.enabled:
+                    continue
+                persistent = health_snap.get(f"{provider.id}/{model.name}")
+                rows.append(
+                    {
+                        "provider": provider.id,
+                        "name": model.name,
+                        "circuit_state": persistent.state if persistent else "closed",
+                        "consecutive_failures": (
+                            persistent.consecutive_failures if persistent else 0
+                        ),
+                        "failure_class": (
+                            persistent.failure_class if persistent else None
+                        ),
+                        "ewma_ms": persistent.ewma_ms if persistent else None,
+                        "success_rate": (
+                            persistent.success_rate
+                            if persistent and persistent.total
+                            else None
+                        ),
+                        "sample_age_s": (
+                            health_store.sample_age(persistent)
+                            if health_store is not None
+                            else None
+                        ),
+                        "reset_remaining_s": (
+                            health_store.reset_remaining(persistent)
+                            if health_store is not None
+                            else 0.0
+                        ),
+                    }
+                )
+        return rows
 
     providers_list = []
     for p in pool.providers:
         cooldown_remaining = cooldown_snap.get(p.id, 0.0)
+        provider_health = health_snap.get(f"{p.id}/*")
 
         models_list = []
         for m in p.models:
@@ -187,15 +229,39 @@ def _status_payload(pool: Pool, recent: Sequence[dict], tokenmax: dict | None = 
             used = quota_snap.get(key, 0)
             remaining = (m.rpd - used) if m.rpd > 0 else None
             stat = metrics_snap.get(f"{p.id}/{m.name}")
+            persistent = health_snap.get(f"{p.id}/{m.name}")
             models_list.append(
                 {
                     "name": m.name,
                     "rpd": m.rpd,
                     "used_today": used,
                     "remaining": remaining,
-                    "ewma_ms": stat.ewma_ms if stat else None,
-                    "success_rate": stat.success_rate if stat else None,
+                    "ewma_ms": (
+                        persistent.ewma_ms
+                        if persistent and persistent.ewma_ms is not None
+                        else stat.ewma_ms if stat else None
+                    ),
+                    "success_rate": (
+                        persistent.success_rate
+                        if persistent and persistent.total
+                        else stat.success_rate if stat else None
+                    ),
                     "last_error": stat.last_error if stat else None,
+                    "circuit_state": persistent.state if persistent else "closed",
+                    "consecutive_failures": (
+                        persistent.consecutive_failures if persistent else 0
+                    ),
+                    "failure_class": persistent.failure_class if persistent else None,
+                    "sample_age_s": (
+                        health_store.sample_age(persistent)
+                        if health_store is not None
+                        else None
+                    ),
+                    "reset_remaining_s": (
+                        health_store.reset_remaining(persistent)
+                        if health_store is not None
+                        else 0.0
+                    ),
                 }
             )
 
@@ -204,6 +270,17 @@ def _status_payload(pool: Pool, recent: Sequence[dict], tokenmax: dict | None = 
                 "id": p.id,
                 "configured": p.is_configured(pool.env),
                 "cooldown_remaining_s": cooldown_remaining,
+                "circuit_state": (
+                    provider_health.state if provider_health else "closed"
+                ),
+                "failure_class": (
+                    provider_health.failure_class if provider_health else None
+                ),
+                "sample_age_s": (
+                    health_store.sample_age(provider_health)
+                    if health_store is not None
+                    else None
+                ),
                 "models": models_list,
             }
         )
@@ -231,6 +308,10 @@ def _status_payload(pool: Pool, recent: Sequence[dict], tokenmax: dict | None = 
             "first_seen": life.get("first_seen"),
         },
         "providers": providers_list,
+        "routes": {
+            "embeddings": modality_routes(pool.embedders),
+            "transcriptions": modality_routes(pool.transcribers),
+        },
         "recent": list(recent),
         "tokenmax": tokenmax or {"active": False},
     }

--- a/src/freellmpool/readiness.py
+++ b/src/freellmpool/readiness.py
@@ -161,20 +161,31 @@ def readiness_snapshot(
     env: Mapping[str, str],
     quota: Mapping[str, int],
     cooldowns: Mapping[str, float],
+    route_cooldowns: Mapping[str, float] | None = None,
 ) -> ReadinessSnapshot:
     """Build a deterministic snapshot without calling an upstream provider."""
     env_copy = dict(env)
+    route_cooldowns = route_cooldowns or {}
     rows: list[ProviderReadiness] = []
     for provider in providers:
         configured = provider.is_configured(env_copy)
         enabled = [model for model in provider.models if model.enabled]
-        cooldown = max(0.0, float(cooldowns.get(provider.id, 0.0)))
+        provider_cooldown = max(0.0, float(cooldowns.get(provider.id, 0.0)))
+        model_cooldowns = {
+            model.name: max(
+                provider_cooldown,
+                0.0,
+                float(route_cooldowns.get(f"{provider.id}/{model.name}", 0.0)),
+            )
+            for model in enabled
+        }
+        cooldown = max((provider_cooldown, *model_cooldowns.values()))
         models = tuple(
             _model_readiness(
                 provider.id,
                 model,
                 configured=configured,
-                cooled=cooldown > 0,
+                cooled=model_cooldowns[model.name] > 0,
                 used=int(quota.get(f"{provider.id}::{model.name}", 0)),
             )
             for model in enabled
@@ -184,12 +195,12 @@ def readiness_snapshot(
             status: ReadinessStatus = "unconfigured"
         elif not enabled:
             status = "no_enabled_models"
-        elif cooldown > 0:
-            status = "cooldown"
-        elif all(model.status == "quota_exhausted" for model in models):
-            status = "quota_exhausted"
-        else:
+        elif any(model.ready for model in models):
             status = "ready"
+        elif any(model.status == "cooldown" for model in models):
+            status = "cooldown"
+        else:
+            status = "quota_exhausted"
         ready_models = sum(model.ready for model in models)
         rows.append(
             ProviderReadiness(

--- a/src/freellmpool/route_health.py
+++ b/src/freellmpool/route_health.py
@@ -1,0 +1,615 @@
+"""Persistent, privacy-safe per-route health and circuit breakers."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import tempfile
+import threading
+import time
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - exercised on POSIX CI; fallback keeps Windows usable
+    import fcntl
+except ImportError:  # pragma: no cover
+    fcntl = None
+
+try:  # pragma: no cover - imported only on Windows
+    import msvcrt
+except ImportError:  # pragma: no cover
+    msvcrt = None
+
+_VERSION = 1
+_VALID_STATES = {"closed", "open", "half_open"}
+_VALID_FAILURE_CLASSES = {
+    "auth",
+    "availability",
+    "capability",
+    "client",
+    "empty",
+    "provider_quota",
+    "rate_limit",
+    "retirement",
+    "timeout",
+    "transport",
+    "other",
+}
+_MAX_SAMPLES = 1_000
+_MAX_INTEGER = 2**63 - 1
+_MAX_STATE_BYTES = 2_000_000
+_UNKNOWN_SCORE = 0.5
+_PATH_LOCKS: dict[str, threading.RLock] = {}
+_PATH_LOCKS_GUARD = threading.Lock()
+
+
+def default_route_health_path(env: dict[str, str] | None = None) -> Path:
+    env = env if env is not None else dict(os.environ)
+    override = env.get("FREELLMPOOL_HEALTH_FILE")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".config" / "freellmpool" / "route_health.json"
+
+
+@dataclass(frozen=True)
+class HealthRecord:
+    """Sanitized rolling health for one ``provider/model`` or ``provider/*`` key."""
+
+    state: str = "closed"
+    successes: int = 0
+    failures: int = 0
+    consecutive_failures: int = 0
+    ewma_ms: float | None = None
+    last_success: float | None = None
+    last_failure: float | None = None
+    failure_class: str | None = None
+    open_until: float = 0.0
+    half_open_until: float = 0.0
+    lease_generation: int = 0
+    open_count: int = 0
+    updated_at: float = 0.0
+
+    @property
+    def total(self) -> int:
+        return self.successes + self.failures
+
+    @property
+    def success_rate(self) -> float:
+        return 1.0 if self.total == 0 else self.successes / self.total
+
+
+@dataclass(frozen=True)
+class HealthLease:
+    """Attempt ownership used to reject out-of-order circuit transitions."""
+
+    started_at: float
+    generations: dict[str, int]
+
+
+@dataclass(frozen=True)
+class FailureUpdate:
+    key: str
+    failure_class: str
+    retry_after: float | None = None
+    counts_for_health: bool = True
+    open_immediately: bool = False
+
+
+class RouteHealthStore:
+    """Atomic, corruption-tolerant rolling health shared by CLI/proxy processes.
+
+    Only route identifiers, timing, counters, and a normalized failure class are
+    persisted. Prompt text, response content, raw errors, headers, and credentials
+    are never accepted by this API.
+    """
+
+    def __init__(
+        self,
+        *,
+        path: Path | None = None,
+        clock: Callable[[], float] | None = None,
+        max_entries: int = 512,
+        stale_after: float = 7 * 24 * 60 * 60,
+        failure_threshold: int = 3,
+        base_cooldown: float = 60.0,
+        max_cooldown: float = 60 * 60,
+        half_open_lease: float = 30.0,
+        alpha: float = 0.3,
+    ):
+        self.path = path or default_route_health_path()
+        self._lock_path = self.path.with_name(f"{self.path.name}.lock")
+        self._clock = clock or time.time
+        self.max_entries = max(1, int(max_entries))
+        self.stale_after = max(0.0, float(stale_after))
+        self.failure_threshold = max(1, int(failure_threshold))
+        self.base_cooldown = max(0.0, float(base_cooldown))
+        self.max_cooldown = max(self.base_cooldown, float(max_cooldown))
+        self.half_open_lease = max(1.0, float(half_open_lease))
+        self.alpha = max(0.0, min(1.0, float(alpha)))
+        self._thread_lock = threading.RLock()
+        self._fallback: dict[str, dict[str, Any]] = {}
+
+    def snapshot(self) -> dict[str, HealthRecord]:
+        """Return fresh non-stale records; unreadable/corrupt state behaves empty."""
+        now = self._clock()
+        with self._thread_lock:
+            try:
+                with self._file_lock():
+                    routes = self._load()
+                clean = self._bound(self._clean(routes, now))
+                self._fallback = clean
+            except OSError:
+                clean = self._bound(self._clean(dict(self._fallback), now))
+            return {key: _record(row) for key, row in clean.items()}
+
+    def state(self, key: str) -> HealthRecord | None:
+        return self.snapshot().get(key)
+
+    def sample_age(self, row: HealthRecord | None) -> float | None:
+        if row is None:
+            return None
+        return max(0.0, self._clock() - row.updated_at)
+
+    def reset_remaining(self, row: HealthRecord | None) -> float:
+        if row is None:
+            return 0.0
+        now = self._clock()
+        if row.state == "half_open":
+            return max(0.0, row.half_open_until - now)
+        if row.state == "open":
+            return max(0.0, row.open_until - now)
+        return 0.0
+
+    def provider_cooldowns(self) -> dict[str, float]:
+        """Provider-wide persistent circuit reset times, in seconds remaining."""
+        return {
+            key[:-2]: self.reset_remaining(row)
+            for key, row in self.snapshot().items()
+            if key.endswith("/*") and row.state != "closed"
+        }
+
+    def route_cooldowns(self) -> dict[str, float]:
+        """Per-model persistent circuit reset times, in seconds remaining."""
+        return {
+            key: self.reset_remaining(row)
+            for key, row in self.snapshot().items()
+            if not key.endswith("/*") and row.state != "closed"
+        }
+
+    def allow(self, key: str) -> bool:
+        """Acquire permission for a request, including a single half-open lease."""
+        return self.allow_many((key,))
+
+    def allow_many(self, keys) -> bool:
+        """Atomically acquire all route/provider circuit leases or none of them."""
+        return self.acquire_many(keys) is not None
+
+    def acquire_many(self, keys) -> HealthLease | None:
+        """Acquire circuits and return ownership for conditional result updates."""
+        requested = tuple(dict.fromkeys(key for key in keys if _valid_key(key)))
+        if not requested:
+            return HealthLease(started_at=self._clock(), generations={})
+
+        def mutate(
+            routes: dict[str, dict[str, Any]], now: float
+        ) -> tuple[HealthLease | None, bool]:
+            for key in requested:
+                row = routes.get(key)
+                if row is None:
+                    continue
+                state = _state(row.get("state"))
+                open_until = _number(row.get("open_until")) or 0.0
+                half_open_until = _number(row.get("half_open_until")) or 0.0
+                if state == "open" and open_until > now:
+                    return None, False
+                if state == "half_open" and half_open_until > now:
+                    return None, False
+            for key in requested:
+                created = key not in routes
+                row = routes.setdefault(key, {})
+                generation = _integer(row.get("lease_generation"))
+                row["lease_generation"] = (
+                    1 if generation >= _MAX_INTEGER else generation + 1
+                )
+                if _state(row.get("state")) != "closed":
+                    row["state"] = "half_open"
+                    row["half_open_until"] = now + self.half_open_lease
+                    row["updated_at"] = now
+                elif created:
+                    row["updated_at"] = now
+            generations = {
+                key: _integer(routes.get(key, {}).get("lease_generation"))
+                for key in requested
+            }
+            return HealthLease(now, generations), True
+
+        return self._update(mutate)
+
+    def record_success(
+        self,
+        key: str,
+        latency_ms: float,
+        *,
+        lease: HealthLease | None = None,
+    ) -> None:
+        self.record_success_many((key,), latency_ms, lease=lease)
+
+    def record_success_many(
+        self,
+        keys,
+        latency_ms: float,
+        *,
+        lease: HealthLease | None = None,
+    ) -> None:
+        requested = tuple(dict.fromkeys(key for key in keys if _valid_key(key)))
+        if not requested:
+            return
+        latency = _number(latency_ms)
+        if latency is None or latency < 0:
+            latency = 0.0
+
+        def mutate(routes: dict[str, dict[str, Any]], now: float) -> tuple[None, bool]:
+            for key in requested:
+                row = routes.setdefault(key, {})
+                _roll_counts(row)
+                row["successes"] = _integer(row.get("successes")) + 1
+                previous = _number(row.get("ewma_ms"))
+                row["ewma_ms"] = (
+                    latency
+                    if previous is None
+                    else self.alpha * latency + (1.0 - self.alpha) * previous
+                )
+                if _owns_transition(row, key, lease):
+                    row.update(
+                        {
+                            "state": "closed",
+                            "consecutive_failures": 0,
+                            "last_success": now,
+                            "failure_class": None,
+                            "open_until": 0.0,
+                            "half_open_until": 0.0,
+                            "open_count": 0,
+                        }
+                    )
+                row["updated_at"] = now
+            return None, True
+
+        self._update(mutate)
+
+    def record_failure(
+        self,
+        key: str,
+        failure_class: str,
+        *,
+        retry_after: float | None = None,
+        counts_for_health: bool = True,
+        open_immediately: bool = False,
+        lease: HealthLease | None = None,
+    ) -> None:
+        self.record_failures(
+            (
+                FailureUpdate(
+                    key=key,
+                    failure_class=failure_class,
+                    retry_after=retry_after,
+                    counts_for_health=counts_for_health,
+                    open_immediately=open_immediately,
+                ),
+            ),
+            lease=lease,
+        )
+
+    def record_failures(
+        self,
+        updates,
+        *,
+        lease: HealthLease | None = None,
+    ) -> None:
+        requested = tuple(update for update in updates if _valid_key(update.key))
+        if not requested:
+            return
+
+        def mutate(routes: dict[str, dict[str, Any]], now: float) -> tuple[None, bool]:
+            dirty = False
+            for update in requested:
+                key = update.key
+                classification = (
+                    update.failure_class
+                    if isinstance(update.failure_class, str)
+                    and update.failure_class in _VALID_FAILURE_CLASSES
+                    else "other"
+                )
+                retry = _number(update.retry_after)
+                if retry is not None:
+                    retry = max(0.0, retry)
+                row = routes.setdefault(key, {})
+                state = _state(row.get("state"))
+                owns_transition = _owns_transition(row, key, lease)
+                if update.counts_for_health:
+                    _roll_counts(row)
+                    row["failures"] = _integer(row.get("failures")) + 1
+                    if owns_transition:
+                        row["consecutive_failures"] = (
+                            _integer(row.get("consecutive_failures")) + 1
+                        )
+                else:
+                    row.setdefault("successes", 0)
+                    row.setdefault("failures", 0)
+                    row.setdefault("consecutive_failures", 0)
+                    # A non-availability response proves the endpoint answered.
+                    if owns_transition and state == "half_open":
+                        row.update(
+                            {
+                                "state": "closed",
+                                "consecutive_failures": 0,
+                                "open_until": 0.0,
+                                "half_open_until": 0.0,
+                                "open_count": 0,
+                            }
+                        )
+                should_open = (
+                    owns_transition
+                    and update.counts_for_health
+                    and (
+                        update.open_immediately
+                        or state == "half_open"
+                        or _integer(row.get("consecutive_failures"))
+                        >= self.failure_threshold
+                    )
+                )
+                if should_open:
+                    open_count = _integer(row.get("open_count")) + 1
+                    cooldown = (
+                        retry
+                        if retry is not None
+                        else min(
+                            self.max_cooldown,
+                            self.base_cooldown * (2 ** min(open_count - 1, 10)),
+                        )
+                    )
+                    row.update(
+                        {
+                            "state": "open",
+                            "open_until": now + cooldown,
+                            "half_open_until": 0.0,
+                            "open_count": open_count,
+                        }
+                    )
+                elif owns_transition:
+                    row.setdefault("state", "closed")
+                    row.setdefault("open_until", 0.0)
+                    row.setdefault("half_open_until", 0.0)
+                    row.setdefault("open_count", 0)
+                if owns_transition:
+                    row["last_failure"] = now
+                    row["failure_class"] = classification
+                row["updated_at"] = now
+                dirty = dirty or update.counts_for_health or owns_transition
+            return None, dirty
+
+        self._update(mutate)
+
+    def routing_penalty(self, key: str) -> float:
+        return score_record(self.state(key))
+
+    def failing(self, key: str) -> bool:
+        row = self.state(key)
+        return bool(
+            row
+            and (
+                row.state != "closed"
+                or row.consecutive_failures >= self.failure_threshold
+            )
+        )
+
+    def _update(self, mutator):
+        now = self._clock()
+        with self._thread_lock:
+            try:
+                with self._file_lock():
+                    routes = self._clean(self._load(), now)
+                    result, dirty = mutator(routes, now)
+                    routes = self._bound(routes)
+                    if dirty:
+                        self._write(routes)
+                self._fallback = routes
+                return result
+            except (OSError, OverflowError, ValueError):
+                routes = self._clean(dict(self._fallback), now)
+                result, _dirty = mutator(routes, now)
+                self._fallback = self._bound(routes)
+                return result
+
+    @contextmanager
+    def _file_lock(self) -> Iterator[None]:
+        path_key = str(self._lock_path.absolute())
+        with _PATH_LOCKS_GUARD:
+            local_lock = _PATH_LOCKS.setdefault(path_key, threading.RLock())
+        with local_lock:
+            self.path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            with self._lock_path.open("a+b") as lock_file:
+                try:
+                    os.chmod(self._lock_path, 0o600)
+                except OSError:
+                    pass
+                if fcntl is not None:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                elif msvcrt is not None:  # pragma: no cover - Windows only
+                    lock_file.seek(0, os.SEEK_END)
+                    if lock_file.tell() == 0:
+                        lock_file.write(b"\0")
+                        lock_file.flush()
+                    lock_file.seek(0)
+                    msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+                try:
+                    yield
+                finally:
+                    if fcntl is not None:
+                        fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+                    elif msvcrt is not None:  # pragma: no cover - Windows only
+                        lock_file.seek(0)
+                        msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+
+    def _load(self) -> dict[str, dict[str, Any]]:
+        try:
+            with self.path.open("rb") as handle:
+                raw = handle.read(_MAX_STATE_BYTES + 1)
+            if len(raw) > _MAX_STATE_BYTES:
+                return {}
+            data = json.loads(raw.decode("utf-8"))
+        except (OSError, ValueError, UnicodeError):
+            return {}
+        if not isinstance(data, dict) or data.get("version") != _VERSION:
+            return {}
+        routes = data.get("routes")
+        if not isinstance(routes, dict):
+            return {}
+        return {
+            key: dict(row)
+            for key, row in routes.items()
+            if _valid_key(key) and isinstance(row, dict)
+        }
+
+    def _clean(
+        self, routes: dict[str, dict[str, Any]], now: float
+    ) -> dict[str, dict[str, Any]]:
+        if self.stale_after <= 0:
+            return routes
+        return {
+            key: row
+            for key, row in routes.items()
+            if now - (_number(row.get("updated_at")) or 0.0) <= self.stale_after
+        }
+
+    def _bound(self, routes: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+        if len(routes) <= self.max_entries:
+            return routes
+        newest = sorted(
+            routes,
+            key=lambda key: _number(routes[key].get("updated_at")) or 0.0,
+            reverse=True,
+        )[: self.max_entries]
+        return {key: routes[key] for key in newest}
+
+    def _write(self, routes: dict[str, dict[str, Any]]) -> None:
+        payload = {
+            "version": _VERSION,
+            "routes": {
+                key: asdict(_record(row))
+                for key, row in sorted(routes.items())
+            },
+        }
+        fd, temp_name = tempfile.mkstemp(
+            prefix=f".{self.path.name}.", dir=self.path.parent
+        )
+        try:
+            os.chmod(temp_name, 0o600)
+            handle = os.fdopen(fd, "w", encoding="utf-8")
+            fd = -1
+            with handle:
+                json.dump(payload, handle, sort_keys=True, separators=(",", ":"))
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_name, self.path)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                os.unlink(temp_name)
+            except FileNotFoundError:
+                pass
+
+
+def _valid_key(value: object) -> bool:
+    return (
+        isinstance(value, str)
+        and 0 < len(value) <= 300
+        and all(ord(char) >= 32 and char not in "\r\n\0" for char in value)
+    )
+
+
+def score_record(row: HealthRecord | None) -> float:
+    """Routing penalty for an already-snapshotted persistent health record."""
+    if row is None or row.total == 0:
+        return _UNKNOWN_SCORE
+    latency_s = (row.ewma_ms or 0.0) / 1000.0
+    circuit = 50.0 if row.state != "closed" else 0.0
+    return circuit + (1.0 - row.success_rate) * 10.0 + min(latency_s, 10.0) * 0.1
+
+
+def _number(value: object) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        result = float(value)
+    except (OverflowError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _integer(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        result = int(value)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+    return min(_MAX_INTEGER, max(0, result))
+
+
+def _state(value: object) -> str:
+    return value if isinstance(value, str) and value in _VALID_STATES else "closed"
+
+
+def _record(row: dict[str, Any]) -> HealthRecord:
+    failure_class = row.get("failure_class")
+    if not isinstance(failure_class, str) or failure_class not in _VALID_FAILURE_CLASSES:
+        failure_class = None
+    return HealthRecord(
+        state=_state(row.get("state")),
+        successes=_integer(row.get("successes")),
+        failures=_integer(row.get("failures")),
+        consecutive_failures=_integer(row.get("consecutive_failures")),
+        ewma_ms=_number(row.get("ewma_ms")),
+        last_success=_number(row.get("last_success")),
+        last_failure=_number(row.get("last_failure")),
+        failure_class=failure_class,
+        open_until=_number(row.get("open_until")) or 0.0,
+        half_open_until=_number(row.get("half_open_until")) or 0.0,
+        lease_generation=_integer(row.get("lease_generation")),
+        open_count=_integer(row.get("open_count")),
+        updated_at=_number(row.get("updated_at")) or 0.0,
+    )
+
+
+def _roll_counts(row: dict[str, Any]) -> None:
+    successes = _integer(row.get("successes"))
+    failures = _integer(row.get("failures"))
+    if successes + failures >= _MAX_SAMPLES:
+        row["successes"] = successes // 2
+        row["failures"] = failures // 2
+
+
+def _owns_transition(
+    row: dict[str, Any],
+    key: str,
+    lease: HealthLease | None,
+) -> bool:
+    if lease is None:
+        return True
+    if lease.generations.get(key) != _integer(row.get("lease_generation")):
+        return False
+    latest = max(
+        _number(row.get("last_success")) or 0.0,
+        _number(row.get("last_failure")) or 0.0,
+    )
+    if latest > lease.started_at:
+        return False
+    if _state(row.get("state")) == "half_open":
+        return lease.generations.get(key) == _integer(row.get("lease_generation"))
+    return True

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -46,6 +46,13 @@ from .metrics import Metrics, score_stat
 from .models import EmbedReply, Provider, Reply, TranscribeReply
 from .observe import EventHook, emit
 from .quota import QuotaStore
+from .route_health import (
+    FailureUpdate,
+    HealthLease,
+    RouteHealthStore,
+    default_route_health_path,
+    score_record,
+)
 from .routing_modes import normalize_routing_mode
 from .stats import StatsStore
 
@@ -106,6 +113,29 @@ def _is_account_quota_exhaustion(exc: ProviderHTTPError) -> bool:
     )
 
 
+def _health_failure_class(exc: Exception) -> str:
+    """Reduce failures to a privacy-safe class suitable for persistent state."""
+    if isinstance(exc, ProviderHTTPError):
+        if _is_account_quota_exhaustion(exc):
+            return "provider_quota"
+        if exc.status == 429:
+            return "rate_limit"
+        if exc.status == 408:
+            return "timeout"
+        if exc.status >= 500:
+            return "availability"
+        if exc.status in (401, 403):
+            return "auth"
+        if exc.status in (404, 410):
+            return "retirement"
+        if exc.status == 402:
+            return "capability"
+        return "client"
+    if isinstance(exc, TimeoutError):
+        return "timeout"
+    return "transport"
+
+
 @dataclass(frozen=True)
 class Target:
     """A concrete (provider, model) pair the router can call."""
@@ -150,6 +180,7 @@ class Pool:
         routing: str = "fair",
         on_event: EventHook | None = None,
         stats_store: StatsStore | None = None,
+        route_health: RouteHealthStore | None = None,
     ):
         self.providers = providers
         targets: list[Target] = []
@@ -185,6 +216,7 @@ class Pool:
         self.cooldown_seconds = cooldown_seconds
         self._clock = clock or time.monotonic
         self.metrics = metrics or Metrics()
+        self.route_health = route_health
         # "fair"   — least-used provider first, then least-used model in provider.
         # "fast"   — lowest measured provider latency / failure penalty first.
         # "quality"— match prompt difficulty to model capability (benchmark-scored),
@@ -231,7 +263,7 @@ class Pool:
         """Provider -> seconds remaining for transient or account-quota backoff."""
         with self._cooldown_lock:
             provider_ids = self._cooldown_until.keys() | self._account_backoff_until.keys()
-            return {
+            result = {
                 provider_id: max(
                     0.0,
                     self._cooldown_until.get(provider_id, 0.0) - now,
@@ -239,6 +271,10 @@ class Pool:
                 )
                 for provider_id in provider_ids
             }
+        if self.route_health is not None:
+            for provider_id, remaining in self.route_health.provider_cooldowns().items():
+                result[provider_id] = max(result.get(provider_id, 0.0), remaining)
+        return result
 
     def lifetime_stats(self) -> dict:
         """Persistent lifetime totals (+ first_seen), or the in-memory session
@@ -246,6 +282,85 @@ class Pool:
         if self._stats_store is not None:
             return self._stats_store.snapshot()
         return {**self.stats_snapshot(), "first_seen": None}
+
+    def route_health_snapshot(self):
+        """Persistent health rows for status surfaces, or an empty mapping."""
+        return self.route_health.snapshot() if self.route_health is not None else {}
+
+    def route_cooldown_snapshot(self) -> dict[str, float]:
+        """Persistent per-model circuit reset times for readiness surfaces."""
+        return self.route_health.route_cooldowns() if self.route_health is not None else {}
+
+    def _acquire_route(self, target: Target) -> HealthLease | None:
+        if self.route_health is None:
+            return HealthLease(started_at=time.time(), generations={})
+        return self.route_health.acquire_many(
+            (f"{target.provider.id}/*", target.name)
+        )
+
+    def _record_route_success(
+        self,
+        target: Target,
+        latency_ms: float,
+        lease: HealthLease,
+    ) -> None:
+        if self.route_health is None:
+            return
+        self.route_health.record_success_many(
+            (target.name, f"{target.provider.id}/*"),
+            latency_ms,
+            lease=lease,
+        )
+
+    def _record_route_failure(
+        self,
+        target: Target,
+        exc: Exception,
+        lease: HealthLease,
+    ) -> None:
+        if self.route_health is None:
+            return
+        failure_class = _health_failure_class(exc)
+        counts = _is_health_failure(exc)
+        retry_after = exc.retry_after if isinstance(exc, ProviderHTTPError) else None
+        updates = [
+            FailureUpdate(
+                key=target.name,
+                failure_class=failure_class,
+                retry_after=retry_after,
+                counts_for_health=counts,
+                open_immediately=(
+                    isinstance(exc, ProviderHTTPError) and exc.status == 429
+                ),
+            )
+        ]
+        if failure_class in {"rate_limit", "provider_quota", "auth"}:
+            provider_retry = retry_after
+            if failure_class == "provider_quota":
+                provider_retry = max(
+                    retry_after or 0.0,
+                    _ACCOUNT_BACKOFF_SECONDS,
+                    self.cooldown_seconds,
+                )
+            updates.append(
+                FailureUpdate(
+                    key=f"{target.provider.id}/*",
+                    failure_class=failure_class,
+                    retry_after=provider_retry,
+                    counts_for_health=failure_class != "auth",
+                    open_immediately=(
+                        failure_class in {"rate_limit", "provider_quota"}
+                    ),
+                )
+            )
+        self.route_health.record_failures(
+            updates,
+            lease=lease,
+        )
+
+    def _record_route_empty(self, target: Target, lease: HealthLease) -> None:
+        if self.route_health is not None:
+            self.route_health.record_failure(target.name, "empty", lease=lease)
 
     def rank_targets(
         self,
@@ -364,6 +479,10 @@ class Pool:
             routing=routing,
             on_event=on_event,
             stats_store=StatsStore(),
+            route_health=RouteHealthStore(
+                path=default_route_health_path(env),
+                base_cooldown=cooldown,
+            ),
         )
 
     def embed(
@@ -392,6 +511,12 @@ class Pool:
                     continue
                 if model is not None and m.name != model:
                     continue
+                target = Target(emb, m.name, m.rpd, m.context)
+                lease = self._acquire_route(target)
+                if lease is None:
+                    attempts.append((target.name, "skipped (persistent circuit open)"))
+                    continue
+                started = self._clock()
                 try:
                     reply = _client.embed(
                         emb,
@@ -403,7 +528,8 @@ class Pool:
                         post=self._post,
                     )
                 except Exception as exc:  # noqa: BLE001 — try the next embedder
-                    attempts.append((f"{emb.id}/{m.name}", f"{type(exc).__name__}: {exc}"))
+                    attempts.append((target.name, f"{type(exc).__name__}: {exc}"))
+                    self._record_route_failure(target, exc, lease)
                     if (
                         isinstance(exc, ProviderHTTPError)
                         and not exc.retryable
@@ -414,6 +540,11 @@ class Pool:
                     continue
                 # Account for embeddings like chat: per-day quota + lifetime stats, so
                 # a heavy embedding workload doesn't bypass RPD pacing / usage totals.
+                self._record_route_success(
+                    target,
+                    max(0.0, (self._clock() - started) * 1000.0),
+                    lease,
+                )
                 self.quota.record(emb.id, m.name)
                 self._bump_stats(requests=1, prompt_tokens=reply.prompt_tokens or 0)
                 return reply
@@ -454,6 +585,12 @@ class Pool:
                     continue
                 if model is not None and m.name != model:
                     continue
+                target = Target(tr, m.name, m.rpd, m.context)
+                lease = self._acquire_route(target)
+                if lease is None:
+                    attempts.append((target.name, "skipped (persistent circuit open)"))
+                    continue
+                started = self._clock()
                 try:
                     reply = _client.transcribe(
                         tr,
@@ -468,7 +605,8 @@ class Pool:
                         post=self._transcribe_post,
                     )
                 except Exception as exc:  # noqa: BLE001 — try the next transcriber
-                    attempts.append((f"{tr.id}/{m.name}", f"{type(exc).__name__}: {exc}"))
+                    attempts.append((target.name, f"{type(exc).__name__}: {exc}"))
+                    self._record_route_failure(target, exc, lease)
                     if (
                         isinstance(exc, ProviderHTTPError)
                         and not exc.retryable
@@ -477,6 +615,11 @@ class Pool:
                     ):
                         client_error = exc
                     continue
+                self._record_route_success(
+                    target,
+                    max(0.0, (self._clock() - started) * 1000.0),
+                    lease,
+                )
                 self.quota.record(tr.id, m.name)
                 self._bump_stats(requests=1, prompt_tokens=reply.prompt_tokens or 0)
                 return reply
@@ -539,6 +682,7 @@ class Pool:
         snap = self.quota.snapshot()
         metrics = self.metrics
         msnap = metrics.snapshot()
+        hsnap = self.route_health_snapshot()
         mode = normalize_routing_mode(routing, self.routing)
 
         def used_of(t: Target) -> int:
@@ -550,11 +694,26 @@ class Pool:
         def stat_of(t: Target):
             return msnap.get(t.name)
 
+        def health_of(t: Target):
+            return hsnap.get(t.name)
+
         def failing_of(t: Target) -> bool:
+            health = health_of(t)
+            if health is not None and (
+                health.state != "closed"
+                or (
+                    self.route_health is not None
+                    and health.consecutive_failures >= self.route_health.failure_threshold
+                )
+            ):
+                return True
             st = stat_of(t)
             return bool(st and st.failing)
 
         def score_of(t: Target) -> float:
+            health = health_of(t)
+            if health is not None:
+                return score_record(health)
             return score_stat(stat_of(t))
 
         if mode == "agent":
@@ -597,9 +756,13 @@ class Pool:
                 # *already clear* the bar — so quality stops parking on a giant that
                 # takes tens of seconds when a comparably-capable model answers in ~1s.
                 st = stat_of(t)
-                if st is None or st.ewma_ms is None:
+                latency = st.ewma_ms if st is not None else None
+                if latency is None:
+                    health = health_of(t)
+                    latency = health.ewma_ms if health is not None else None
+                if latency is None:
                     return _QUALITY_UNKNOWN_LAT
-                return min(st.ewma_ms / 1000.0, _QUALITY_SLOW_S) / _QUALITY_SLOW_S
+                return min(latency / 1000.0, _QUALITY_SLOW_S) / _QUALITY_SLOW_S
 
             def quality_key(t: Target) -> tuple[int, int, float, int]:
                 # over-budget, then known-failing sink to the back (still reachable);
@@ -838,6 +1001,12 @@ class Pool:
             if remaining <= 0:
                 attempts.append((target.name, "skipped (overall request timeout exhausted)"))
                 break
+            lease = self._acquire_route(target)
+            if lease is None:
+                non_ctx_failure = True
+                attempts.append((target.name, "skipped (persistent circuit open)"))
+                emit(self._on_event, "circuit_skip", target=target.name)
+                continue
             emit(self._on_event, "attempt", target=target.name, n=len(attempts) + 1)
             try:
                 reply = _client.call(
@@ -856,6 +1025,7 @@ class Pool:
             except ProviderHTTPError as exc:
                 is_ctx, limit = context_limit_from_error(exc.status, str(exc))
                 if is_ctx:
+                    self._record_route_failure(target, exc, lease)
                     ctx_overflow = True
                     if limit is not None:
                         self._learn_context_limit(target.name, limit)
@@ -883,12 +1053,14 @@ class Pool:
                     client_error = exc
                 if _is_health_failure(exc):
                     self.metrics.record_failure(target.name, str(exc))
+                self._record_route_failure(target, exc, lease)
                 emit(self._on_event, "error", target=target.name, reason=str(exc))
                 attempts.append((target.name, str(exc)))
                 continue
             except Exception as exc:  # network error, etc. — try the next one
                 non_ctx_failure = True
                 self.metrics.record_failure(target.name, f"{type(exc).__name__}: {exc}")
+                self._record_route_failure(target, exc, lease)
                 emit(self._on_event, "error", target=target.name, reason=f"{type(exc).__name__}")
                 attempts.append((target.name, f"{type(exc).__name__}: {exc}"))
                 continue
@@ -897,12 +1069,14 @@ class Pool:
             if not reply.text and not has_tool_calls:
                 non_ctx_failure = True
                 self.metrics.record_failure(target.name, "empty completion")
+                self._record_route_empty(target, lease)
                 emit(self._on_event, "error", target=target.name, reason="empty completion")
                 attempts.append((target.name, "empty completion"))
                 continue
 
             latency_ms = max(0.0, (self._clock() - started) * 1000.0)
             self.metrics.record_success(target.name, latency_ms)
+            self._record_route_success(target, latency_ms, lease)
             emit(
                 self._on_event,
                 "success",
@@ -1013,6 +1187,12 @@ class Pool:
             if remaining <= 0:
                 attempts.append((target.name, "skipped (overall request timeout exhausted)"))
                 break
+            lease = self._acquire_route(target)
+            if lease is None:
+                non_ctx_failure = True
+                attempts.append((target.name, "skipped (persistent circuit open)"))
+                emit(self._on_event, "circuit_skip", target=target.name, stream=True)
+                continue
             emit(self._on_event, "attempt", target=target.name, stream=True)
             gen = _client.stream_call(
                 target.provider,
@@ -1030,12 +1210,14 @@ class Pool:
             except StopIteration:
                 non_ctx_failure = True
                 self.metrics.record_failure(target.name, "empty stream")
+                self._record_route_empty(target, lease)
                 emit(self._on_event, "error", target=target.name, reason="empty stream")
                 attempts.append((target.name, "empty stream"))
                 continue
             except ProviderHTTPError as exc:
                 is_ctx, limit = context_limit_from_error(exc.status, str(exc))
                 if is_ctx:
+                    self._record_route_failure(target, exc, lease)
                     ctx_overflow = True
                     if limit is not None:
                         self._learn_context_limit(target.name, limit)
@@ -1059,12 +1241,14 @@ class Pool:
                     client_error = exc
                 if _is_health_failure(exc):
                     self.metrics.record_failure(target.name, str(exc))
+                self._record_route_failure(target, exc, lease)
                 emit(self._on_event, "error", target=target.name, reason=str(exc))
                 attempts.append((target.name, str(exc)))
                 continue
             except Exception as exc:  # noqa: BLE001
                 non_ctx_failure = True
                 self.metrics.record_failure(target.name, f"{type(exc).__name__}: {exc}")
+                self._record_route_failure(target, exc, lease)
                 emit(self._on_event, "error", target=target.name, reason=f"{type(exc).__name__}")
                 attempts.append((target.name, f"{type(exc).__name__}: {exc}"))
                 continue
@@ -1099,7 +1283,22 @@ class Pool:
                     if isinstance(chunk, str):
                         streamed.append(chunk)
                     yield chunk
+            except Exception as exc:
+                self.metrics.record_failure(
+                    target.name,
+                    f"{type(exc).__name__}: {exc}",
+                )
+                self._record_route_failure(target, exc, lease)
+                emit(
+                    self._on_event,
+                    "error",
+                    target=target.name,
+                    reason=f"mid-stream {type(exc).__name__}",
+                )
+                raise
+            else:
                 drained = True
+                self._record_route_success(target, latency_ms, lease)
             finally:
                 # The manual loop (vs `yield from`) doesn't auto-delegate close(), so on an
                 # early consumer disconnect we must close the upstream stream ourselves to

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -59,6 +59,81 @@ def test_non_thinking_model_keeps_max_tokens():
     assert seen["max_tokens"] == 512
 
 
+def test_http_error_preserves_retry_after_for_circuit_breaker():
+    def post(url, headers, body, timeout):
+        return C.HTTPResult(
+            429,
+            {"error": {"message": "slow down"}},
+            "",
+            headers={"Retry-After": "75"},
+        )
+
+    with pytest.raises(ProviderHTTPError) as exc_info:
+        C.call(
+            P,
+            "zai-glm-4.7",
+            [{"role": "user", "content": "hi"}],
+            api_key="k",
+            env={},
+            max_tokens=512,
+            post=post,
+        )
+
+    assert exc_info.value.retry_after == 75.0
+
+
+def test_retry_after_parser_supports_standard_and_legacy_reset_headers(monkeypatch):
+    monkeypatch.setattr(C.time, "time", lambda: 1_700_000_000.0)
+
+    assert C._retry_after_seconds({"RateLimit-Reset": "45"}) == 45.0
+    assert C._retry_after_seconds({"X-RateLimit-Reset": "1700000075"}) == 75.0
+    # Retry-After is authoritative when a provider returns both.
+    assert (
+        C._retry_after_seconds(
+            {"Retry-After": "12", "X-RateLimit-Reset": "1700000075"}
+        )
+        == 12.0
+    )
+
+
+def test_stream_http_error_preserves_retry_after():
+    def stream_post(url, headers, body, timeout):
+        return 429, {"Retry-After": "80"}, iter(("rate limited",))
+
+    with pytest.raises(ProviderHTTPError) as exc_info:
+        list(
+            C.stream_call(
+                P,
+                "zai-glm-4.7",
+                [{"role": "user", "content": "hi"}],
+                api_key="k",
+                env={},
+                stream_post=stream_post,
+            )
+        )
+
+    assert exc_info.value.retry_after == 80.0
+
+
+def test_stream_rejects_clean_truncation_without_done_marker():
+    def stream_post(url, headers, body, timeout):
+        return 200, iter(
+            ('data: {"choices":[{"delta":{"content":"partial"}}]}',)
+        )
+
+    stream = C.stream_call(
+        P,
+        "zai-glm-4.7",
+        [{"role": "user", "content": "hi"}],
+        api_key="k",
+        env={},
+        stream_post=stream_post,
+    )
+    assert next(stream) == "partial"
+    with pytest.raises(ProviderHTTPError, match="before.*DONE"):
+        next(stream)
+
+
 def test_tools_forwarded_and_tool_calls_preserved():
     tc = [{"id": "call_1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]
     seen = {}

--- a/tests/test_route_health.py
+++ b/tests/test_route_health.py
@@ -1,0 +1,925 @@
+"""Persistent per-route health and circuit-breaker behavior."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from freellmpool.aio import AsyncPool
+from freellmpool.client import HTTPResult
+from freellmpool.errors import AllProvidersExhausted
+from freellmpool.models import Model, Provider
+from freellmpool.proxy import _readiness_snapshot, _status_payload
+from freellmpool.quota import QuotaStore
+from freellmpool.route_health import FailureUpdate, RouteHealthStore
+from freellmpool.router import Pool
+
+
+def _provider() -> Provider:
+    return Provider(
+        id="alpha",
+        label="Alpha",
+        adapter="openai",
+        base_url="https://alpha.test/v1",
+        key_env="ALPHA_KEY",
+        models=(Model("alpha-model"),),
+    )
+
+
+def _ok_result() -> HTTPResult:
+    return HTTPResult(
+        200,
+        {"choices": [{"message": {"role": "assistant", "content": "ok"}}]},
+        "",
+    )
+
+
+def test_restart_preserves_open_circuit_and_half_open_recovery(tmp_path):
+    now = [1_000.0]
+    path = tmp_path / "health.json"
+    first = RouteHealthStore(
+        path=path,
+        clock=lambda: now[0],
+        failure_threshold=1,
+        base_cooldown=30.0,
+    )
+    first.record_failure("alpha/model", "availability")
+
+    restarted = RouteHealthStore(
+        path=path,
+        clock=lambda: now[0],
+        failure_threshold=1,
+        base_cooldown=30.0,
+    )
+    assert restarted.state("alpha/model").state == "open"
+    assert not restarted.allow("alpha/model")
+
+    now[0] = 1_031.0
+    assert restarted.allow("alpha/model")
+    assert restarted.state("alpha/model").state == "half_open"
+    # A second process cannot consume the same half-open probe lease.
+    competing = RouteHealthStore(path=path, clock=lambda: now[0], failure_threshold=1)
+    assert not competing.allow("alpha/model")
+
+    restarted.record_success("alpha/model", 125.0)
+    recovered = RouteHealthStore(path=path, clock=lambda: now[0])
+    row = recovered.state("alpha/model")
+    assert row.state == "closed"
+    assert row.consecutive_failures == 0
+    assert row.ewma_ms == 125.0
+    assert recovered.allow("alpha/model")
+
+
+def test_retry_after_opens_until_provider_reset(tmp_path):
+    now = [50.0]
+    store = RouteHealthStore(path=tmp_path / "health.json", clock=lambda: now[0])
+
+    store.record_failure(
+        "alpha/*",
+        "rate_limit",
+        retry_after=90.0,
+        open_immediately=True,
+    )
+
+    row = store.state("alpha/*")
+    assert row.open_until == 140.0
+    assert not store.allow("alpha/*")
+    now[0] = 141.0
+    assert store.allow("alpha/*")
+
+
+def test_client_and_capability_failures_do_not_poison_availability(tmp_path):
+    store = RouteHealthStore(path=tmp_path / "health.json", failure_threshold=1)
+
+    for failure_class in ("client", "capability", "auth", "retirement"):
+        store.record_failure(
+            f"alpha/{failure_class}",
+            failure_class,
+            counts_for_health=False,
+        )
+        row = store.state(f"alpha/{failure_class}")
+        assert row.failure_class == failure_class
+        assert row.consecutive_failures == 0
+        assert row.state == "closed"
+        assert store.allow(f"alpha/{failure_class}")
+
+
+def test_non_availability_response_releases_half_open_probe(tmp_path):
+    now = [100.0]
+    store = RouteHealthStore(
+        path=tmp_path / "health.json",
+        clock=lambda: now[0],
+        failure_threshold=1,
+        base_cooldown=10,
+    )
+    store.record_failure("alpha/model", "availability")
+    now[0] = 111.0
+    assert store.allow("alpha/model")
+    assert store.state("alpha/model").state == "half_open"
+
+    store.record_failure("alpha/model", "client", counts_for_health=False)
+
+    row = store.state("alpha/model")
+    assert row.state == "closed"
+    assert row.consecutive_failures == 0
+
+
+def test_stale_and_corrupt_state_are_ignored(tmp_path):
+    now = [1_000.0]
+    path = tmp_path / "health.json"
+    store = RouteHealthStore(
+        path=path,
+        clock=lambda: now[0],
+        stale_after=10.0,
+        failure_threshold=1,
+    )
+    store.record_failure("alpha/model", "availability")
+    now[0] = 1_011.0
+    assert store.snapshot() == {}
+
+    path.write_text("{not-json", encoding="utf-8")
+    assert store.snapshot() == {}
+    store.record_success("beta/model", 10.0)
+    assert set(json.loads(path.read_text(encoding="utf-8"))["routes"]) == {"beta/model"}
+
+    path.write_bytes(b"x" * 2_000_001)
+    assert store.snapshot() == {}
+
+    path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "routes": {
+                    "crafted/model": {
+                        "state": [],
+                        "failure_class": {},
+                        "updated_at": now[0],
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    row = store.state("crafted/model")
+    assert row.state == "closed"
+    assert row.failure_class is None
+
+    path.write_text(
+        '{"version":1,"routes":{"crafted/model":{"updated_at":'
+        + "9" * 4_000
+        + "}}}",
+        encoding="utf-8",
+    )
+    assert store.snapshot() == {}
+
+
+def test_hostile_maximum_length_integer_cannot_break_health_update(tmp_path):
+    path = tmp_path / "health.json"
+    path.write_text(
+        '{"version":1,"routes":{"crafted/model":{"state":"closed",'
+        '"updated_at":100,"lease_generation":'
+        + "9" * 4_300
+        + "}}}",
+        encoding="utf-8",
+    )
+    store = RouteHealthStore(path=path, clock=lambda: 100.0)
+
+    older = store.acquire_many(("crafted/model",))
+    newer = store.acquire_many(("crafted/model",))
+
+    assert older is not None
+    assert newer is not None
+    assert older.generations["crafted/model"] < newer.generations["crafted/model"]
+
+    store.record_success("crafted/model", 10.0, lease=newer)
+    store.record_failure(
+        "crafted/model",
+        "availability",
+        lease=older,
+    )
+    row = store.state("crafted/model")
+    assert row.state == "closed"
+    assert row.consecutive_failures == 0
+
+
+def test_state_is_size_bounded_and_contains_only_sanitized_fields(tmp_path):
+    now = [100.0]
+    path = tmp_path / "health.json"
+    store = RouteHealthStore(path=path, clock=lambda: now[0], max_entries=3)
+    for index in range(5):
+        now[0] += 1
+        store.record_failure(f"provider/model-{index}", "availability")
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert len(payload["routes"]) == 3
+    serialized = json.dumps(payload)
+    assert "prompt" not in serialized
+    assert "secret" not in serialized
+    assert set(next(iter(payload["routes"].values()))) <= {
+        "state",
+        "successes",
+        "failures",
+        "consecutive_failures",
+        "ewma_ms",
+        "last_success",
+        "last_failure",
+        "failure_class",
+        "open_until",
+        "half_open_until",
+        "lease_generation",
+        "open_count",
+        "updated_at",
+    }
+
+    payload["routes"].update(
+        {
+            f"manual/model-{index}": {
+                "state": "closed",
+                "updated_at": now[0] + index + 1,
+            }
+            for index in range(5)
+        }
+    )
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    assert len(store.snapshot()) == 3
+
+
+def test_concurrent_instances_do_not_lose_updates(tmp_path):
+    path = tmp_path / "health.json"
+
+    def record(index: int) -> None:
+        RouteHealthStore(path=path).record_success("alpha/model", float(index + 1))
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        list(executor.map(record, range(16)))
+
+    row = RouteHealthStore(path=path).state("alpha/model")
+    assert row.successes == 16
+    assert row.failures == 0
+
+
+def test_route_and_provider_results_commit_in_one_transaction(tmp_path):
+    class CountingStore(RouteHealthStore):
+        writes = 0
+
+        def _write(self, routes):
+            self.writes += 1
+            return super()._write(routes)
+
+    store = CountingStore(path=tmp_path / "health.json")
+    keys = ("alpha/model", "alpha/*")
+    lease = store.acquire_many(keys)
+
+    store.writes = 0
+    store.record_success_many(keys, 10.0, lease=lease)
+    assert store.writes == 1
+    assert all(store.state(key).successes == 1 for key in keys)
+
+    lease = store.acquire_many(keys)
+    store.writes = 0
+    store.record_failures(
+        (
+            FailureUpdate("alpha/model", "rate_limit", 60, True, True),
+            FailureUpdate("alpha/*", "rate_limit", 60, True, True),
+        ),
+        lease=lease,
+    )
+    assert store.writes == 1
+    assert all(store.state(key).state == "open" for key in keys)
+
+
+def test_stale_half_open_result_cannot_overwrite_newer_probe(tmp_path):
+    now = [1_000.0]
+    store = RouteHealthStore(
+        path=tmp_path / "health.json",
+        clock=lambda: now[0],
+        failure_threshold=1,
+        base_cooldown=30,
+        half_open_lease=10,
+    )
+    store.record_failure("alpha/model", "availability")
+
+    now[0] = 1_031.0
+    first_probe = store.acquire_many(("alpha/model",))
+    assert first_probe is not None
+
+    now[0] = 1_042.0
+    second_probe = store.acquire_many(("alpha/model",))
+    assert second_probe is not None
+    store.record_failure(
+        "alpha/model",
+        "availability",
+        lease=second_probe,
+    )
+    assert store.state("alpha/model").state == "open"
+
+    now[0] = 1_043.0
+    store.record_success("alpha/model", 10.0, lease=first_probe)
+    assert store.state("alpha/model").state == "open"
+
+
+def test_older_failure_cannot_reopen_after_newer_request_succeeds(tmp_path):
+    now = [100.0]
+    store = RouteHealthStore(
+        path=tmp_path / "health.json",
+        clock=lambda: now[0],
+        failure_threshold=1,
+    )
+    older = store.acquire_many(("alpha/model",))
+    now[0] = 101.0
+    newer = store.acquire_many(("alpha/model",))
+
+    now[0] = 102.0
+    store.record_success("alpha/model", 12.0, lease=newer)
+    now[0] = 103.0
+    store.record_failure("alpha/model", "availability", lease=older)
+
+    row = store.state("alpha/model")
+    assert row.state == "closed"
+    assert row.consecutive_failures == 0
+    assert row.successes == 1
+    assert row.failures == 1
+
+
+def test_same_timestamp_closed_leases_have_distinct_generations(tmp_path):
+    now = [100.0]
+    path = tmp_path / "health.json"
+    older_store = RouteHealthStore(
+        path=path,
+        clock=lambda: now[0],
+        failure_threshold=1,
+    )
+    newer_store = RouteHealthStore(
+        path=path,
+        clock=lambda: now[0],
+        failure_threshold=1,
+    )
+    older = older_store.acquire_many(("alpha/model",))
+    newer = newer_store.acquire_many(("alpha/model",))
+    assert older.generations["alpha/model"] < newer.generations["alpha/model"]
+
+    newer_store.record_success("alpha/model", 10.0, lease=newer)
+    older_store.record_failure(
+        "alpha/model",
+        "availability",
+        lease=older,
+    )
+
+    row = RouteHealthStore(path=path, clock=lambda: now[0]).state("alpha/model")
+    assert row.state == "closed"
+    assert row.consecutive_failures == 0
+
+
+def test_missing_fchmod_and_non_fcntl_instances_remain_safe(
+    tmp_path, monkeypatch
+):
+    import freellmpool.route_health as route_health
+
+    path = tmp_path / "health.json"
+    monkeypatch.delattr(route_health.os, "fchmod")
+    monkeypatch.setattr(route_health, "fcntl", None)
+
+    def record(index: int) -> None:
+        RouteHealthStore(path=path).record_success("alpha/model", index)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        list(executor.map(record, range(8)))
+
+    assert RouteHealthStore(path=path).state("alpha/model").successes == 8
+
+
+def test_telemetry_filesystem_failure_cannot_break_successful_request(tmp_path):
+    blocker = tmp_path / "not-a-directory"
+    blocker.write_text("file", encoding="utf-8")
+    store = RouteHealthStore(path=blocker / "health.json")
+    pool = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        post=lambda *args: _ok_result(),
+        route_health=store,
+        quota=QuotaStore(path=tmp_path / "quota.json"),
+    )
+
+    assert pool.ask("hello").text == "ok"
+    assert store.state("alpha/alpha-model").successes == 1
+
+
+def test_pool_restart_skips_open_route_then_runs_one_half_open_probe(tmp_path):
+    now = [1_000.0]
+    path = tmp_path / "health.json"
+    calls: list[str] = []
+
+    def unavailable(url, headers, body, timeout):
+        calls.append(url)
+        return HTTPResult(503, {"error": {"message": "down"}}, "")
+
+    health = RouteHealthStore(
+        path=path,
+        clock=lambda: now[0],
+        failure_threshold=1,
+        base_cooldown=30,
+    )
+    first = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        post=unavailable,
+        route_health=health,
+    )
+    with pytest.raises(AllProvidersExhausted):
+        first.ask("hello")
+    assert len(calls) == 1
+
+    def available(url, headers, body, timeout):
+        calls.append(url)
+        return _ok_result()
+
+    restarted = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        post=available,
+        route_health=RouteHealthStore(
+            path=path,
+            clock=lambda: now[0],
+            failure_threshold=1,
+            base_cooldown=30,
+        ),
+    )
+    with pytest.raises(AllProvidersExhausted):
+        restarted.ask("still open")
+    assert len(calls) == 1
+
+    now[0] = 1_031.0
+    assert restarted.ask("probe").text == "ok"
+    assert len(calls) == 2
+    assert restarted.route_health.state("alpha/alpha-model").state == "closed"
+
+
+def test_pool_uses_retry_after_for_provider_wide_rate_limit(tmp_path):
+    now = [100.0]
+    health = RouteHealthStore(path=tmp_path / "health.json", clock=lambda: now[0])
+
+    def rate_limited(url, headers, body, timeout):
+        return HTTPResult(
+            429,
+            {"error": {"message": "slow down"}},
+            "",
+            headers={"Retry-After": "75"},
+        )
+
+    pool = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        post=rate_limited,
+        route_health=health,
+    )
+    with pytest.raises(AllProvidersExhausted):
+        pool.ask("hello")
+
+    row = health.state("alpha/*")
+    assert row.failure_class == "rate_limit"
+    assert row.open_until == 175.0
+    assert not health.allow("alpha/*")
+
+
+def test_provider_quota_never_shortens_longer_retry_after(tmp_path):
+    now = [100.0]
+    health = RouteHealthStore(path=tmp_path / "health.json", clock=lambda: now[0])
+
+    def quota_exhausted(url, headers, body, timeout):
+        return HTTPResult(
+            429,
+            {"error": {"message": "quota exhausted"}},
+            "",
+            headers={"Retry-After": "3600"},
+        )
+
+    pool = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        post=quota_exhausted,
+        route_health=health,
+    )
+    with pytest.raises(AllProvidersExhausted):
+        pool.ask("hello")
+
+    assert health.state("alpha/*").open_until == 3_700.0
+
+
+def test_pool_records_client_error_without_opening_route(tmp_path):
+    health = RouteHealthStore(
+        path=tmp_path / "health.json",
+        failure_threshold=1,
+    )
+
+    def bad_request(url, headers, body, timeout):
+        return HTTPResult(400, {"error": {"message": "bad input"}}, "")
+
+    pool = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        post=bad_request,
+        route_health=health,
+    )
+    with pytest.raises(AllProvidersExhausted):
+        pool.ask("hello")
+
+    row = health.state("alpha/alpha-model")
+    assert row.failure_class == "client"
+    assert row.consecutive_failures == 0
+    assert row.state == "closed"
+    assert health.allow("alpha/alpha-model")
+
+
+def test_streaming_failures_and_recovery_use_persistent_circuit(tmp_path):
+    now = [10.0]
+    path = tmp_path / "health.json"
+    calls: list[str] = []
+
+    def unavailable(url, headers, body, timeout):
+        calls.append(url)
+        return 503, iter(())
+
+    health = RouteHealthStore(
+        path=path,
+        clock=lambda: now[0],
+        failure_threshold=1,
+        base_cooldown=20,
+    )
+    pool = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        stream_post=unavailable,
+        route_health=health,
+    )
+    with pytest.raises(AllProvidersExhausted):
+        list(pool.stream_chat([{"role": "user", "content": "hello"}]))
+
+    def available(url, headers, body, timeout):
+        calls.append(url)
+        return 200, iter(
+            (
+                'data: {"choices":[{"delta":{"content":"ok"}}]}',
+                "data: [DONE]",
+            )
+        )
+
+    restarted = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        stream_post=available,
+        route_health=RouteHealthStore(
+            path=path,
+            clock=lambda: now[0],
+            failure_threshold=1,
+            base_cooldown=20,
+        ),
+    )
+    with pytest.raises(AllProvidersExhausted):
+        list(restarted.stream_chat([{"role": "user", "content": "open"}]))
+    assert len(calls) == 1
+
+    now[0] = 31.0
+    chunks = list(restarted.stream_chat([{"role": "user", "content": "probe"}]))
+    assert chunks[-1] == "ok"
+    assert len(calls) == 2
+    assert restarted.route_health.state("alpha/alpha-model").state == "closed"
+
+
+def test_midstream_reset_records_failure_instead_of_persistent_success(tmp_path):
+    health = RouteHealthStore(
+        path=tmp_path / "health.json",
+        failure_threshold=1,
+    )
+
+    def chunks():
+        yield 'data: {"choices":[{"delta":{"content":"partial"}}]}'
+        raise ConnectionError("reset")
+
+    pool = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        stream_post=lambda *args: (200, iter(chunks())),
+        route_health=health,
+        quota=QuotaStore(path=tmp_path / "quota.json"),
+    )
+
+    with pytest.raises(ConnectionError, match="reset"):
+        list(pool.stream_chat([{"role": "user", "content": "hello"}]))
+
+    row = health.state("alpha/alpha-model")
+    assert row.state == "open"
+    assert row.failure_class == "transport"
+    assert row.successes == 0
+    assert row.failures == 1
+
+
+def test_streaming_rate_limit_persists_provider_reset_header(tmp_path):
+    now = [300.0]
+    health = RouteHealthStore(
+        path=tmp_path / "health.json",
+        clock=lambda: now[0],
+    )
+    pool = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        stream_post=lambda *args: (
+            429,
+            {"RateLimit-Reset": "65"},
+            iter(("rate limited",)),
+        ),
+        route_health=health,
+        quota=QuotaStore(path=tmp_path / "quota.json"),
+    )
+
+    with pytest.raises(AllProvidersExhausted):
+        list(pool.stream_chat([{"role": "user", "content": "hello"}]))
+
+    row = health.state("alpha/*")
+    assert row.failure_class == "rate_limit"
+    assert row.open_until == 365.0
+
+
+def test_async_failover_uses_persistent_circuit(tmp_path):
+    now = [20.0]
+    path = tmp_path / "health.json"
+    calls: list[str] = []
+
+    async def unavailable(url, headers, body, timeout):
+        calls.append(url)
+        return HTTPResult(503, {"error": {"message": "down"}}, "")
+
+    health = RouteHealthStore(
+        path=path,
+        clock=lambda: now[0],
+        failure_threshold=1,
+        base_cooldown=15,
+    )
+    first = AsyncPool(
+        Pool(
+            [_provider()],
+            env={"ALPHA_KEY": "a"},
+            route_health=health,
+        ),
+        apost=unavailable,
+    )
+    with pytest.raises(AllProvidersExhausted):
+        asyncio.run(first.aask("hello"))
+
+    async def available(url, headers, body, timeout):
+        calls.append(url)
+        return _ok_result()
+
+    restarted_pool = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        route_health=RouteHealthStore(
+            path=path,
+            clock=lambda: now[0],
+            failure_threshold=1,
+            base_cooldown=15,
+        ),
+    )
+    restarted = AsyncPool(restarted_pool, apost=available)
+    with pytest.raises(AllProvidersExhausted):
+        asyncio.run(restarted.aask("open"))
+    assert len(calls) == 1
+
+    now[0] = 36.0
+    assert asyncio.run(restarted.aask("probe")).text == "ok"
+    assert len(calls) == 2
+    assert restarted_pool.route_health.state("alpha/alpha-model").state == "closed"
+
+
+def test_default_pool_wires_configurable_persistent_health_path(tmp_path):
+    path = tmp_path / "custom-health.json"
+    pool = Pool.from_default_config(
+        env={
+            "FREELLMPOOL_HEALTH_FILE": str(path),
+            "FREELLMPOOL_CONFIG": str(tmp_path / "missing.toml"),
+        }
+    )
+
+    assert pool.route_health.path == path
+
+
+def test_embedding_routes_respect_persistent_circuit(tmp_path):
+    path = tmp_path / "health.json"
+    calls: list[str] = []
+    health = RouteHealthStore(path=path, failure_threshold=1, base_cooldown=60)
+
+    def unavailable(url, headers, body, timeout):
+        calls.append(url)
+        return HTTPResult(503, {"error": {"message": "down"}}, "")
+
+    first = Pool(
+        [],
+        embedders=[_provider()],
+        env={"ALPHA_KEY": "a"},
+        post=unavailable,
+        route_health=health,
+    )
+    with pytest.raises(AllProvidersExhausted):
+        first.embed("hello")
+
+    def available(url, headers, body, timeout):
+        calls.append(url)
+        return HTTPResult(200, {"data": [{"embedding": [1.0, 2.0]}]}, "")
+
+    restarted = Pool(
+        [],
+        embedders=[_provider()],
+        env={"ALPHA_KEY": "a"},
+        post=available,
+        route_health=RouteHealthStore(
+            path=path,
+            failure_threshold=1,
+            base_cooldown=60,
+        ),
+    )
+    with pytest.raises(AllProvidersExhausted):
+        restarted.embed("still open")
+    assert len(calls) == 1
+
+
+def test_transcription_routes_respect_persistent_circuit(tmp_path):
+    path = tmp_path / "health.json"
+    calls: list[str] = []
+    health = RouteHealthStore(path=path, failure_threshold=1, base_cooldown=60)
+
+    def unavailable(url, headers, files, data, timeout):
+        calls.append(url)
+        return HTTPResult(503, {"error": {"message": "down"}}, "")
+
+    first = Pool(
+        [],
+        transcribers=[_provider()],
+        env={"ALPHA_KEY": "a"},
+        transcribe_post=unavailable,
+        route_health=health,
+    )
+    with pytest.raises(AllProvidersExhausted):
+        first.transcribe(b"audio", "clip.wav")
+
+    def available(url, headers, files, data, timeout):
+        calls.append(url)
+        return HTTPResult(200, {"text": "ok"}, "")
+
+    restarted = Pool(
+        [],
+        transcribers=[_provider()],
+        env={"ALPHA_KEY": "a"},
+        transcribe_post=available,
+        route_health=RouteHealthStore(
+            path=path,
+            failure_threshold=1,
+            base_cooldown=60,
+        ),
+    )
+    with pytest.raises(AllProvidersExhausted):
+        restarted.transcribe(b"audio", "clip.wav")
+    assert len(calls) == 1
+
+
+def test_sample_age_and_provider_cooldown_are_derived_from_store_clock(tmp_path):
+    now = [500.0]
+    store = RouteHealthStore(path=tmp_path / "health.json", clock=lambda: now[0])
+    store.record_failure(
+        "alpha/*",
+        "rate_limit",
+        retry_after=90,
+        open_immediately=True,
+    )
+
+    row = store.state("alpha/*")
+    assert store.sample_age(row) == 0.0
+    assert store.provider_cooldowns() == {"alpha": 90.0}
+
+    now[0] = 505.0
+    assert store.sample_age(row) == 5.0
+    assert store.provider_cooldowns() == {"alpha": 85.0}
+
+
+def test_status_exposes_persistent_route_health_without_raw_errors(tmp_path):
+    now = [800.0]
+    store = RouteHealthStore(
+        path=tmp_path / "health.json",
+        clock=lambda: now[0],
+        failure_threshold=1,
+    )
+    store.record_failure("alpha/alpha-model", "availability")
+    pool = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        route_health=store,
+        quota=QuotaStore(path=tmp_path / "quota.json"),
+    )
+
+    payload = _status_payload(pool, [])
+    model = payload["providers"][0]["models"][0]
+    assert model["circuit_state"] == "open"
+    assert model["failure_class"] == "availability"
+    assert model["consecutive_failures"] == 1
+    assert model["sample_age_s"] == 0.0
+    assert model["last_error"] is None
+
+
+def test_readiness_marks_persistently_open_model_unavailable(tmp_path):
+    store = RouteHealthStore(
+        path=tmp_path / "health.json",
+        failure_threshold=1,
+    )
+    store.record_failure("alpha/alpha-model", "availability")
+    pool = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        route_health=store,
+        quota=QuotaStore(path=tmp_path / "quota.json"),
+    )
+
+    provider = _readiness_snapshot(pool).providers[0]
+    assert provider.ready is False
+    assert provider.status == "cooldown"
+    assert provider.models[0].status == "cooldown"
+
+
+def test_status_includes_embedding_and_transcription_circuits(tmp_path):
+    store = RouteHealthStore(
+        path=tmp_path / "health.json",
+        failure_threshold=1,
+    )
+    store.record_failure("alpha/alpha-model", "availability")
+    pool = Pool(
+        [],
+        embedders=[_provider()],
+        transcribers=[_provider()],
+        env={"ALPHA_KEY": "a"},
+        route_health=store,
+        quota=QuotaStore(path=tmp_path / "quota.json"),
+    )
+
+    routes = _status_payload(pool, [])["routes"]
+    assert routes["embeddings"][0]["circuit_state"] == "open"
+    assert routes["transcriptions"][0]["failure_class"] == "availability"
+
+
+def test_quality_routing_uses_persisted_latency_after_restart(tmp_path):
+    shared = Model("shared-model")
+    slow = Provider(
+        id="slow",
+        label="Slow",
+        adapter="openai",
+        base_url="https://slow.test/v1",
+        key_env="SLOW_KEY",
+        models=(shared,),
+    )
+    fast = Provider(
+        id="fast",
+        label="Fast",
+        adapter="openai",
+        base_url="https://fast.test/v1",
+        key_env="FAST_KEY",
+        models=(shared,),
+    )
+    store = RouteHealthStore(path=tmp_path / "health.json")
+    store.record_success("slow/shared-model", 8_000)
+    store.record_success("fast/shared-model", 100)
+    pool = Pool(
+        [slow, fast],
+        env={"SLOW_KEY": "s", "FAST_KEY": "f"},
+        route_health=RouteHealthStore(path=tmp_path / "health.json"),
+        quota=QuotaStore(path=tmp_path / "quota.json"),
+        routing="quality",
+    )
+
+    ranked = pool.rank_targets([{"role": "user", "content": "explain this"}])
+    assert ranked[0].provider.id == "fast"
+
+
+def test_async_ordering_keeps_persistent_disk_reads_off_event_loop(
+    tmp_path, monkeypatch
+):
+    pool = Pool(
+        [_provider()],
+        env={"ALPHA_KEY": "a"},
+        route_health=RouteHealthStore(path=tmp_path / "health.json"),
+        quota=QuotaStore(path=tmp_path / "quota.json"),
+    )
+    loop_thread = threading.get_ident()
+    seen: list[int] = []
+    original = pool._order
+
+    def observed_order(*args, **kwargs):
+        seen.append(threading.get_ident())
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(pool, "_order", observed_order)
+
+    async def post(url, headers, body, timeout):
+        return _ok_result()
+
+    assert asyncio.run(AsyncPool(pool, apost=post).aask("hello")).text == "ok"
+    assert seen and seen[0] != loop_thread


### PR DESCRIPTION
## Summary
- persist bounded, privacy-safe per-route and provider health across processes
- add atomic closed/open/half-open circuit handling with Retry-After/reset support
- integrate chat, streaming, async, embeddings, transcription, readiness, status, and routing quality
- harden corruption, concurrency, stale-result ownership, filesystem fallback, and Windows locking

## Validation
- 863 tests passed
- line coverage 86.50%; branch coverage 74.67%
- Ruff, focused strict mypy, catalog/count/release gates
- proxy stress: 144 requests at concurrency 24 across 12 routes
- build, twine check, and fresh-wheel smoke
- Codex Sol 5.6 xhigh pre-commit review: APPROVE

Closes #70

## Summary by Sourcery

Persist per-route and per-provider health with circuit breakers and integrate this state into routing, readiness, and status surfaces, using provider backoff hints to avoid unhealthy routes across restarts.

New Features:
- Introduce a persistent, privacy-safe RouteHealthStore with per-route and per-provider circuit breaker semantics shared across processes.
- Expose persistent health, cooldowns, and circuit states for chat, streaming, embeddings, and transcription routes via router APIs and /status output.
- Add support for provider backoff hints (Retry-After and rate limit reset headers) in HTTP and streaming clients, propagating them into routing decisions.

Bug Fixes:
- Ensure streaming calls detect truncated responses that end without a [DONE] marker and treat them as retryable errors instead of silent success.

Enhancements:
- Improve routing quality by combining in-memory metrics with persisted latency and success rates when ranking targets, including after restarts.
- Refine readiness snapshots to account for per-model circuit breaker state so persistently unhealthy models and providers are marked unavailable.
- Make provider HTTP error construction preserve retry-after guidance and reuse it consistently across sync and async clients.
- Harden route health persistence against corruption, oversized state, filesystem failures, and missing platform-specific locking primitives.
- Offload potentially blocking ordering and health access work from the asyncio event loop to threads in async paths.

Tests:
- Add an extensive test suite for RouteHealthStore behavior, corruption handling, concurrency safety, and integration with routing, readiness, status, and async flows.
- Extend client tests to cover retry-after header parsing, streaming error propagation, and truncated stream handling.