### PR TITLE
security: harden supply chain and release provenance

### DIFF
--- a/.github/security-exceptions.json
+++ b/.github/security-exceptions.json
@@ -1,0 +1,4 @@
+{
+  "schema_version": 1,
+  "exceptions": []
+}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -9,9 +9,11 @@ jobs:
   hotpaths:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
       - name: Install
@@ -19,7 +21,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e .
       - name: Restore previous benchmark
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .benchmarks/latest.json
           key: hotpath-benchmark-${{ runner.os }}-${{ github.run_id }}
@@ -38,12 +40,12 @@ jobs:
           fi
           cp .benchmarks/current.json .benchmarks/latest.json
       - name: Upload benchmark artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: hotpath-benchmarks
           path: .benchmarks/current.json
       - name: Save benchmark baseline
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: .benchmarks/latest.json
           key: hotpath-benchmark-${{ runner.os }}-${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,11 @@ jobs:
   quickstart:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Set up Python
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
       - name: Cold quickstart
@@ -25,9 +27,11 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install
@@ -71,13 +75,15 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.14"
       - name: Use trusted-publishing-capable npm
@@ -90,7 +96,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Build and smoke-test the container
         run: |
           set -euo pipefail
@@ -116,7 +124,7 @@ jobs:
           docker run --detach --name "$container" --publish 127.0.0.1:18080:8080 "$image"
 
           healthy=false
-          for attempt in $(seq 1 30); do
+          for _attempt in $(seq 1 30); do
             if response=$(curl --fail --silent http://127.0.0.1:18080/healthz) && \
               python -c 'import json, sys; payload = json.loads(sys.argv[1]); assert payload["status"] == "ok"' "$response"; then
               healthy=true

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,39 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "31 4 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Python
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          languages: python
+          build-mode: none
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          category: /language:python

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,37 +3,155 @@ name: Docker
 on:
   push:
     tags: ["v*"]
-  workflow_dispatch:
 
 jobs:
-  build-push:
+  gate:
+    name: Build and scan release image
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate release tag provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_version=$(python -c \
+            'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          test "$GITHUB_REF_NAME" = "v$package_version"
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - name: Validate security exceptions
+        run: |
+          python3 scripts/security_exceptions.py validate
+          python3 scripts/security_exceptions.py ids trivy > .trivyignore.generated
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Build exact release image archive
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: .
+          tags: freellmpool:release-scan-${{ github.sha }}
+          outputs: type=docker,dest=/tmp/freellmpool-image.tar
+
+      - name: Fail on high or critical image vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          input: /tmp/freellmpool-image.tar
+          format: table
+          exit-code: "1"
+          ignore-unfixed: false
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          scanners: vuln
+          trivyignores: .trivyignore.generated
+          version: v0.72.0
+
+      - name: Record scanned archive identity
+        run: |
+          cd /tmp
+          sha256sum freellmpool-image.tar > freellmpool-image.tar.sha256
+
+      - name: Upload exact scanned image
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanned-release-image-${{ github.sha }}
+          path: |
+            /tmp/freellmpool-image.tar
+            /tmp/freellmpool-image.tar.sha256
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Publish scanned release image
+    needs: gate
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
       packages: write
     steps:
-      - uses: actions/checkout@v7
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v4
+      - name: Download exact scanned image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          name: scanned-release-image-${{ github.sha }}
+          path: /tmp/scanned-release-image
+
+      - name: Load exact scanned image
+        run: |
+          cd /tmp/scanned-release-image
+          sha256sum --check freellmpool-image.tar.sha256
+          docker load --input freellmpool-image.tar
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest
 
-      - name: Build and push
-        uses: docker/build-push-action@v7
+      - name: Log in to GHCR
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
         with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote exact scanned image
+        id: push
+        shell: bash
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          source_image="freellmpool:release-scan-$GITHUB_SHA"
+          mapfile -t tags <<< "$IMAGE_TAGS"
+          test "${#tags[@]}" -gt 0
+          digest=""
+          for tag in "${tags[@]}"; do
+            docker tag "$source_image" "$tag"
+            docker push "$tag"
+            tag_digest="sha256:$(docker buildx imagetools inspect "$tag" --raw | sha256sum | cut -d ' ' -f 1)"
+            if test -z "$digest"; then
+              digest="$tag_digest"
+            else
+              test "$tag_digest" = "$digest"
+            fi
+          done
+          [[ "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Generate downloadable image SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          image: ghcr.io/${{ github.repository }}@${{ steps.push.outputs.digest }}
+          format: spdx-json
+          artifact-name: container-sbom.spdx.json
+          output-file: container-sbom.spdx.json
+          syft-version: v1.50.0
+          upload-release-assets: false
+
+      - name: Attest image provenance
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest image SBOM
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          sbom-path: container-sbom.spdx.json
+          push-to-registry: true

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,10 +25,12 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/configure-pages@v6
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: docs
       - id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/publish-opencode.yml
+++ b/.github/workflows/publish-opencode.yml
@@ -37,10 +37,11 @@ jobs:
           esac
           test "${#RELEASE_COMMIT}" -eq 40
 
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ inputs.commit }}
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Require the exact current main tip
         env:
@@ -51,13 +52,13 @@ jobs:
           test "$(git rev-parse origin/main)" = "$RELEASE_COMMIT"
 
       - name: Set up Node
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "24"
           registry-url: https://registry.npmjs.org
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: "1.3.14"
 

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -1,0 +1,143 @@
+name: Release evidence
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: Audit release dependencies
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Validate release tag provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_version=$(python -c \
+            'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          test "$GITHUB_REF_NAME" = "v$package_version"
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.14"
+      - name: Install pinned release and security tooling
+        run: >-
+          python -m pip install
+          --disable-pip-version-check
+          pip-audit==2.10.1
+      - name: Validate exceptions and audit release dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/security_exceptions.py validate
+          mapfile -t ignored < <(python scripts/security_exceptions.py ids pip-audit)
+          args=()
+          for advisory in "${ignored[@]}"; do
+            args+=(--ignore-vuln "$advisory")
+          done
+          python -m pip_audit . --strict --desc=on --aliases=on "${args[@]}"
+
+  packages:
+    name: Package SBOMs and provenance
+    needs: gate
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Revalidate release tag provenance
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_version=$(python -c \
+            'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          test "$GITHUB_REF_NAME" = "v$package_version"
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.14"
+      - name: Install pinned build tooling
+        run: >-
+          python -m pip install
+          --disable-pip-version-check
+          build==1.5.0
+      - name: Build wheel and source archive
+        run: python -m build
+      - name: Resolve exact artifacts
+        id: artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t wheels < <(find dist -maxdepth 1 -type f -name '*.whl' -print)
+          mapfile -t sdists < <(find dist -maxdepth 1 -type f -name '*.tar.gz' -print)
+          test "${#wheels[@]}" -eq 1
+          test "${#sdists[@]}" -eq 1
+          echo "wheel=${wheels[0]}" >> "$GITHUB_OUTPUT"
+          echo "sdist=${sdists[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate wheel SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          file: ${{ steps.artifacts.outputs.wheel }}
+          format: spdx-json
+          output-file: dist/wheel.spdx.json
+          syft-version: v1.50.0
+          upload-artifact: false
+          upload-release-assets: false
+      - name: Generate source archive SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          file: ${{ steps.artifacts.outputs.sdist }}
+          format: spdx-json
+          output-file: dist/sdist.spdx.json
+          syft-version: v1.50.0
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest package provenance
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
+        with:
+          subject-path: |
+            dist/*.whl
+            dist/*.tar.gz
+      - name: Attest wheel SBOM
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
+        with:
+          subject-path: ${{ steps.artifacts.outputs.wheel }}
+          sbom-path: dist/wheel.spdx.json
+      - name: Attest source archive SBOM
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
+        with:
+          subject-path: ${{ steps.artifacts.outputs.sdist }}
+          sbom-path: dist/sdist.spdx.json
+
+      - name: Upload package evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: python-release-evidence-${{ github.ref_name }}
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+            dist/*.spdx.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,122 @@
+name: Security
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "47 4 * * 2"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  source:
+    name: High-severity Python source audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.14"
+      - name: Install pinned scanner
+        run: python -m pip install --disable-pip-version-check bandit==1.9.4
+      - name: Validate security exceptions
+        run: |
+          python scripts/security_exceptions.py validate
+          python scripts/security_exceptions.py check-suppressions
+      - name: Fail on high-confidence, high-severity source findings
+        run: >-
+          bandit
+          --recursive src
+          --severity-level high
+          --confidence-level high
+          --ignore-nosec
+
+  dependencies:
+    name: Python dependency audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.14"
+      - name: Install pinned scanner
+        run: python -m pip install --disable-pip-version-check pip-audit==2.10.1
+      - name: Validate security exceptions
+        run: |
+          python scripts/security_exceptions.py validate
+          python scripts/security_exceptions.py check-suppressions
+      - name: Audit resolved project dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t ignored < <(python scripts/security_exceptions.py ids pip-audit)
+          args=()
+          for advisory in "${ignored[@]}"; do
+            args+=(--ignore-vuln "$advisory")
+          done
+          python -m pip_audit . --strict --desc=on --aliases=on "${args[@]}"
+
+  workflows:
+    name: GitHub Actions audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.14"
+      - name: Install pinned scanner
+        run: python -m pip install --disable-pip-version-check zizmor==1.28.0
+      - name: Validate security exceptions
+        run: python scripts/security_exceptions.py validate
+      - name: Fail on high-confidence, high-severity workflow findings
+        run: >-
+          zizmor
+          --strict-collection
+          --no-ignores
+          --no-config
+          --min-severity=high
+          --min-confidence=high
+          .
+
+  container:
+    name: Container vulnerability audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Validate security exceptions
+        run: |
+          python3 scripts/security_exceptions.py validate
+          python3 scripts/security_exceptions.py ids trivy > .trivyignore.generated
+      - name: Build image
+        run: docker build --tag freellmpool:security-${{ github.sha }} .
+      - name: Fail on high or critical image vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: freellmpool:security-${{ github.sha }}
+          format: table
+          exit-code: "1"
+          ignore-unfixed: false
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          scanners: vuln
+          trivyignores: .trivyignore.generated
+          version: v0.72.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@
 # Works out of the box with no keys (keyless providers). Add provider keys as
 # env vars to unlock more, e.g. `-e GROQ_API_KEY=...`. When exposing the proxy
 # beyond localhost, set FREELLMPOOL_PROXY_KEY to require a Bearer token.
-FROM python:3.14-slim
+FROM python:3.14-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92
 
 WORKDIR /app
 COPY pyproject.toml README.md ./
 COPY src ./src
-RUN pip install --no-cache-dir .
+RUN pip install --no-cache-dir "httpx==0.28.1" .
 
-RUN useradd --create-home --uid 10001 freellmpool
+RUN adduser -D -u 10001 freellmpool
 USER freellmpool
 
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -665,6 +665,9 @@ python -m pip install -e ".[dev]" && ruff check . && pytest
 Source-first verification in this repo uses `PYTHONPATH=src` so `pytest` exercises
 the checkout without requiring an editable install first; CI runs the same
 configuration. Release readiness uses `PYTHONPATH=src python3 scripts/check_release_ready.py`.
+Security scanners, severity gates, the expiring exception process, local
+reproduction, SBOMs, and provenance verification are documented in
+[SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,114 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities through
+[GitHub private vulnerability reporting](https://github.com/0xzr/freellmpool/security/advisories/new).
+Do not include credentials, provider keys, prompts, or other sensitive data in a
+public issue. Include the affected version or commit, a minimal reproduction,
+impact, and any suggested mitigation. Maintainers will acknowledge a complete
+report as soon as practical and coordinate disclosure after a fix is available.
+
+The latest release and current `main` receive security fixes. Older versions may
+require upgrading to the latest fixed release.
+
+## Automated gates
+
+Pull requests and `main` are checked by:
+
+- CodeQL `security-extended` queries for Python, with code-scanning annotations;
+- Bandit, failing on high-confidence/high-severity Python findings;
+- `pip-audit`, failing on any known vulnerable resolved Python dependency;
+- zizmor, failing on high-confidence/high-severity GitHub Actions findings;
+- Trivy, failing on high or critical OS/library findings in the built image; and
+- a repository test requiring every third-party Action to use a full commit SHA
+  and the Python base image to use an OCI digest.
+
+Release tag workflows build wheel/source artifacts and the GHCR image, generate
+SPDX JSON SBOMs, and create GitHub artifact attestations. The image additionally
+publishes OCI SBOM/provenance attestations.
+
+Scanner and Action versions are pinned in the workflows. Dependabot proposes
+updates for Python, Actions, and Docker references.
+The required GitHub status contexts and CodeQL ruleset are recorded in
+[`docs/SECURITY_ENFORCEMENT.md`](docs/SECURITY_ENFORCEMENT.md).
+
+## Reproducing checks locally
+
+Install the pinned security extra, then run the same policy and scanner
+arguments used by CI:
+
+```bash
+python3 -m pip install -e ".[dev,security]"
+python3 scripts/security_exceptions.py validate
+python3 scripts/security_exceptions.py check-suppressions
+bandit --recursive src --severity-level high --confidence-level high --ignore-nosec
+mapfile -t ignored < <(python3 scripts/security_exceptions.py ids pip-audit)
+audit_args=()
+for advisory in "${ignored[@]}"; do audit_args+=(--ignore-vuln "$advisory"); done
+python3 -m pip_audit . --strict --desc=on --aliases=on "${audit_args[@]}"
+zizmor --strict-collection --no-ignores --no-config \
+  --min-severity=high --min-confidence=high .
+pytest -q tests/test_supply_chain.py
+```
+
+Reproduce the container gate with Trivy v0.72.0:
+
+```bash
+docker build --tag freellmpool:security .
+trivy_ignore=$(mktemp)
+python3 scripts/security_exceptions.py ids trivy > "$trivy_ignore"
+docker run --rm \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "$trivy_ignore:/trivyignore:ro" \
+  aquasec/trivy:0.72.0 image \
+  --exit-code 1 --severity HIGH,CRITICAL --pkg-types os,library --scanners vuln \
+  --ignorefile /trivyignore \
+  freellmpool:security
+```
+
+CodeQL uses GitHub's hosted database builder; inspect its workflow annotations
+and uploaded SARIF in the Actions run.
+
+## False positives and temporary exceptions
+
+Fix or upgrade first. The repository exception registry supports only
+`pip-audit` and Trivy because those scanners can exclude an exact advisory
+without hiding unrelated findings. If one of those findings is demonstrably
+inapplicable and cannot be removed immediately:
+
+1. Open a public issue with the scanner ID, affected artifact/path, reachability
+   analysis, compensating controls, and removal plan. Use a private advisory if
+   the analysis itself is sensitive.
+2. Add one entry to `.github/security-exceptions.json` with the scanner, exact
+   finding ID, accountable GitHub owner, issue URL, justification, and expiry.
+3. Keep expiry within 90 days. Expired, malformed, duplicate, or overlong
+   exceptions fail closed in CI.
+4. Obtain the normal xhigh security review. Remove the exception as soon as the
+   underlying finding is fixed.
+
+Bandit `# nosec`, CodeQL/LGTM inline directives, and zizmor inline ignores are
+forbidden and checked in CI. Bandit also runs with `--ignore-nosec`, so an
+obfuscated or missed comment cannot weaken its gate. CodeQL false positives
+must be dismissed in GitHub's code-scanning alert UI with a linked issue and
+review rationale; the active code-scanning ruleset remains the merge
+enforcement point.
+
+Never suppress a class of findings globally, lower the configured severity
+threshold, use `continue-on-error`, or add `|| true` to a security gate.
+
+## Verifying release provenance
+
+Download the matching workflow artifact, then verify package or image provenance:
+
+```bash
+gh attestation verify dist/freellmpool-*.whl -R 0xzr/freellmpool
+gh attestation verify dist/freellmpool-*.tar.gz -R 0xzr/freellmpool
+gh attestation verify oci://ghcr.io/0xzr/freellmpool:VERSION -R 0xzr/freellmpool
+```
+
+SPDX attestations can be verified by adding:
+
+```bash
+--predicate-type https://spdx.dev/Document/v2.3
+```

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,6 +1,7 @@
 # Release Checklist
 
-Prepared release: `0.11.4`
+Prepared release: next unreleased version. The package version must be bumped
+before using this checklist; never reuse an existing tag.
 
 This checklist is for the operator after the polish PR is merged. Do not publish,
 push tags, or create a GitHub release from the polish automation branch.
@@ -8,13 +9,29 @@ push tags, or create a GitHub release from the polish automation branch.
 ## Verify
 
 ```bash
-python -m pip install -e ".[dev]"
+python -m pip install -e ".[dev,security]"
 ruff check .
 PYTHONPATH=src python3 -m pytest
 scripts/check-counts
 PYTHONPATH=src python3 scripts/validate_catalog.py
 PYTHONPATH=src python3 scripts/check_release_ready.py --skip-build
 PYTHONPATH=src python3 scripts/check_release_ready.py
+python3 scripts/security_exceptions.py validate
+python3 scripts/security_exceptions.py check-suppressions
+bandit --recursive src --severity-level high --confidence-level high --ignore-nosec
+mapfile -t ignored < <(python3 scripts/security_exceptions.py ids pip-audit)
+audit_args=()
+for advisory in "${ignored[@]}"; do audit_args+=(--ignore-vuln "$advisory"); done
+python3 -m pip_audit . --strict --desc=on --aliases=on "${audit_args[@]}"
+zizmor --strict-collection --no-ignores --no-config \
+  --min-severity=high --min-confidence=high .
+docker build --tag freellmpool:release-check .
+trivy_ignore=$(mktemp)
+python3 scripts/security_exceptions.py ids trivy > "$trivy_ignore"
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+  -v "$trivy_ignore:/trivyignore:ro" aquasec/trivy:0.72.0 image \
+  --exit-code 1 --severity HIGH,CRITICAL --pkg-types os,library \
+  --scanners vuln --ignorefile /trivyignore freellmpool:release-check
 ```
 
 `check_release_ready.py` now bootstraps its own compatible `twine`/`pkginfo`
@@ -28,18 +45,40 @@ Run after the PR is merged and the verified commit is on `main`:
 ```bash
 git switch main
 git pull --ff-only
-git tag -a v0.11.4 -m "freellmpool 0.11.4"
+release_version=$(python3 -c \
+  'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+release_tag="v$release_version"
+test -z "$(git tag --list "$release_tag")"
+if gh release view "$release_tag" >/dev/null 2>&1; then
+  echo "Refusing to reuse existing release $release_tag" >&2
+  exit 1
+fi
+git tag -a "$release_tag" -m "freellmpool $release_version"
+git push origin "$release_tag"
 ```
 
 ## Build And Publish
 
-Only the operator should run the publish step:
+The pushed tag starts the `Release evidence` and `Docker` workflows. Each
+workflow revalidates the tag and security gates before publishing anything.
+Wait for both to pass. Download the matching evidence artifact and verify that
+its wheel and source archive attestations resolve to the tagged commit:
 
 ```bash
-rm -rf dist
-python3 -m build
-python3 -m twine check dist/*
-python3 -m twine upload dist/*
+release_evidence_dir=$(mktemp -d)
+gh run download --name "python-release-evidence-$release_tag" \
+  --dir "$release_evidence_dir"
+gh attestation verify "$release_evidence_dir"/*.whl -R 0xzr/freellmpool
+gh attestation verify "$release_evidence_dir"/*.tar.gz -R 0xzr/freellmpool
+python3 -m twine check "$release_evidence_dir"/*.whl \
+  "$release_evidence_dir"/*.tar.gz
+```
+
+Only the operator should upload those exact attested package files:
+
+```bash
+python3 -m twine upload "$release_evidence_dir"/*.whl \
+  "$release_evidence_dir"/*.tar.gz
 ```
 
 After upload, smoke-test the published artifact:
@@ -50,10 +89,9 @@ python3 scripts/check_release_ready.py --check-pypi
 
 ## Post-Release
 
-```bash
-git push origin v0.11.4
-```
-
-Create the GitHub release from the pushed tag and paste the `0.11.4` changelog
-entry. Do not include API keys, provider credentials, or unpublished issue draft
-details in the release notes.
+Create the GitHub release from `$release_tag` and paste its changelog entry.
+Attach the downloaded SPDX JSON files. Verify the GHCR image provenance with
+`gh attestation verify
+oci://ghcr.io/0xzr/freellmpool:$release_version -R 0xzr/freellmpool`. Do not
+include API keys, provider credentials, or unpublished issue draft details in
+the release notes.

--- a/docs/SECURITY_ENFORCEMENT.md
+++ b/docs/SECURITY_ENFORCEMENT.md
@@ -1,0 +1,32 @@
+# Security Merge Enforcement
+
+The repository-level workflows are only gates when GitHub requires their
+results. The live `main` protection must retain the existing CI contexts and
+also require these GitHub Actions check contexts:
+
+- `High-severity Python source audit`
+- `Python dependency audit`
+- `GitHub Actions audit`
+- `Container vulnerability audit`
+- `Analyze Python`
+
+The repository also has active ruleset `19967943`, named `CodeQL high-severity
+merge protection`. It targets the default branch, requires the `CodeQL` tool,
+uses `high_or_higher` for security alerts, and uses `errors` for non-security
+alerts. There are no bypass actors.
+
+Administrators can verify the live controls without changing them:
+
+```bash
+gh api repos/0xzr/freellmpool/branches/main/protection/required_status_checks \
+  --jq '{strict, contexts}'
+gh api repos/0xzr/freellmpool/rulesets \
+  --jq '.[] | select(.name == "CodeQL high-severity merge protection") | .id'
+gh api repos/0xzr/freellmpool/rules/branches/main
+```
+
+After changing workflow job names, update branch protection in the same pull
+request and verify the exact PR head reports every replacement context before
+merging. Never remove an existing required context merely to unblock a merge.
+The CodeQL ruleset should remain active; use GitHub's code-scanning dismissal
+workflow with a linked issue for reviewed false positives.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,14 @@ dev = [
     "mypy>=1.10",
     "pytest>=8.0",
     "pytest-cov>=5.0",
+    "pyyaml>=6.0,<7",
     "ruff>=0.6",
     "twine>=5.0",
+]
+security = [
+    "bandit==1.9.4",
+    "pip-audit==2.10.1",
+    "zizmor==1.28.0",
 ]
 
 [project.scripts]

--- a/scripts/security_exceptions.py
+++ b/scripts/security_exceptions.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Validate and render the repository's time-bounded scanner exceptions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tokenize
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_POLICY = ROOT / ".github" / "security-exceptions.json"
+SCANNERS = frozenset({"pip-audit", "trivy"})
+_FIELDS = frozenset(
+    {"id", "scanner", "justification", "owner", "expires", "issue"}
+)
+_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{2,127}")
+_OWNER = re.compile(r"@[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?")
+_ISSUE = re.compile(
+    r"https://github\.com/0xzr/freellmpool/"
+    r"(?:issues/[1-9][0-9]*|security/advisories/GHSA-[A-Za-z0-9-]+)"
+)
+_MAX_POLICY_BYTES = 256_000
+_PYTHON_SUPPRESSION_PATTERNS = (
+    ("Bandit", re.compile(r"#\s*nosec(?:\s|$)", re.IGNORECASE)),
+    ("CodeQL", re.compile(r"#\s*(?:lgtm|codeql)\s*\[", re.IGNORECASE)),
+)
+_YAML_SUPPRESSION_PATTERNS = (
+    ("zizmor", re.compile(r"#\s*zizmor:\s*ignore", re.IGNORECASE)),
+    ("CodeQL", re.compile(r"#\s*(?:lgtm|codeql)\s*\[", re.IGNORECASE)),
+)
+_IGNORED_TREE_PARTS = frozenset(
+    {
+        ".codegraph",
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "build",
+        "dist",
+        "node_modules",
+        "site-packages",
+        "vendor",
+        "venv",
+    }
+)
+
+
+class ExceptionPolicyError(ValueError):
+    """The exception registry is malformed, expired, or too permissive."""
+
+
+@dataclass(frozen=True)
+class SecurityException:
+    id: str
+    scanner: str
+    justification: str
+    owner: str
+    expires: date
+    issue: str
+
+
+def load_exceptions(
+    path: Path = DEFAULT_POLICY,
+    *,
+    today: date | None = None,
+) -> tuple[SecurityException, ...]:
+    """Load a strict, bounded registry and reject expired entries."""
+    today = today or datetime.now(UTC).date()
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        raise ExceptionPolicyError(f"cannot read exception policy: {exc}") from exc
+    if len(raw) > _MAX_POLICY_BYTES:
+        raise ExceptionPolicyError("exception policy exceeds size limit")
+    try:
+        payload = json.loads(raw)
+    except (UnicodeError, json.JSONDecodeError) as exc:
+        raise ExceptionPolicyError(f"invalid exception policy JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ExceptionPolicyError("exception policy must be an object")
+    if set(payload) != {"schema_version", "exceptions"}:
+        raise ExceptionPolicyError("exception policy has unknown or missing fields")
+    if payload["schema_version"] != 1:
+        raise ExceptionPolicyError("unsupported exception policy schema_version")
+    entries = payload["exceptions"]
+    if not isinstance(entries, list):
+        raise ExceptionPolicyError("exceptions must be a list")
+
+    result: list[SecurityException] = []
+    seen: set[tuple[str, str]] = set()
+    for index, entry in enumerate(entries):
+        prefix = f"exceptions[{index}]"
+        if not isinstance(entry, dict) or set(entry) != _FIELDS:
+            raise ExceptionPolicyError(f"{prefix} has unknown or missing fields")
+        values = {key: entry[key] for key in _FIELDS}
+        if not all(isinstance(value, str) for value in values.values()):
+            raise ExceptionPolicyError(f"{prefix} fields must all be strings")
+        scanner = values["scanner"]
+        if scanner not in SCANNERS:
+            raise ExceptionPolicyError(f"{prefix} scanner is unsupported")
+        exception_id = values["id"]
+        if _ID.fullmatch(exception_id) is None:
+            raise ExceptionPolicyError(f"{prefix} id is invalid")
+        justification = values["justification"].strip()
+        if not 20 <= len(justification) <= 1_000:
+            raise ExceptionPolicyError(
+                f"{prefix} justification must contain 20-1000 characters"
+            )
+        owner = values["owner"]
+        if _OWNER.fullmatch(owner) is None:
+            raise ExceptionPolicyError(f"{prefix} owner must be a GitHub handle")
+        issue = values["issue"]
+        if _ISSUE.fullmatch(issue) is None:
+            raise ExceptionPolicyError(
+                f"{prefix} issue must link to this repository's issue tracker"
+            )
+        try:
+            expires = date.fromisoformat(values["expires"])
+        except ValueError as exc:
+            raise ExceptionPolicyError(
+                f"{prefix} expires must be an ISO date"
+            ) from exc
+        if expires < today:
+            raise ExceptionPolicyError(
+                f"{prefix} expired on {expires.isoformat()}"
+            )
+        if (expires - today).days > 90:
+            raise ExceptionPolicyError(
+                f"{prefix} expires more than 90 days in the future"
+            )
+        identity = (scanner, exception_id)
+        if identity in seen:
+            raise ExceptionPolicyError(f"{prefix} duplicates {scanner}/{exception_id}")
+        seen.add(identity)
+        result.append(
+            SecurityException(
+                id=exception_id,
+                scanner=scanner,
+                justification=justification,
+                owner=owner,
+                expires=expires,
+                issue=issue,
+            )
+        )
+    return tuple(result)
+
+
+def find_native_suppressions(root: Path = ROOT) -> tuple[str, ...]:
+    """Find in-repository directives that would bypass mandatory scanners."""
+    findings: list[str] = []
+    python_paths = sorted(
+        path
+        for path in root.rglob("*.py")
+        if not _IGNORED_TREE_PARTS.intersection(path.relative_to(root).parts)
+    )
+    for path in python_paths:
+        try:
+            with path.open(encoding="utf-8") as handle:
+                comments = (
+                    token
+                    for token in tokenize.generate_tokens(handle.readline)
+                    if token.type == tokenize.COMMENT
+                )
+                for token in comments:
+                    for scanner, pattern in _PYTHON_SUPPRESSION_PATTERNS:
+                        if pattern.search(token.string):
+                            relative = path.relative_to(root).as_posix()
+                            findings.append(
+                                f"{relative}:{token.start[0]}: {scanner} suppression"
+                            )
+        except (OSError, UnicodeError, tokenize.TokenError) as exc:
+            raise ExceptionPolicyError(f"cannot inspect {path}: {exc}") from exc
+
+    yaml_paths = [
+        *sorted((root / ".github").rglob("*.yml")),
+        *sorted((root / ".github").rglob("*.yaml")),
+        *(path for path in (root / "zizmor.yml", root / "zizmor.yaml") if path.is_file()),
+    ]
+    for path in yaml_paths:
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeError) as exc:
+            raise ExceptionPolicyError(f"cannot inspect {path}: {exc}") from exc
+        for line_number, line in enumerate(lines, 1):
+            for scanner, pattern in _YAML_SUPPRESSION_PATTERNS:
+                if pattern.search(line):
+                    relative = path.relative_to(root).as_posix()
+                    findings.append(
+                        f"{relative}:{line_number}: {scanner} suppression"
+                    )
+    return tuple(sorted(findings))
+
+
+def ids_for(
+    exceptions: Iterable[SecurityException],
+    scanner: str,
+) -> tuple[str, ...]:
+    if scanner not in SCANNERS:
+        raise ExceptionPolicyError(f"unsupported scanner: {scanner}")
+    return tuple(
+        sorted(entry.id for entry in exceptions if entry.scanner == scanner)
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--file",
+        type=Path,
+        default=DEFAULT_POLICY,
+        help="exception registry (default: .github/security-exceptions.json)",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("validate", help="validate the complete registry")
+    subparsers.add_parser(
+        "check-suppressions",
+        help="reject native source and workflow suppression directives",
+    )
+    ids_parser = subparsers.add_parser("ids", help="print active IDs for one scanner")
+    ids_parser.add_argument("scanner", choices=sorted(SCANNERS))
+    args = parser.parse_args(argv)
+    try:
+        exceptions = load_exceptions(args.file)
+    except ExceptionPolicyError as exc:
+        print(f"security exception policy failed: {exc}", file=sys.stderr)
+        return 2
+    if args.command == "ids":
+        for exception_id in ids_for(exceptions, args.scanner):
+            print(exception_id)
+    elif args.command == "check-suppressions":
+        try:
+            findings = find_native_suppressions()
+        except ExceptionPolicyError as exc:
+            print(f"security suppression check failed: {exc}", file=sys.stderr)
+            return 2
+        if findings:
+            for finding in findings:
+                print(finding, file=sys.stderr)
+            return 2
+        print("Security suppression check passed: none found.")
+    else:
+        print(f"Security exception policy passed: {len(exceptions)} active.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -76,9 +76,9 @@ def test_ci_validates_opencode_packages_with_current_runtimes() -> None:
     )[0]
     for required in (
         "permissions:\n      contents: read",
-        "actions/setup-node@v7",
+        "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
         'node-version: "24"',
-        "oven-sh/setup-bun@v2",
+        "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
         "npm@11.5.1",
         "node scripts/check_opencode_packages.mjs",
     ):
@@ -111,10 +111,10 @@ def test_opencode_publish_workflow_is_manual_protected_and_exact_sha() -> None:
         "contents: read",
         "id-token: write",
         "runs-on: ubuntu-latest",
-        "actions/checkout@v7",
-        "actions/setup-node@v7",
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
         'node-version: "24"',
-        "oven-sh/setup-bun@v2",
+        "oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6",
         "npm@11.5.1",
         "git rev-parse origin/main",
         "node scripts/check_opencode_packages.mjs",
@@ -165,9 +165,13 @@ def test_supported_python_versions_match_ci() -> None:
 
 def test_container_uses_supported_python_314() -> None:
     dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
-    match = re.search(r"^FROM python:(3\.\d+)-slim$", dockerfile, re.MULTILINE)
+    match = re.search(
+        r"^FROM python:(3\.\d+)-(?:alpine|slim)@sha256:([0-9a-f]{64})$",
+        dockerfile,
+        re.MULTILINE,
+    )
 
-    assert match is not None, "Dockerfile must use a versioned official Python slim image"
+    assert match is not None, "Dockerfile must use a digest-pinned official Python image"
     assert match.group(1) == "3.14"
     assert match.group(1) in _ci_python_versions()
 

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import re
+import sys
+import tomllib
+from datetime import date
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = ROOT / ".github" / "workflows"
+SPEC = importlib.util.spec_from_file_location(
+    "security_exceptions",
+    ROOT / "scripts" / "security_exceptions.py",
+)
+assert SPEC is not None and SPEC.loader is not None
+SECURITY_EXCEPTIONS = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = SECURITY_EXCEPTIONS
+SPEC.loader.exec_module(SECURITY_EXCEPTIONS)
+ExceptionPolicyError = SECURITY_EXCEPTIONS.ExceptionPolicyError
+find_native_suppressions = SECURITY_EXCEPTIONS.find_native_suppressions
+ids_for = SECURITY_EXCEPTIONS.ids_for
+load_exceptions = SECURITY_EXCEPTIONS.load_exceptions
+
+
+def _action_uses(value: object) -> list[str]:
+    if isinstance(value, dict):
+        found = [
+            action
+            for key, action in value.items()
+            if key == "uses" and isinstance(action, str)
+        ]
+        for nested in value.values():
+            found.extend(_action_uses(nested))
+        return found
+    if isinstance(value, list):
+        found = []
+        for nested in value:
+            found.extend(_action_uses(nested))
+        return found
+    return []
+
+
+def _unpinned_actions(workflows: list[Path]) -> list[str]:
+    unpinned: list[str] = []
+    for workflow in sorted(workflows):
+        document = yaml.safe_load(workflow.read_text(encoding="utf-8"))
+        for action in _action_uses(document):
+            if action.startswith("./"):
+                continue
+            if re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", action) is None:
+                unpinned.append(f"{workflow.name}: {action}")
+    return unpinned
+
+
+def _action_manifests(root: Path) -> list[Path]:
+    ignored = {
+        ".git",
+        ".venv",
+        "build",
+        "dist",
+        "node_modules",
+        "site-packages",
+        "vendor",
+        "venv",
+    }
+    manifests = {
+        *root.glob(".github/workflows/*.yml"),
+        *root.glob(".github/workflows/*.yaml"),
+        *(
+            path
+            for name in ("action.yml", "action.yaml")
+            for path in root.rglob(name)
+            if not ignored.intersection(path.relative_to(root).parts)
+        ),
+    }
+    queue = list(manifests)
+    while queue:
+        manifest = queue.pop()
+        document = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+        for action in _action_uses(document):
+            if not action.startswith("./"):
+                continue
+            candidate = root / action.removeprefix("./")
+            choices = (
+                (candidate / "action.yml", candidate / "action.yaml")
+                if candidate.is_dir()
+                else (candidate,)
+            )
+            local_manifest = next((path for path in choices if path.is_file()), None)
+            if local_manifest is not None and local_manifest not in manifests:
+                manifests.add(local_manifest)
+                queue.append(local_manifest)
+    return sorted(manifests)
+
+
+def test_all_third_party_actions_are_pinned_to_full_commits():
+    unpinned = _unpinned_actions(_action_manifests(ROOT))
+    assert unpinned == []
+
+
+def test_yaml_workflows_are_included_in_action_pin_checks(tmp_path):
+    regular = tmp_path / "regular.yaml"
+    regular.write_text("steps:\n  - uses : actions/checkout@v7\n", encoding="utf-8")
+    flow = tmp_path / "flow.yaml"
+    flow.write_text("steps: [{uses: actions/setup-python@v7}]\n", encoding="utf-8")
+
+    assert _unpinned_actions([regular, flow]) == [
+        "flow.yaml: actions/setup-python@v7",
+        "regular.yaml: actions/checkout@v7",
+    ]
+
+
+def test_composite_actions_outside_github_are_included_in_pin_checks(tmp_path):
+    action = tmp_path / "actions" / "example" / "action.yml"
+    action.parent.mkdir(parents=True)
+    action.write_text(
+        "runs:\n"
+        "  using: composite\n"
+        "  steps:\n"
+        "    - uses: actions/checkout@v7\n",
+        encoding="utf-8",
+    )
+
+    assert _unpinned_actions(_action_manifests(tmp_path)) == [
+        "action.yml: actions/checkout@v7"
+    ]
+
+
+def test_referenced_local_actions_are_followed_through_excluded_trees(tmp_path):
+    workflow = tmp_path / ".github" / "workflows" / "ci.yml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "jobs:\n  test:\n    steps:\n      - uses: ./vendor/example\n",
+        encoding="utf-8",
+    )
+    action = tmp_path / "vendor" / "example" / "action.yml"
+    action.parent.mkdir(parents=True)
+    action.write_text(
+        "runs:\n"
+        "  using: composite\n"
+        "  steps:\n"
+        "    - uses: actions/checkout@v7\n",
+        encoding="utf-8",
+    )
+
+    assert _unpinned_actions(_action_manifests(tmp_path)) == [
+        "action.yml: actions/checkout@v7"
+    ]
+
+
+def test_container_base_is_digest_pinned():
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+    assert re.search(
+        r"^FROM python:3\.14-(?:alpine|slim)@sha256:[0-9a-f]{64}$",
+        dockerfile,
+        re.MULTILINE,
+    )
+
+
+def test_pull_requests_have_source_dependency_workflow_and_container_gates():
+    codeql = (WORKFLOWS / "codeql.yml").read_text(encoding="utf-8")
+    security = (WORKFLOWS / "security.yml").read_text(encoding="utf-8")
+
+    assert "pull_request:" in codeql
+    assert "security-events: write" in codeql
+    assert "github/codeql-action/init@" in codeql
+    assert "github/codeql-action/analyze@" in codeql
+
+    assert "pip-audit==2.10.1" in security
+    assert "zizmor==1.28.0" in security
+    assert "--no-ignores" in security
+    assert "--no-config" in security
+    assert "bandit\n          --recursive src" in security
+    assert "--skip" not in security
+    assert "--ignore-nosec" in security
+    assert "check-suppressions" in security
+    assert "--min-severity=high" in security
+    assert "aquasecurity/trivy-action@" in security
+    assert "severity: HIGH,CRITICAL" in security
+    assert "exit-code: \"1\"" in security
+
+
+def test_release_artifacts_and_images_have_sboms_and_provenance():
+    packages = (WORKFLOWS / "release-evidence.yml").read_text(encoding="utf-8")
+    images = (WORKFLOWS / "docker.yml").read_text(encoding="utf-8")
+    package_jobs = yaml.safe_load(packages)["jobs"]
+    image_jobs = yaml.safe_load(images)["jobs"]
+
+    for workflow in (packages, images):
+        assert "workflow_dispatch:" not in workflow
+        assert "if: github.ref_type == 'tag'" not in workflow
+        assert 'tags: ["v*"]' in workflow
+        assert "git merge-base --is-ancestor" in workflow
+
+    assert "anchore/sbom-action@" in packages
+    assert "pip-audit==2.10.1" in packages
+    assert "scripts/security_exceptions.py validate" in packages
+    assert package_jobs["gate"]["permissions"] == {"contents": "read"}
+    assert package_jobs["packages"]["needs"] == "gate"
+    assert package_jobs["packages"]["permissions"]["id-token"] == "write"
+    assert packages.count("actions/attest@") >= 3
+    assert "actions/upload-artifact@" in packages
+    assert "dist/*.whl" in packages
+    assert "dist/*.tar.gz" in packages
+
+    assert "anchore/sbom-action@" in images
+    assert "aquasecurity/trivy-action@" in images
+    assert images.index("aquasecurity/trivy-action@") < images.index(
+        "Promote exact scanned image"
+    )
+    assert images.count("docker/build-push-action@") == 1
+    assert "docker/setup-buildx-action@" in images
+    assert "type=docker,dest=/tmp/freellmpool-image.tar" in images
+    assert "input: /tmp/freellmpool-image.tar" in images
+    assert "actions/download-artifact@" in images
+    assert "sha256sum --check freellmpool-image.tar.sha256" in images
+    assert "docker load --input" in images
+    assert image_jobs["gate"]["permissions"] == {"contents": "read"}
+    assert image_jobs["publish"]["needs"] == "gate"
+    assert image_jobs["publish"]["permissions"]["packages"] == "write"
+    assert images.count("actions/attest@") >= 2
+    assert "push-to-registry: true" in images
+
+
+def test_release_checklist_only_passes_distributions_to_twine():
+    checklist = (ROOT / "docs" / "RELEASE_CHECKLIST.md").read_text(encoding="utf-8")
+
+    assert "v0.11.4" not in checklist
+    assert ".[dev,security]" in checklist
+    assert 'twine check "$release_evidence_dir"/*.whl' in checklist
+    assert '"$release_evidence_dir"/*.tar.gz' in checklist
+    assert 'twine upload "$release_evidence_dir"/*.whl' in checklist
+
+
+def test_security_enforcement_is_documented():
+    enforcement = (ROOT / "docs" / "SECURITY_ENFORCEMENT.md").read_text(
+        encoding="utf-8"
+    )
+
+    for required in (
+        "High-severity Python source audit",
+        "Python dependency audit",
+        "GitHub Actions audit",
+        "Container vulnerability audit",
+        "Analyze Python",
+        "high_or_higher",
+    ):
+        assert required in enforcement
+
+
+def test_security_tooling_extra_is_complete_and_pinned():
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    extras = pyproject["project"]["optional-dependencies"]
+
+    assert "pyyaml>=6.0,<7" in extras["dev"]
+    assert extras["security"] == [
+        "bandit==1.9.4",
+        "pip-audit==2.10.1",
+        "zizmor==1.28.0",
+    ]
+
+
+def test_native_source_and_workflow_suppressions_are_rejected(tmp_path):
+    source = tmp_path / "scripts" / "unsafe.py"
+    source.parent.mkdir()
+    source.write_text("dangerous()  # nosec B608\n", encoding="utf-8")
+    workflow = tmp_path / ".github" / "actions" / "nested" / "action.yaml"
+    workflow.parent.mkdir(parents=True)
+    workflow.write_text(
+        "# zizmor: ignore[dangerous-triggers]\n"
+        "steps:\n"
+        "  - run: thing  # codeql[py/command-line-injection]\n",
+        encoding="utf-8",
+    )
+
+    assert find_native_suppressions(tmp_path) == (
+        ".github/actions/nested/action.yaml:1: zizmor suppression",
+        ".github/actions/nested/action.yaml:3: CodeQL suppression",
+        "scripts/unsafe.py:1: Bandit suppression",
+    )
+
+
+def test_dependabot_and_zizmor_config_suppressions_are_rejected(tmp_path):
+    dependabot = tmp_path / ".github" / "dependabot.yml"
+    dependabot.parent.mkdir()
+    dependabot.write_text(
+        "# zizmor: ignore[dependabot-execution]\nversion: 2\n",
+        encoding="utf-8",
+    )
+    zizmor_config = tmp_path / "zizmor.yml"
+    zizmor_config.write_text(
+        "# zizmor: ignore[dangerous-triggers]\nrules: {}\n",
+        encoding="utf-8",
+    )
+
+    assert find_native_suppressions(tmp_path) == (
+        ".github/dependabot.yml:1: zizmor suppression",
+        "zizmor.yml:1: zizmor suppression",
+    )
+
+
+def test_default_security_exception_registry_is_valid_and_empty():
+    exceptions = load_exceptions(
+        ROOT / ".github" / "security-exceptions.json",
+        today=date(2026, 7, 29),
+    )
+    assert exceptions == ()
+    assert ids_for(exceptions, "pip-audit") == ()
+
+
+@pytest.mark.parametrize(
+    ("change", "message"),
+    [
+        ({"expires": "2026-07-28"}, "expired"),
+        ({"justification": "too short"}, "justification"),
+        ({"owner": ""}, "owner"),
+        ({"scanner": "unknown"}, "scanner"),
+        ({"id": "../../escape"}, "id"),
+        ({"issue": "http://example.test/1"}, "issue"),
+    ],
+)
+def test_invalid_or_expired_security_exceptions_fail_closed(
+    tmp_path,
+    change,
+    message,
+):
+    entry = {
+        "id": "GHSA-abcd-1234-efgh",
+        "scanner": "pip-audit",
+        "justification": "False positive confirmed against the shipped call path.",
+        "owner": "@maintainer",
+        "expires": "2026-08-15",
+        "issue": "https://github.com/0xzr/freellmpool/issues/999",
+    }
+    entry.update(change)
+    path = tmp_path / "exceptions.json"
+    path.write_text(
+        json.dumps({"schema_version": 1, "exceptions": [entry]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ExceptionPolicyError, match=message):
+        load_exceptions(path, today=date(2026, 7, 29))
+
+
+def test_private_advisory_exception_is_valid(tmp_path):
+    path = tmp_path / "exceptions.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "exceptions": [
+                    {
+                        "id": "GHSA-abcd-1234-efgh",
+                        "scanner": "pip-audit",
+                        "justification": (
+                            "False positive confirmed against the shipped call path."
+                        ),
+                        "owner": "@maintainer",
+                        "expires": "2026-08-15",
+                        "issue": (
+                            "https://github.com/0xzr/freellmpool/"
+                            "security/advisories/GHSA-abcd-1234-efgh"
+                        ),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exceptions = load_exceptions(path, today=date(2026, 7, 29))
+
+    assert ids_for(exceptions, "pip-audit") == ("GHSA-abcd-1234-efgh",)


### PR DESCRIPTION
Closes #72.

## Summary
- require pinned Actions, CodeQL, Bandit, pip-audit, zizmor, Trivy, and fail-closed exception policy
- build and scan one exact release image before a separate least-privilege publisher promotes it
- generate package/image SPDX SBOMs and GitHub provenance attestations
- document reproducible security/release workflows and live merge enforcement

## Validation
- 883 tests passed; 84% coverage
- Ruff and actionlint clean
- Bandit 1.9.4, pip-audit 2.10.1, and zizmor 1.28.0 clean
- Trivy 0.72.0: zero high/critical findings on exact archive handoff
- fresh wheel/sdist build, Twine check, and install smoke passed
- Sol 5.6 xhigh approved exact pre-commit tree ce85abe95bfc05f670571d9610a698664b3c2ce4

## Summary by Sourcery

Harden supply chain security and release provenance for packages and container images.

New Features:
- Add dedicated security workflows for CodeQL, Python source/dependency analysis, GitHub Actions scanning, and container vulnerability auditing.
- Introduce release evidence and Docker workflows that generate SBOMs and GitHub provenance attestations for packages and container images, with strict tag provenance checks.

Enhancements:
- Pin all GitHub Actions and the container base image to exact commit or digest identifiers and enforce this via new supply-chain tests.
- Refine Docker image build and publish process to separate scan and promotion stages with least-privilege publishing and high/critical vulnerability gates.
- Extend release checklist and security documentation to cover local reproduction of security gates, exception handling, and provenance verification.
- Add a security optional-dependency extra for pinned scanner tooling and update CI to use pinned action SHAs and tools.

Tests:
- Add supply-chain tests to ensure action pinning, container base digest pinning, security workflows, exception policies, and release evidence workflows remain enforced.