### PR TITLE
Add cross-provider protocol conformance canaries

### DIFF
--- a/.github/workflows/catalog-sentinel.yml
+++ b/.github/workflows/catalog-sentinel.yml
@@ -119,7 +119,7 @@ jobs:
   authenticated-probes:
     name: Protected authenticated completion probes
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
     environment: catalog-sentinel
     permissions:
       contents: read
@@ -151,7 +151,9 @@ jobs:
         if: steps.probe-config.outputs.configured == 'true'
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: .sentinel-state/probe.json
+          path: |
+            .sentinel-state/probe.json
+            .sentinel-state/conformance.json
           key: catalog-sentinel-probe-${{ github.run_id }}
           restore-keys: |
             catalog-sentinel-probe-
@@ -175,6 +177,21 @@ jobs:
             --max-models-per-provider 1 \
             "${previous[@]}"
           cp .sentinel-artifacts/probe.json .sentinel-state/probe.json
+      - name: Run bounded protocol conformance canaries
+        if: steps.probe-config.outputs.configured == 'true'
+        env:
+          FREELLMPOOL_CONFORMANCE_FILE: .sentinel-state/conformance.json
+          FREELLMPOOL_CONFORMANCE_KEYS_JSON: ${{ secrets.FREELLMPOOL_SENTINEL_KEYS_JSON }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .sentinel-artifacts .sentinel-state
+          freellmpool conformance run \
+            --features chat,streaming,tools,json,json_schema,vision,responses,anthropic_messages \
+            --max-targets 8 \
+            --timeout 20 \
+            --json > .sentinel-artifacts/conformance.json
+          cp .sentinel-state/conformance.json .sentinel-artifacts/conformance-state.json
       - name: Prepare bounded probe issue
         if: steps.probe-config.outputs.configured == 'true'
         id: probe-drift
@@ -230,11 +247,15 @@ jobs:
           path: |
             .sentinel-artifacts/probe.json
             .sentinel-artifacts/probe.md
+            .sentinel-artifacts/conformance.json
+            .sentinel-artifacts/conformance-state.json
           if-no-files-found: error
           retention-days: 30
       - name: Save probe lifecycle state
         if: steps.probe-config.outputs.configured == 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
-          path: .sentinel-state/probe.json
+          path: |
+            .sentinel-state/probe.json
+            .sentinel-state/conformance.json
           key: catalog-sentinel-probe-${{ github.run_id }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project are documented here. The format is based on
 ## [Unreleased]
 
 ### Added
+- Deterministic, quota-bounded per-model protocol conformance canaries for
+  chat, streaming, tools, JSON object/schema, vision, Responses, and Anthropic Messages,
+  with sanitized persisted evidence, model/status visibility, protected
+  scheduled probes, and feature-aware routing.
 - A weekly, manually dispatchable catalog sentinel with bounded public
   discovery, environment-protected completion probes, sanitized lifecycle
   artifacts, and advisory drift issues that never mutate routing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,9 @@ The whole catalog is [`src/freellmpool/providers.toml`](src/freellmpool/provider
 The scheduled discovery and protected-probe contract is documented in
 [`docs/CATALOG_SENTINEL.md`](docs/CATALOG_SENTINEL.md); sentinel output is
 advisory and never authorizes an automatic catalog mutation.
+Protocol-feature verification, bounded canary rules, and the exact-pin routing
+override are documented in
+[`docs/PROTOCOL_CONFORMANCE.md`](docs/PROTOCOL_CONFORMANCE.md).
 Most providers are OpenAI-compatible, so adding one is just a TOML block:
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -376,6 +376,14 @@ freellmpool keys checklist --target 5    # which keys to add to reach N healthy 
 freellmpool keys add groq                # configure a key (and record metadata)
 ```
 
+Protocol support is verified separately from basic provider health. Run
+`freellmpool conformance run` to check chat, streaming, tools, JSON object/schema,
+vision, Responses, and Anthropic Messages with bounded synthetic requests, then inspect
+the sanitized evidence with `freellmpool conformance status --json`.
+Feature-specific auto-routing uses only verified targets; an exact
+provider/model pin is the explicit override. Full operator and privacy contract:
+[docs/PROTOCOL_CONFORMANCE.md](docs/PROTOCOL_CONFORMANCE.md).
+
 `capacity status` is local-first: it reads your catalog, environment, and
 per-day quota counters and labels each provider `healthy`, `low_quota`,
 `exhausted`, `invalid_key`, or `missing`. It also syncs an advisory external

--- a/docs/PROTOCOL_CONFORMANCE.md
+++ b/docs/PROTOCOL_CONFORMANCE.md
@@ -1,0 +1,74 @@
+# Protocol conformance canaries
+
+A successful short completion proves basic availability, not support for
+streaming, tools, structured JSON, images, the OpenAI Responses bridge, or the
+Anthropic Messages bridge. freellmpool records those capabilities separately
+for each exact provider/model target.
+
+## Run and inspect canaries
+
+Run the default deterministic matrix against at most the first enabled model
+of eight configured providers:
+
+```bash
+freellmpool conformance run
+freellmpool conformance status
+freellmpool conformance status --json
+```
+
+Narrow the quota spend when needed:
+
+```bash
+freellmpool conformance run \
+  --providers groq,cerebras \
+  --model some-exact-model \
+  --features chat,streaming,tools,json,json_schema,vision,responses,anthropic_messages \
+  --max-targets 2 \
+  --timeout 10 \
+  --json
+```
+
+Each selected feature makes at most one request per target, requests no more
+than 16 output tokens, and clamps its timeout to 60 seconds. The prompts,
+tool schema, and one-pixel vision image are fixed synthetic constants. Canaries
+never send repository files, user prompts, or previous conversations.
+
+Registered providers and `freellmpool.providers` entry-point providers are
+included in both `freellmpool models` and `freellmpool conformance run`, so
+plugin targets can earn the same per-feature evidence as built-in targets.
+
+The state defaults to
+`~/.config/freellmpool/conformance.json`. Set
+`FREELLMPOOL_CONFORMANCE_FILE` to use another path. The file contains only a
+target fingerprint, bounded status/classification values, timestamps, and
+verification counts. It never stores credentials, provider response text,
+exception messages, prompts, repository content, or user content.
+
+## Routing contract
+
+Feature-specific, unpinned traffic is eligible only for targets with a current
+`pass` for every required feature. If no target qualifies, routing fails
+locally without spending provider quota. A request that is explicitly pinned
+to exactly one provider and one model is the deliberate override.
+
+Evidence is bound to the provider id, adapter, base URL, and model id. Changing
+an adapter, endpoint, or model id invalidates the old evidence automatically;
+run the canaries again. Unsupported feature results remain separate from
+provider availability health and do not open availability circuits.
+
+`freellmpool models --json`, the proxy `/v1/models` responses, and `/status`
+include `capabilities` and `verified_features`.
+
+## Protected automation
+
+The scheduled and manually dispatchable catalog-sentinel workflow runs a
+bounded matrix inside the protected `catalog-sentinel` environment. It caches
+the sanitized state and uploads sanitized run/state artifacts.
+
+The workflow maps its existing protected JSON secret into
+`FREELLMPOOL_CONFORMANCE_KEYS_JSON`. This input is capped at 64 KiB; only
+catalog-declared `key_env` and `extra_env` names are imported, values are
+bounded strings, unknown names are ignored, and values are never printed or
+persisted in evidence. This variable is intended for protected automation;
+normal local use should continue to use ordinary provider environment
+variables or the freellmpool key configuration.

--- a/scripts/stress_proxy.py
+++ b/scripts/stress_proxy.py
@@ -324,9 +324,18 @@ def _exercise(base: str, index: int) -> tuple[str, int]:
             )
             assert _event_names(events) == [
                 "response.created",
+                "response.output_item.added",
+                "response.content_part.added",
                 "response.output_text.delta",
+                "response.output_text.done",
+                "response.content_part.done",
+                "response.output_item.done",
                 "response.completed",
             ]
+            assert events[0][1]["response"]["output"] == []
+            assert [event["sequence_number"] for _, event in events] == list(
+                range(len(events))
+            )
             assert events[-1][1]["type"] == "response.completed"
             return "responses_stream", status
         if route == 7:

--- a/src/freellmpool/aio.py
+++ b/src/freellmpool/aio.py
@@ -28,6 +28,7 @@ from .client import (
     _strip_think,
     _to_gemini_contents,
 )
+from .conformance import required_features
 from .context import context_limit_from_error, estimate_input_tokens
 from .errors import (
     AllProvidersExhausted,
@@ -208,6 +209,7 @@ class AsyncPool:
         timeout: float,
         tools,
         tool_choice,
+        response_format,
     ) -> Reply:
         if _is_thinking(model) and max_tokens < _THINKING_FLOOR:
             max_tokens = _THINKING_FLOOR
@@ -216,6 +218,12 @@ class AsyncPool:
             if tools:
                 raise ProviderHTTPError(
                     400, "gemini adapter does not support tools", retryable=True
+                )
+            if response_format is not None:
+                raise ProviderHTTPError(
+                    400,
+                    "gemini adapter does not support OpenAI response_format",
+                    retryable=True,
                 )
             return await self._acall_gemini(
                 provider,
@@ -245,6 +253,7 @@ class AsyncPool:
                     timeout=timeout,
                     tools=tools,
                     tool_choice=tool_choice,
+                    response_format=response_format,
                     post=self._pool._post,
                 )
         return await self._acall_openai(
@@ -257,6 +266,7 @@ class AsyncPool:
             timeout=timeout,
             tools=tools,
             tool_choice=tool_choice,
+            response_format=response_format,
         )
 
     async def _acall_openai(
@@ -271,6 +281,7 @@ class AsyncPool:
         timeout,
         tools,
         tool_choice,
+        response_format,
     ) -> Reply:
         base_url = provider.base_url
         if provider.adapter == "cloudflare":
@@ -290,6 +301,8 @@ class AsyncPool:
             body["tools"] = tools
             if tool_choice is not None:
                 body["tool_choice"] = tool_choice
+        if response_format is not None:
+            body["response_format"] = response_format
         result = await self._apost(url, headers, body, timeout)
         if result.status != 200:
             raise _client._provider_http_error(result)
@@ -366,6 +379,8 @@ class AsyncPool:
         timeout: float = 90.0,
         tools: list | None = None,
         tool_choice=None,
+        response_format=None,
+        protocol: str | None = None,
         routing: str | None = None,
     ) -> Reply:
         """Async failover completion — same routing/cache/metrics as :meth:`Pool.chat`.
@@ -377,6 +392,21 @@ class AsyncPool:
             raise NoProvidersConfigured("no provider has an API key set")
         provider_list = list(providers) if providers else None
         eff = normalize_routing_mode(routing, p.routing)
+        features = required_features(
+            messages,
+            tools=tools,
+            response_format=response_format,
+            protocol=protocol,
+        )
+        exact_pin = (
+            model is not None and provider_list is not None and len(provider_list) == 1
+        )
+        candidates = await asyncio.to_thread(
+            p._feature_targets,
+            p._all_targets(include=provider_list, model=model),
+            features,
+            exact_pin=exact_pin,
+        )
 
         cache_key = None
         if p._cache is not None:
@@ -389,9 +419,24 @@ class AsyncPool:
                 tools,
                 tool_choice,
                 eff,
+                response_format=response_format,
+                protocol=protocol,
             )
             hit = await asyncio.to_thread(p._cache.get, cache_key)  # blocking sqlite off-loop
-            if hit is not None:
+            feature_cache_eligible = (
+                hit is not None
+                and (
+                    not features
+                    or exact_pin
+                    or p.conformance is None
+                    or any(
+                        target.provider.id == hit.get("provider_id")
+                        and target.model == hit.get("model")
+                        for target in candidates
+                    )
+                )
+            )
+            if hit is not None and feature_cache_eligible:
                 emit(p._on_event, "cache_hit", key=cache_key)
                 p._bump_stats(cache_hits=1)
                 return Reply(
@@ -409,7 +454,7 @@ class AsyncPool:
         difficulty = prompt_difficulty(messages, max_tokens, tools) if eff == "quality" else None
         targets = await asyncio.to_thread(
             p._order,
-            p._all_targets(include=provider_list, model=model),
+            candidates,
             difficulty,
             eff,
         )
@@ -473,6 +518,7 @@ class AsyncPool:
                     timeout=remaining,
                     tools=tools,
                     tool_choice=tool_choice,
+                    response_format=response_format,
                 )
             except ProviderHTTPError as exc:
                 is_ctx, limit = context_limit_from_error(exc.status, str(exc))

--- a/src/freellmpool/cache.py
+++ b/src/freellmpool/cache.py
@@ -65,7 +65,16 @@ class Cache:
 
     @staticmethod
     def make_key(
-        messages, model, providers, max_tokens, temperature, tools, tool_choice=None, routing=None
+        messages,
+        model,
+        providers,
+        max_tokens,
+        temperature,
+        tools,
+        tool_choice=None,
+        routing=None,
+        response_format=None,
+        protocol=None,
     ) -> str | None:
         try:
             payload = json.dumps(
@@ -80,6 +89,8 @@ class Cache:
                     # routing mode expresses an intent about answer source/quality, so
                     # a quality request must not be served a cached fast-routed answer.
                     "routing": routing,
+                    "response_format": response_format,
+                    "protocol": protocol,
                 },
                 sort_keys=True,
             )

--- a/src/freellmpool/cli.py
+++ b/src/freellmpool/cli.py
@@ -17,10 +17,24 @@ from pathlib import Path
 from . import __version__
 from .config import (
     configured_providers,
+    effective_env,
     load_catalog,
     resolve_alias,
     settings,
     split_provider_model,
+)
+from .conformance import (
+    FEATURE_ANTHROPIC_MESSAGES,
+    FEATURE_CHAT,
+    FEATURE_JSON,
+    FEATURE_JSON_SCHEMA,
+    FEATURE_RESPONSES,
+    FEATURE_STREAMING,
+    FEATURE_TOOLS,
+    FEATURE_VISION,
+    FEATURES,
+    ConformanceStore,
+    run_target_canaries,
 )
 from .errors import AllProvidersExhausted, NoProvidersConfigured
 from .mode import (
@@ -47,6 +61,17 @@ def _read_stdin() -> str:
     if sys.stdin is None or sys.stdin.isatty():
         return ""
     return sys.stdin.read()
+
+
+def _runtime_catalog():
+    """Built-in plus registered/entry-point providers, merged by provider id."""
+
+    from .plugins import registered_providers
+
+    by_id = {provider.id: provider for provider in load_catalog()}
+    for provider in registered_providers():
+        by_id[provider.id] = provider
+    return list(by_id.values())
 
 
 def cmd_ask(args: argparse.Namespace) -> int:
@@ -337,7 +362,7 @@ def _strip_fences(text: str) -> str:
 
 
 def cmd_providers(args: argparse.Namespace) -> int:
-    catalog = load_catalog()
+    catalog = _runtime_catalog()
     configured = {p.id for p in configured_providers(catalog)}
     n_models = sum(1 for p in catalog for m in p.models if m.enabled)
     print(f"freellmpool catalog: {len(catalog)} providers, {n_models} models\n")
@@ -371,23 +396,40 @@ def cmd_providers_health(args: argparse.Namespace) -> int:
 def cmd_models(args: argparse.Namespace) -> int:
     import json
 
-    catalog = load_catalog()
+    catalog = _runtime_catalog()
     configured = {p.id for p in configured_providers(catalog)}
+    conformance = ConformanceStore()
+    conformance_snapshot = conformance.snapshot()
     only = set(args.providers.split(",")) if args.providers else None
     if args.json:
-        rows = [
-            {
-                "provider": provider.id,
-                "model": model.name,
-                "enabled": model.enabled,
-                "configured": provider.id in configured,
-            }
-            for provider in catalog
-            if (only is None or provider.id in only)
-            and (not args.configured_only or provider.id in configured)
-            for model in provider.models
-            if model.enabled or args.all
-        ]
+        rows = []
+        for provider in catalog:
+            if (only is not None and provider.id not in only) or (
+                args.configured_only and provider.id not in configured
+            ):
+                continue
+            for model in provider.models:
+                if not model.enabled and not args.all:
+                    continue
+                evidence = conformance.evidence(
+                    provider,
+                    model.name,
+                    snapshot=conformance_snapshot,
+                )
+                rows.append(
+                    {
+                        "provider": provider.id,
+                        "model": model.name,
+                        "enabled": model.enabled,
+                        "configured": provider.id in configured,
+                        "capabilities": evidence,
+                        "verified_features": sorted(
+                            feature
+                            for feature, result in evidence.items()
+                            if result.get("status") == "pass"
+                        ),
+                    }
+                )
         print(json.dumps(rows, separators=(",", ":")))
         return 0
 
@@ -900,6 +942,130 @@ def cmd_capability_status(args: argparse.Namespace) -> int:
     print(f"  top {args.limit} catalog models by capability:")
     for cap, name in scored[: args.limit]:
         print(f"    {cap:.3f}  {name}")
+    return 0
+
+
+def cmd_conformance_run(args: argparse.Namespace) -> int:
+    """Run a bounded deterministic feature matrix and persist sanitized evidence."""
+
+    import json
+
+    features = tuple(part.strip() for part in args.features.split(",") if part.strip())
+    unknown = sorted(set(features) - set(FEATURES))
+    if not features or unknown or len(set(features)) != len(features):
+        detail = f": {', '.join(unknown)}" if unknown else ""
+        print(f"freellmpool: invalid conformance feature selection{detail}", file=sys.stderr)
+        return 2
+    catalog = _runtime_catalog()
+    try:
+        env = _conformance_env(catalog)
+    except ValueError:
+        print(
+            "freellmpool: invalid bounded conformance key map",
+            file=sys.stderr,
+        )
+        return 2
+    configured = configured_providers(catalog, env)
+    only = {part.strip() for part in args.providers.split(",")} if args.providers else None
+    targets = []
+    for provider in configured:
+        if only is not None and provider.id not in only:
+            continue
+        models = [
+            model
+            for model in provider.models
+            if model.enabled and (args.model is None or model.name == args.model)
+        ]
+        if not args.all_models:
+            models = models[:1]
+        targets.extend((provider, model.name) for model in models)
+    targets = targets[: args.max_targets]
+    if not targets:
+        print("freellmpool: no configured provider/model matched the conformance filters", file=sys.stderr)
+        return 3
+
+    store = ConformanceStore()
+    rows = []
+    for provider, model in targets:
+        results = run_target_canaries(
+            provider,
+            model,
+            env=env,
+            features=features,
+            timeout=args.timeout,
+        )
+        for feature, result in results.items():
+            store.record(
+                provider,
+                model,
+                feature,
+                status=result["status"],
+                classification=result["classification"],
+            )
+        rows.append({"provider": provider.id, "model": model, "features": results})
+    if args.json:
+        print(json.dumps(rows, separators=(",", ":"), sort_keys=True))
+    else:
+        for row in rows:
+            print(f"{row['provider']}/{row['model']}")
+            for feature, result in row["features"].items():
+                print(f"  {feature:<20} {result['status']:<12} {result['classification']}")
+    return 0
+
+
+def _conformance_env(catalog) -> dict[str, str]:
+    """Merge a bounded workflow secret map, restricted to catalog-declared names."""
+
+    import json
+
+    env = effective_env()
+    raw = os.environ.get("FREELLMPOOL_CONFORMANCE_KEYS_JSON")
+    env.pop("FREELLMPOOL_CONFORMANCE_KEYS_JSON", None)
+    if not raw:
+        return env
+    if len(raw) > 65_536:
+        raise ValueError("conformance key map exceeds size limit")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("conformance key map must be JSON") from exc
+    if not isinstance(payload, dict) or len(payload) > 256:
+        raise ValueError("conformance key map must be a bounded object")
+    allowed = {
+        name
+        for provider in catalog
+        for name in ((provider.key_env,) + tuple(provider.extra_env))
+        if name
+    }
+    for name, value in payload.items():
+        if name not in allowed:
+            continue
+        if not isinstance(value, str) or len(value) > 8_192:
+            raise ValueError("conformance credential values must be bounded strings")
+        env[name] = value
+    return env
+
+
+def cmd_conformance_status(args: argparse.Namespace) -> int:
+    """Show the sanitized local protocol evidence store."""
+
+    import json
+
+    state = ConformanceStore().snapshot()
+    if args.json:
+        print(json.dumps(state, separators=(",", ":"), sort_keys=True))
+        return 0
+    targets = state.get("targets", {})
+    if not targets:
+        print("No protocol conformance evidence yet. Run `freellmpool conformance run`.")
+        return 0
+    for target, row in sorted(targets.items()):
+        print(target)
+        for feature, result in sorted(row.get("features", {}).items()):
+            print(
+                f"  {feature:<20} {result['status']:<12} "
+                f"{result['classification']}  {result['verified_at']}"
+            )
     return 0
 
 
@@ -2159,6 +2325,65 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_cap_status.add_argument("--limit", type=int, default=15, help="number of models to show")
     p_cap_status.set_defaults(func=cmd_capability_status)
+
+    p_conformance = sub.add_parser(
+        "conformance",
+        help="run and inspect deterministic per-model protocol feature canaries",
+    )
+    conformance_sub = p_conformance.add_subparsers(
+        dest="conformance_command",
+        required=True,
+    )
+    p_conf_run = conformance_sub.add_parser(
+        "run",
+        help="probe a bounded provider/model feature matrix",
+    )
+    default_features = ",".join(
+        (
+            FEATURE_CHAT,
+            FEATURE_STREAMING,
+            FEATURE_TOOLS,
+            FEATURE_JSON,
+            FEATURE_JSON_SCHEMA,
+            FEATURE_VISION,
+            FEATURE_RESPONSES,
+            FEATURE_ANTHROPIC_MESSAGES,
+        )
+    )
+    p_conf_run.add_argument(
+        "--features",
+        default=default_features,
+        help=f"comma-separated features ({', '.join(FEATURES)})",
+    )
+    p_conf_run.add_argument("--providers", help="comma-separated configured provider ids")
+    p_conf_run.add_argument("--model", help="exact model name to probe")
+    p_conf_run.add_argument(
+        "--all-models",
+        action="store_true",
+        help="probe every matching enabled model (still bounded by --max-targets)",
+    )
+    p_conf_run.add_argument(
+        "--max-targets",
+        type=int,
+        choices=range(1, 65),
+        default=8,
+        metavar="1..64",
+        help="maximum exact provider/model targets (default: 8)",
+    )
+    p_conf_run.add_argument(
+        "--timeout",
+        type=float,
+        default=20.0,
+        help="per-feature timeout seconds, clamped to 0.1..60",
+    )
+    p_conf_run.add_argument("--json", action="store_true", help="emit sanitized JSON results")
+    p_conf_run.set_defaults(func=cmd_conformance_run)
+    p_conf_status = conformance_sub.add_parser(
+        "status",
+        help="show cached per-model feature evidence",
+    )
+    p_conf_status.add_argument("--json", action="store_true", help="emit the sanitized state JSON")
+    p_conf_status.set_defaults(func=cmd_conformance_status)
 
     p_capacity = sub.add_parser("capacity", help="summarize legitimate LLM capacity")
     capacity_sub = p_capacity.add_subparsers(dest="capacity_command", required=True)

--- a/src/freellmpool/client.py
+++ b/src/freellmpool/client.py
@@ -485,6 +485,7 @@ def _adapter_openai(
     timeout,
     tools,
     tool_choice,
+    response_format,
     post,
 ) -> Reply:
     return _call_openai(
@@ -498,6 +499,7 @@ def _adapter_openai(
         timeout=timeout,
         tools=tools,
         tool_choice=tool_choice,
+        response_format=response_format,
         post=post,
     )
 
@@ -514,12 +516,19 @@ def _adapter_gemini(
     timeout,
     tools,
     tool_choice,
+    response_format,
     post,
 ) -> Reply:
     # Gemini uses a different tool schema; skip tools for now (the router will
     # fail over to an openai-shape provider that supports them).
     if tools:
         raise ProviderHTTPError(400, "gemini adapter does not support tools", retryable=True)
+    if response_format is not None:
+        raise ProviderHTTPError(
+            400,
+            "gemini adapter does not support OpenAI response_format",
+            retryable=True,
+        )
     return _call_gemini(
         provider,
         model,
@@ -562,6 +571,7 @@ def call(
     timeout: float = 90.0,
     tools: list | None = None,
     tool_choice=None,
+    response_format=None,
     enforce_thinking_floor: bool = True,
     post: PostFn = default_post,
 ) -> Reply:
@@ -577,18 +587,26 @@ def call(
         # budget and return empty content.
         max_tokens = _THINKING_FLOOR
     adapter = _resolve_adapter(provider.adapter)
+    kwargs = {
+        "api_key": api_key,
+        "env": env,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "timeout": timeout,
+        "tools": tools,
+        "tool_choice": tool_choice,
+        "post": post,
+    }
+    # Keep custom adapters source-compatible for ordinary calls. A structured-output
+    # request opts into the new adapter keyword and cleanly fails over if an older
+    # custom adapter does not support it.
+    if response_format is not None or adapter in _BUILTIN_ADAPTERS.values():
+        kwargs["response_format"] = response_format
     return adapter(
         provider,
         model,
         messages,
-        api_key=api_key,
-        env=env,
-        max_tokens=max_tokens,
-        temperature=temperature,
-        timeout=timeout,
-        tools=tools,
-        tool_choice=tool_choice,
-        post=post,
+        **kwargs,
     )
 
 
@@ -604,6 +622,7 @@ def _call_openai(
     timeout: float,
     tools: list | None = None,
     tool_choice=None,
+    response_format=None,
     post: PostFn,
 ) -> Reply:
     base_url = provider.base_url
@@ -626,6 +645,8 @@ def _call_openai(
         body["tools"] = tools
         if tool_choice is not None:
             body["tool_choice"] = tool_choice
+    if response_format is not None:
+        body["response_format"] = response_format
     result = post(url, headers, body, timeout)
     if result.status != 200:
         raise _provider_http_error(result)

--- a/src/freellmpool/conformance.py
+++ b/src/freellmpool/conformance.py
@@ -1,0 +1,618 @@
+"""Per-model protocol conformance evidence and deterministic canary validators.
+
+The store deliberately contains only bounded classifications and timestamps. Provider
+responses, prompts, exception strings, credentials, and user/repository content are
+never persisted.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import os
+import re
+import threading
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from .errors import ProviderHTTPError
+from .models import Provider, Reply
+
+if TYPE_CHECKING:
+    from .router import Target
+
+try:  # pragma: no cover - Windows fallback
+    import fcntl
+except ImportError:  # pragma: no cover
+    fcntl = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - POSIX fallback
+    import msvcrt
+except ImportError:  # pragma: no cover
+    msvcrt = None  # type: ignore[assignment]
+
+
+FEATURE_CHAT = "chat"
+FEATURE_STREAMING = "streaming"
+FEATURE_TOOLS = "tools"
+FEATURE_JSON = "json"
+FEATURE_JSON_SCHEMA = "json_schema"
+FEATURE_VISION = "vision"
+FEATURE_RESPONSES = "responses"
+FEATURE_ANTHROPIC_MESSAGES = "anthropic_messages"
+FEATURES = (
+    FEATURE_CHAT,
+    FEATURE_STREAMING,
+    FEATURE_TOOLS,
+    FEATURE_JSON,
+    FEATURE_JSON_SCHEMA,
+    FEATURE_VISION,
+    FEATURE_RESPONSES,
+    FEATURE_ANTHROPIC_MESSAGES,
+)
+
+STATUS_PASS = "pass"
+STATUS_FAIL = "fail"
+STATUS_UNSUPPORTED = "unsupported"
+STATUS_UNAVAILABLE = "unavailable"
+STATUSES = frozenset({STATUS_PASS, STATUS_FAIL, STATUS_UNSUPPORTED, STATUS_UNAVAILABLE})
+
+_SCHEMA = 1
+_MAX_BYTES = 2_000_000
+_MAX_TARGETS = 1_024
+_MAX_CLASSIFICATION = 64
+_SAFE_CLASSIFICATION = re.compile(r"[a-z][a-z0-9_]{0,63}\Z")
+_MAX_CANARY_FEATURES = len(FEATURES)
+_CANARY_MAX_TOKENS = 16
+_OK_PROMPT = "Reply with exactly OK."
+_JSON_PROMPT = 'Return exactly this JSON object: {"ok":true}'
+_TOOL_PROMPT = "Call record_number exactly once with number 7. Do not answer in text."
+_VISION_PROMPT = "What single color is this image? Reply with one lowercase color word."
+# A fixed 1x1 red PNG. It contains no user or repository content.
+_RED_PIXEL = (
+    "data:image/png;base64,"
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGP4z8DwHwAFAAH/"
+    "iZk9HQAAAABJRU5ErkJggg=="
+)
+_CANARY_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "record_number",
+        "description": "Record the deterministic conformance-test number.",
+        "parameters": {
+            "type": "object",
+            "properties": {"number": {"type": "integer"}},
+            "required": ["number"],
+            "additionalProperties": False,
+        },
+    },
+}
+
+
+def default_conformance_path(env: Mapping[str, str] | None = None) -> Path:
+    """Return the local machine-readable protocol evidence path."""
+
+    source = env if env is not None else os.environ
+    override = source.get("FREELLMPOOL_CONFORMANCE_FILE")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".config" / "freellmpool" / "conformance.json"
+
+
+def target_fingerprint(provider: Provider, model: str) -> str:
+    """Stable identity used to invalidate evidence after adapter/model endpoint changes."""
+
+    value = "\0".join((provider.id, provider.adapter, provider.base_url, model))
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _empty_state() -> dict[str, Any]:
+    return {"version": _SCHEMA, "targets": {}}
+
+
+def _clean_feature(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    status = value.get("status")
+    classification = value.get("classification")
+    verified_at = value.get("verified_at")
+    count = value.get("verification_count")
+    if status not in STATUSES:
+        return None
+    if not isinstance(classification, str) or not _SAFE_CLASSIFICATION.fullmatch(classification):
+        return None
+    if not isinstance(verified_at, str) or len(verified_at) > 32:
+        return None
+    if not isinstance(count, int) or isinstance(count, bool) or not 1 <= count <= 1_000_000:
+        return None
+    return {
+        "status": status,
+        "classification": classification,
+        "verified_at": verified_at,
+        "verification_count": count,
+    }
+
+
+def _clean_state(value: object) -> dict[str, Any]:
+    if not isinstance(value, dict) or value.get("version") != _SCHEMA:
+        return _empty_state()
+    raw_targets = value.get("targets")
+    if not isinstance(raw_targets, dict) or len(raw_targets) > _MAX_TARGETS:
+        return _empty_state()
+    targets: dict[str, Any] = {}
+    for key, raw in raw_targets.items():
+        if (
+            not isinstance(key, str)
+            or not key
+            or len(key) > 512
+            or not isinstance(raw, dict)
+            or not isinstance(raw.get("fingerprint"), str)
+            or len(raw["fingerprint"]) != 64
+        ):
+            continue
+        raw_features = raw.get("features")
+        if not isinstance(raw_features, dict):
+            continue
+        features: dict[str, Any] = {}
+        for feature in FEATURES:
+            cleaned = _clean_feature(raw_features.get(feature))
+            if cleaned is not None:
+                features[feature] = cleaned
+        targets[key] = {"fingerprint": raw["fingerprint"], "features": features}
+    result = {"version": _SCHEMA, "targets": targets}
+    updated_at = value.get("updated_at")
+    if isinstance(updated_at, str) and len(updated_at) <= 32:
+        result["updated_at"] = updated_at
+    return result
+
+
+def _target_recency(value: object) -> str:
+    """Comparable latest verification timestamp for deterministic eviction."""
+
+    if not isinstance(value, dict) or not isinstance(value.get("features"), dict):
+        return ""
+    return max(
+        (
+            row.get("verified_at", "")
+            for row in value["features"].values()
+            if isinstance(row, dict) and isinstance(row.get("verified_at"), str)
+        ),
+        default="",
+    )
+
+
+class ConformanceStore:
+    """Small JSON-backed feature evidence store shared by CLI, router, and proxy."""
+
+    def __init__(self, path: Path | str | None = None):
+        self.path = Path(path) if path is not None else default_conformance_path()
+        self._lock = threading.Lock()
+
+    def _load(self) -> dict[str, Any]:
+        try:
+            if self.path.stat().st_size > _MAX_BYTES:
+                return _empty_state()
+            with self.path.open("r", encoding="utf-8") as handle:
+                return _clean_state(json.load(handle))
+        except (
+            FileNotFoundError,
+            OSError,
+            ValueError,
+            json.JSONDecodeError,
+            RecursionError,
+        ):
+            return _empty_state()
+
+    @contextlib.contextmanager
+    def _file_lock(self) -> Iterator[None]:
+        if fcntl is None and msvcrt is None:
+            raise RuntimeError("no supported cross-process file lock is available")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self.path.with_suffix(self.path.suffix + ".lock")
+        handle = open(lock_path, "a+b")
+        try:
+            if fcntl is not None:
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+            else:
+                handle.seek(0, os.SEEK_END)
+                if handle.tell() == 0:
+                    handle.write(b"\0")
+                    handle.flush()
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+            yield
+        finally:
+            if fcntl is not None:
+                with contextlib.suppress(OSError):
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            else:
+                with contextlib.suppress(OSError):
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            handle.close()
+
+    def _save(self, state: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(
+            f"{self.path.suffix}.{os.getpid()}.{threading.get_ident()}.tmp"
+        )
+        try:
+            flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+            fd = os.open(tmp, flags, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(state, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+            if tmp.stat().st_size > _MAX_BYTES:
+                raise OSError("conformance state exceeds bounded size")
+            os.replace(tmp, self.path)
+        finally:
+            tmp.unlink(missing_ok=True)
+
+    def record(
+        self,
+        provider: Provider,
+        model: str,
+        feature: str,
+        *,
+        status: str,
+        classification: str,
+        verified_at: str | None = None,
+    ) -> None:
+        """Persist one sanitized feature result, preserving only a bounded classification."""
+
+        if feature not in FEATURES:
+            raise ValueError(f"unknown conformance feature: {feature}")
+        if status not in STATUSES:
+            raise ValueError(f"invalid conformance status: {status}")
+        if (
+            not isinstance(classification, str)
+            or len(classification) > _MAX_CLASSIFICATION
+            or _SAFE_CLASSIFICATION.fullmatch(classification) is None
+        ):
+            raise ValueError("invalid conformance classification")
+        stamp = verified_at or datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+        if len(stamp) > 32:
+            raise ValueError("invalid conformance timestamp")
+        key = f"{provider.id}/{model}"
+        with self._lock, self._file_lock():
+            state = self._load()
+            targets = state["targets"]
+            raw = targets.get(key)
+            fingerprint = target_fingerprint(provider, model)
+            if not isinstance(raw, dict) or raw.get("fingerprint") != fingerprint:
+                if key not in targets and len(targets) >= _MAX_TARGETS:
+                    oldest = min(
+                        targets,
+                        key=lambda target: (_target_recency(targets[target]), target),
+                    )
+                    del targets[oldest]
+                raw = {"fingerprint": fingerprint, "features": {}}
+                targets[key] = raw
+            previous = raw["features"].get(feature)
+            count = int(previous.get("verification_count", 0)) + 1 if previous else 1
+            raw["features"][feature] = {
+                "status": status,
+                "classification": classification,
+                "verified_at": stamp,
+                "verification_count": min(count, 1_000_000),
+            }
+            state["updated_at"] = stamp
+            self._save(state)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a sanitized current snapshot without mutating a malformed source file."""
+
+        with self._lock:
+            return self._load()
+
+    def evidence(
+        self,
+        provider: Provider,
+        model: str,
+        *,
+        snapshot: Mapping[str, Any] | None = None,
+    ) -> dict[str, dict[str, Any]]:
+        """Feature evidence for the exact current target identity, or an empty mapping."""
+
+        state = self.snapshot() if snapshot is None else snapshot
+        raw_targets = state.get("targets")
+        if not isinstance(raw_targets, Mapping):
+            return {}
+        raw = raw_targets.get(f"{provider.id}/{model}")
+        if not isinstance(raw, dict) or raw.get("fingerprint") != target_fingerprint(provider, model):
+            return {}
+        return {name: dict(row) for name, row in raw.get("features", {}).items()}
+
+    def passes(
+        self,
+        provider: Provider,
+        model: str,
+        features: Iterable[str],
+        *,
+        snapshot: Mapping[str, Any] | None = None,
+    ) -> bool:
+        evidence = self.evidence(provider, model, snapshot=snapshot)
+        return all(evidence.get(feature, {}).get("status") == STATUS_PASS for feature in features)
+
+    def verified_targets(
+        self,
+        targets: Iterable[Target],
+        features: Iterable[str],
+    ) -> list[Target]:
+        wanted = frozenset(features)
+        if not wanted:
+            return list(targets)
+        snapshot = self.snapshot()
+        return [
+            target
+            for target in targets
+            if self.passes(target.provider, target.model, wanted, snapshot=snapshot)
+        ]
+
+
+def _has_vision_content(messages: Iterable[object] | None) -> bool:
+    for message in messages or ():
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            kind = part.get("type")
+            if kind in {"image", "image_url", "input_image"} or "image_url" in part:
+                return True
+    return False
+
+
+def required_features(
+    messages: Iterable[object] | None,
+    *,
+    tools: list[Any] | None = None,
+    response_format: object | None = None,
+    stream: bool = False,
+    protocol: str | None = None,
+) -> frozenset[str]:
+    """Infer protocol features required by a request without inspecting its text."""
+
+    features: set[str] = set()
+    if tools:
+        features.add(FEATURE_TOOLS)
+    if isinstance(response_format, Mapping):
+        response_type = response_format.get("type")
+        if response_type == "json_object":
+            features.add(FEATURE_JSON)
+        elif response_type == "json_schema":
+            features.add(FEATURE_JSON_SCHEMA)
+    if stream:
+        features.add(FEATURE_STREAMING)
+    if _has_vision_content(messages):
+        features.add(FEATURE_VISION)
+    if protocol == FEATURE_RESPONSES:
+        features.add(FEATURE_RESPONSES)
+    elif protocol == FEATURE_ANTHROPIC_MESSAGES:
+        features.add(FEATURE_ANTHROPIC_MESSAGES)
+    return frozenset(features)
+
+
+def classify_canary_exception(exc: Exception) -> str:
+    """Return a privacy-safe failure class; never include the exception message."""
+
+    if isinstance(exc, ProviderHTTPError):
+        if exc.status in {400, 404, 405, 415, 422}:
+            return "unsupported"
+        if exc.status == 429:
+            return "rate_limit"
+        if exc.status in {401, 403}:
+            return "auth"
+        if exc.status == 402:
+            return "quota"
+        if exc.status == 408:
+            return "timeout"
+        if exc.status >= 500:
+            return "availability"
+        return "client"
+    if isinstance(exc, TimeoutError):
+        return "timeout"
+    return "transport"
+
+
+def _normalized_ok(text: str) -> bool:
+    return text.strip().rstrip(".").strip().casefold() == "ok"
+
+
+def validate_canary_result(feature: str, result: Reply | str | Iterable[str]) -> str:
+    """Validate normalized feature semantics, not merely syntactic provider success."""
+
+    if feature == FEATURE_STREAMING:
+        if isinstance(result, str):
+            text = result
+        elif isinstance(result, Reply):
+            text = result.text
+        else:
+            text = "".join(part for part in result if isinstance(part, str))
+        return "verified" if _normalized_ok(text) else "semantic_mismatch"
+    if not isinstance(result, Reply):
+        return "malformed_result"
+    if feature in {FEATURE_CHAT, FEATURE_RESPONSES, FEATURE_ANTHROPIC_MESSAGES}:
+        return "verified" if _normalized_ok(result.text) else "semantic_mismatch"
+    if feature in {FEATURE_JSON, FEATURE_JSON_SCHEMA}:
+        try:
+            value = json.loads(result.text)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return "malformed_json"
+        return "verified" if value == {"ok": True} else "semantic_mismatch"
+    if feature == FEATURE_TOOLS:
+        calls = result.message.get("tool_calls") if isinstance(result.message, dict) else None
+        if not isinstance(calls, list) or len(calls) != 1 or not isinstance(calls[0], dict):
+            return "malformed_tool_call"
+        function = calls[0].get("function")
+        if not isinstance(function, dict) or function.get("name") != "record_number":
+            return "semantic_mismatch"
+        try:
+            arguments = json.loads(function.get("arguments", ""))
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return "malformed_tool_call"
+        return "verified" if arguments == {"number": 7} else "semantic_mismatch"
+    if feature == FEATURE_VISION:
+        return "verified" if result.text.strip().casefold() == "red" else "semantic_mismatch"
+    raise ValueError(f"unknown conformance feature: {feature}")
+
+
+def _canary_status(classification: str) -> str:
+    if classification == "verified":
+        return STATUS_PASS
+    if classification == "unsupported":
+        return STATUS_UNSUPPORTED
+    if classification in {"rate_limit", "quota", "auth", "timeout", "availability", "transport"}:
+        return STATUS_UNAVAILABLE
+    return STATUS_FAIL
+
+
+def run_target_canaries(
+    provider: Provider,
+    model: str,
+    *,
+    env: dict[str, str],
+    features: Iterable[str] = FEATURES,
+    timeout: float = 20.0,
+    call_fn: Callable[..., Reply] | None = None,
+    stream_fn: Callable[..., Iterable[str]] | None = None,
+) -> dict[str, dict[str, str]]:
+    """Run a deterministic, quota-bounded feature matrix for one exact target.
+
+    Each selected feature performs at most one provider call with at most 16 output
+    tokens. Inputs are module constants only. Returned rows contain no response,
+    exception, credential, prompt, repository, or user content.
+    """
+
+    selected = tuple(features)
+    if len(selected) > _MAX_CANARY_FEATURES:
+        raise ValueError(f"canary matrix supports at most {_MAX_CANARY_FEATURES} features")
+    unknown = sorted(set(selected) - set(FEATURES))
+    if unknown:
+        raise ValueError(f"unknown conformance feature(s): {', '.join(unknown)}")
+    if len(set(selected)) != len(selected):
+        raise ValueError("canary matrix features must be unique")
+    bounded_timeout = max(0.1, min(float(timeout), 60.0))
+    if call_fn is None or stream_fn is None:
+        from . import client
+
+        call_fn = call_fn or client.call
+        stream_fn = stream_fn or client.stream_call
+    api_key = provider.api_key(env)
+    results: dict[str, dict[str, str]] = {}
+    for feature in selected:
+        try:
+            if feature == FEATURE_STREAMING:
+                chunks = list(
+                    stream_fn(
+                        provider,
+                        model,
+                        [{"role": "user", "content": _OK_PROMPT}],
+                        api_key=api_key,
+                        env=env,
+                        max_tokens=_CANARY_MAX_TOKENS,
+                        temperature=0.0,
+                        timeout=bounded_timeout,
+                    )
+                )
+                classification = validate_canary_result(feature, chunks)
+            else:
+                messages: list[dict[str, Any]]
+                if feature in {FEATURE_JSON, FEATURE_JSON_SCHEMA}:
+                    messages = [{"role": "user", "content": _JSON_PROMPT}]
+                elif feature == FEATURE_TOOLS:
+                    messages = [{"role": "user", "content": _TOOL_PROMPT}]
+                elif feature == FEATURE_VISION:
+                    messages = [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": _VISION_PROMPT},
+                                {"type": "image_url", "image_url": {"url": _RED_PIXEL}},
+                            ],
+                        }
+                    ]
+                elif feature == FEATURE_RESPONSES:
+                    from .proxy import _responses_input_to_messages, _to_responses_object
+
+                    messages = _responses_input_to_messages({"input": _OK_PROMPT})
+                elif feature == FEATURE_ANTHROPIC_MESSAGES:
+                    from .anthropic_shim import reply_to_message, request_to_chat
+
+                    translated = request_to_chat(
+                        {
+                            "model": model,
+                            "max_tokens": _CANARY_MAX_TOKENS,
+                            "messages": [{"role": "user", "content": _OK_PROMPT}],
+                        }
+                    )
+                    messages = translated["messages"]
+                else:
+                    messages = [{"role": "user", "content": _OK_PROMPT}]
+                call_kwargs: dict[str, Any] = {}
+                if feature == FEATURE_JSON:
+                    call_kwargs["response_format"] = {"type": "json_object"}
+                elif feature == FEATURE_JSON_SCHEMA:
+                    call_kwargs["response_format"] = {
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": "freellmpool_conformance",
+                            "strict": True,
+                            "schema": {
+                                "type": "object",
+                                "properties": {"ok": {"type": "boolean"}},
+                                "required": ["ok"],
+                                "additionalProperties": False,
+                            },
+                        },
+                    }
+                elif feature == FEATURE_TOOLS:
+                    call_kwargs["tools"] = [_CANARY_TOOL]
+                    call_kwargs["tool_choice"] = {
+                        "type": "function",
+                        "function": {"name": "record_number"},
+                    }
+                reply = call_fn(
+                    provider,
+                    model,
+                    messages,
+                    api_key=api_key,
+                    env=env,
+                    max_tokens=_CANARY_MAX_TOKENS,
+                    temperature=0.0,
+                    timeout=bounded_timeout,
+                    enforce_thinking_floor=False,
+                    **call_kwargs,
+                )
+                if feature == FEATURE_RESPONSES:
+                    framed = _to_responses_object(reply)
+                    content = framed.get("output", [{}])[0].get("content", [{}])[0].get("text", "")
+                    reply = Reply(
+                        text=content,
+                        provider_id=reply.provider_id,
+                        model=reply.model,
+                        raw={},
+                    )
+                elif feature == FEATURE_ANTHROPIC_MESSAGES:
+                    framed = reply_to_message(reply, model)
+                    content = framed.get("content", [{}])[0].get("text", "")
+                    reply = Reply(
+                        text=content,
+                        provider_id=reply.provider_id,
+                        model=reply.model,
+                        raw={},
+                    )
+                classification = validate_canary_result(feature, reply)
+        except Exception as exc:  # noqa: BLE001 - every feature result remains advisory
+            classification = classify_canary_exception(exc)
+        results[feature] = {
+            "status": _canary_status(classification),
+            "classification": classification,
+        }
+    return results

--- a/src/freellmpool/proxy.py
+++ b/src/freellmpool/proxy.py
@@ -94,10 +94,29 @@ def _model_ids(pool: Pool, ready_model_ids: frozenset[str] | None = None) -> lis
 def _openai_models_payload(
     pool: Pool, ready_model_ids: frozenset[str] | None = None
 ) -> dict:
-    data = [
-        {"id": mid, "object": "model", "owned_by": "freellmpool"}
-        for mid in _model_ids(pool, ready_model_ids)
-    ]
+    target_lookup = {
+        f"{provider.id}/{model.name}": (provider, model.name)
+        for provider in pool.providers
+        for model in provider.models
+        if model.enabled
+    }
+    conformance_snapshot = (
+        pool.conformance.snapshot() if pool.conformance is not None else None
+    )
+    data = []
+    for model_id in _model_ids(pool, ready_model_ids):
+        row = {"id": model_id, "object": "model", "owned_by": "freellmpool"}
+        target = target_lookup.get(model_id)
+        evidence = (
+            pool.conformance.evidence(*target, snapshot=conformance_snapshot)
+            if target is not None and pool.conformance is not None
+            else {}
+        )
+        row["capabilities"] = evidence
+        row["verified_features"] = sorted(
+            feature for feature, result in evidence.items() if result.get("status") == "pass"
+        )
+        data.append(row)
     return {"object": "list", "data": data}
 
 
@@ -107,15 +126,37 @@ def _anthropic_models_payload(
     ids = _model_ids(pool, ready_model_ids)
     if ready_model_ids is None:
         ids.extend(a for a in known_aliases(pool.env) if a.startswith("claude-") and a not in ids)
-    data = [
-        {
+    target_lookup = {
+        f"{provider.id}/{model.name}": (provider, model.name)
+        for provider in pool.providers
+        for model in provider.models
+        if model.enabled
+    }
+    conformance_snapshot = (
+        pool.conformance.snapshot() if pool.conformance is not None else None
+    )
+    data = []
+    for mid in ids:
+        target = target_lookup.get(mid)
+        evidence = (
+            pool.conformance.evidence(*target, snapshot=conformance_snapshot)
+            if target is not None and pool.conformance is not None
+            else {}
+        )
+        data.append(
+            {
             "type": "model",
             "id": mid,
             "display_name": mid,
             "created_at": "2024-01-01T00:00:00Z",
-        }
-        for mid in ids
-    ]
+                "capabilities": evidence,
+                "verified_features": sorted(
+                    feature
+                    for feature, result in evidence.items()
+                    if result.get("status") == "pass"
+                ),
+            }
+        )
     return {
         "data": data,
         "has_more": False,
@@ -177,6 +218,9 @@ def _status_payload(pool: Pool, recent: Sequence[dict], tokenmax: dict | None = 
     health_snap = pool.route_health_snapshot()
     health_store = pool.route_health
     cooldown_snap = pool.cooldown_snapshot(now)  # locked read; no torn cooldown state
+    conformance_snapshot = (
+        pool.conformance.snapshot() if pool.conformance is not None else None
+    )
 
     def modality_routes(providers) -> list[dict]:
         rows = []
@@ -230,6 +274,15 @@ def _status_payload(pool: Pool, recent: Sequence[dict], tokenmax: dict | None = 
             remaining = (m.rpd - used) if m.rpd > 0 else None
             stat = metrics_snap.get(f"{p.id}/{m.name}")
             persistent = health_snap.get(f"{p.id}/{m.name}")
+            capabilities = (
+                pool.conformance.evidence(
+                    p,
+                    m.name,
+                    snapshot=conformance_snapshot,
+                )
+                if pool.conformance is not None
+                else {}
+            )
             models_list.append(
                 {
                     "name": m.name,
@@ -261,6 +314,12 @@ def _status_payload(pool: Pool, recent: Sequence[dict], tokenmax: dict | None = 
                         health_store.reset_remaining(persistent)
                         if health_store is not None
                         else 0.0
+                    ),
+                    "capabilities": capabilities,
+                    "verified_features": sorted(
+                        feature
+                        for feature, result in capabilities.items()
+                        if result.get("status") == "pass"
                     ),
                 }
             )
@@ -731,6 +790,7 @@ def make_handler(pool: Pool, api_key: str | None = None):
                     temperature=chat["temperature"],
                     tools=chat["tools"],
                     tool_choice=chat["tool_choice"],
+                    protocol="anthropic_messages",
                     routing=routing_override,
                 )
             except NoProvidersConfigured as exc:
@@ -875,6 +935,8 @@ def make_handler(pool: Pool, api_key: str | None = None):
             *,
             tools=None,
             tool_choice=None,
+            response_format=None,
+            protocol: str | None = None,
             timeout: float | None = None,
         ):
             """Shared: resolve model/params and call the pool. Returns a Reply or
@@ -917,6 +979,8 @@ def make_handler(pool: Pool, api_key: str | None = None):
                     timeout=max(0.0, upstream_timeout),
                     tools=tools,
                     tool_choice=tool_choice,
+                    response_format=response_format,
+                    protocol=protocol,
                     routing=routing_override,
                 )
             except NoProvidersConfigured as exc:
@@ -950,11 +1014,25 @@ def make_handler(pool: Pool, api_key: str | None = None):
                 return
             norm = _normalize_messages(messages)
             tools = req.get("tools") if isinstance(req.get("tools"), list) else None
+            response_format = req.get("response_format")
+            if response_format is not None and not isinstance(response_format, dict):
+                self._error(
+                    400,
+                    "'response_format' must be an object",
+                    "invalid_request_error",
+                )
+                return
             # True token streaming for plain chat; tools/stream falls back to buffered.
-            if req.get("stream") and not tools:
+            if req.get("stream") and not tools and response_format is None:
                 self._stream_chat(req, norm)
                 return
-            reply = self._resolve(req, norm, tools=tools, tool_choice=req.get("tool_choice"))
+            reply = self._resolve(
+                req,
+                norm,
+                tools=tools,
+                tool_choice=req.get("tool_choice"),
+                response_format=response_format,
+            )
             if reply is None:
                 return
             # Record recent served
@@ -1102,7 +1180,18 @@ def make_handler(pool: Pool, api_key: str | None = None):
             if not messages:
                 self._error(400, "'input' is required", "invalid_request_error")
                 return
-            reply = self._resolve(req, messages)
+            try:
+                tools, tool_choice = _responses_tools_to_chat(req)
+            except ValueError as exc:
+                self._error(400, str(exc), "invalid_request_error")
+                return
+            reply = self._resolve(
+                req,
+                messages,
+                tools=tools,
+                tool_choice=tool_choice,
+                protocol="responses",
+            )
             if reply is None:
                 return
             record_recent(
@@ -1180,11 +1269,15 @@ def _content(message: dict) -> str:
 
 
 def _normalize_messages(messages: list) -> list[dict]:
-    """Flatten content to text while preserving tool-calling fields so multi-turn
-    tool conversations (assistant tool_calls + tool results) survive the proxy."""
+    """Normalize roles while preserving multimodal and tool-calling content."""
     out: list[dict] = []
     for m in messages:
-        nm: dict = {"role": str(m.get("role", "user")), "content": _content(m)}
+        content = m.get("content")
+        normalized_content = content if isinstance(content, list) else _content(m)
+        nm: dict = {
+            "role": str(m.get("role", "user")),
+            "content": normalized_content,
+        }
         for key in ("tool_calls", "tool_call_id", "name"):
             if m.get(key) is not None:
                 nm[key] = m[key]
@@ -1523,38 +1616,231 @@ def _responses_input_to_messages(req: dict) -> list[dict]:
         for item in data:
             if not isinstance(item, dict):
                 continue
+            kind = item.get("type")
+            if kind == "function_call":
+                call_id = item.get("call_id")
+                name = item.get("name")
+                arguments = item.get("arguments")
+                if (
+                    isinstance(call_id, str)
+                    and call_id
+                    and isinstance(name, str)
+                    and name
+                    and isinstance(arguments, str)
+                ):
+                    messages.append(
+                        {
+                            "role": "assistant",
+                            "content": "",
+                            "tool_calls": [
+                                {
+                                    "id": call_id,
+                                    "type": "function",
+                                    "function": {
+                                        "name": name,
+                                        "arguments": arguments,
+                                    },
+                                }
+                            ],
+                        }
+                    )
+                continue
+            if kind == "function_call_output":
+                call_id = item.get("call_id")
+                output = item.get("output")
+                if isinstance(call_id, str) and call_id and isinstance(output, str):
+                    messages.append(
+                        {
+                            "role": "tool",
+                            "content": output,
+                            "tool_call_id": call_id,
+                        }
+                    )
+                continue
             role = str(item.get("role", "user"))
             content = item.get("content", "")
             if isinstance(content, list):
-                text = "".join(part.get("text", "") for part in content if isinstance(part, dict))
+                parts = []
+                for part in content:
+                    if not isinstance(part, dict):
+                        continue
+                    kind = part.get("type")
+                    text = part.get("text")
+                    if kind in {"input_text", "text"} and isinstance(text, str):
+                        parts.append({"type": "text", "text": text})
+                    elif kind in {"input_image", "image_url"}:
+                        image_url = part.get("image_url")
+                        if isinstance(image_url, str):
+                            parts.append(
+                                {
+                                    "type": "image_url",
+                                    "image_url": {"url": image_url},
+                                }
+                            )
+                        elif isinstance(image_url, dict) and isinstance(
+                            image_url.get("url"), str
+                        ):
+                            parts.append({"type": "image_url", "image_url": image_url})
+                normalized_content: object = parts
             else:
-                text = str(content)
-            messages.append({"role": role, "content": text})
+                normalized_content = str(content)
+            messages.append({"role": role, "content": normalized_content})
     return messages
+
+
+def _responses_tools_to_chat(req: dict) -> tuple[list[dict] | None, object | None]:
+    """Translate Responses function tools/tool choice to Chat Completions shape."""
+
+    raw_tools = req.get("tools")
+    raw_choice = req.get("tool_choice")
+    if raw_tools is None:
+        if raw_choice is not None:
+            raise ValueError("'tool_choice' requires a non-empty 'tools' array")
+        return None, None
+    if not isinstance(raw_tools, list):
+        raise ValueError("'tools' must be an array of function tools")
+    if not raw_tools:
+        if raw_choice is not None:
+            raise ValueError("'tool_choice' requires a non-empty 'tools' array")
+        return None, None
+
+    tools: list[dict] = []
+    for tool in raw_tools:
+        if not isinstance(tool, dict) or tool.get("type") != "function":
+            raise ValueError("only Responses function tools are supported")
+        source = tool.get("function") if isinstance(tool.get("function"), dict) else tool
+        name = source.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError("each function tool requires a non-empty 'name'")
+        function: dict[str, object] = {"name": name}
+        description = source.get("description")
+        if description is not None:
+            if not isinstance(description, str):
+                raise ValueError("function tool 'description' must be a string")
+            function["description"] = description
+        parameters = source.get("parameters")
+        if parameters is not None:
+            if not isinstance(parameters, dict):
+                raise ValueError("function tool 'parameters' must be an object")
+            function["parameters"] = parameters
+        strict = source.get("strict")
+        if strict is not None:
+            if not isinstance(strict, bool):
+                raise ValueError("function tool 'strict' must be a boolean")
+            function["strict"] = strict
+        tools.append({"type": "function", "function": function})
+
+    if raw_choice is None or isinstance(raw_choice, str):
+        if isinstance(raw_choice, str) and raw_choice not in {"auto", "none", "required"}:
+            raise ValueError("unsupported Responses 'tool_choice'")
+        return tools, raw_choice
+    if not isinstance(raw_choice, dict) or raw_choice.get("type") != "function":
+        raise ValueError("unsupported Responses 'tool_choice'")
+    choice_source = (
+        raw_choice.get("function")
+        if isinstance(raw_choice.get("function"), dict)
+        else raw_choice
+    )
+    choice_name = choice_source.get("name")
+    if not isinstance(choice_name, str) or not choice_name:
+        raise ValueError("function 'tool_choice' requires a non-empty 'name'")
+    return tools, {"type": "function", "function": {"name": choice_name}}
+
+
+def _responses_function_call_items(reply) -> list[dict]:
+    tool_calls = reply.message.get("tool_calls") if isinstance(reply.message, dict) else None
+    if not isinstance(tool_calls, list):
+        return []
+    items = []
+    for index, tool_call in enumerate(tool_calls):
+        if not isinstance(tool_call, dict):
+            continue
+        function = tool_call.get("function")
+        if tool_call.get("type") != "function" or not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        arguments = function.get("arguments")
+        if not isinstance(name, str) or not name or not isinstance(arguments, str):
+            continue
+        raw_call_id = tool_call.get("id")
+        call_id = (
+            raw_call_id
+            if isinstance(raw_call_id, str) and raw_call_id
+            else f"call-{reply.provider_id}-{index}"
+        )
+        items.append(
+            {
+                "type": "function_call",
+                "id": f"fc-{call_id}",
+                "call_id": call_id,
+                "name": name,
+                "arguments": arguments,
+                "status": "completed",
+            }
+        )
+    return items
 
 
 def _to_responses_object(reply) -> dict:
     rid = f"resp-freellmpool-{reply.provider_id}"
-    return {
-        "id": rid,
-        "object": "response",
-        "status": "completed",
-        "model": f"{reply.provider_id}/{reply.model}",
-        "output": [
+    output = []
+    if reply.text:
+        output.append(
             {
                 "type": "message",
                 "id": f"msg-{reply.provider_id}",
                 "status": "completed",
                 "role": "assistant",
-                "content": [{"type": "output_text", "text": reply.text or "", "annotations": []}],
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": reply.text,
+                        "annotations": [],
+                    }
+                ],
             }
-        ],
+        )
+    output.extend(_responses_function_call_items(reply))
+    if not output:
+        output.append(
+            {
+                "type": "message",
+                "id": f"msg-{reply.provider_id}",
+                "status": "completed",
+                "role": "assistant",
+                "content": [{"type": "output_text", "text": "", "annotations": []}],
+            }
+        )
+    return {
+        "id": rid,
+        "object": "response",
+        "created_at": int(time.time()),
+        "status": "completed",
+        "completed_at": int(time.time()),
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "max_output_tokens": None,
+        "model": f"{reply.provider_id}/{reply.model}",
+        "output": output,
         "output_text": reply.text or "",  # string per the Responses schema (never null)
+        "parallel_tool_calls": True,
+        "previous_response_id": None,
+        "reasoning": {"effort": None, "summary": None},
+        "store": False,
+        "temperature": 0.0,
+        "text": {"format": {"type": "text"}},
+        "tool_choice": "auto",
+        "tools": [],
+        "top_p": 1.0,
+        "truncation": "disabled",
         "usage": {
             "input_tokens": reply.prompt_tokens or 0,
             "output_tokens": reply.completion_tokens or 0,
             "total_tokens": (reply.prompt_tokens or 0) + (reply.completion_tokens or 0),
         },
+        "user": None,
+        "metadata": {},
         "x_freellmpool": {"provider": reply.provider_id, "model": reply.model},
     }
 
@@ -1562,18 +1848,132 @@ def _to_responses_object(reply) -> dict:
 def _responses_sse_events(reply):
     """Yield Responses-API SSE blocks (typed events) for a finished reply."""
     obj = _to_responses_object(reply)
+    sequence_number = 0
 
     def event(name, payload):
+        nonlocal sequence_number
+        payload = {**payload, "sequence_number": sequence_number}
+        sequence_number += 1
         return f"event: {name}\ndata: {json.dumps(payload)}\n\n"
 
+    created = {
+        **obj,
+        "status": "in_progress",
+        "completed_at": None,
+        "output": [],
+        "output_text": "",
+        "usage": None,
+    }
     yield event(
         "response.created",
-        {"type": "response.created", "response": {"id": obj["id"], "status": "in_progress"}},
+        {"type": "response.created", "response": created},
     )
-    yield event(
-        "response.output_text.delta",
-        {"type": "response.output_text.delta", "delta": reply.text or ""},
-    )
+    for output_index, item in enumerate(obj["output"]):
+        if item.get("type") == "message":
+            initial_item = {**item, "status": "in_progress", "content": []}
+            yield event(
+                "response.output_item.added",
+                {
+                    "type": "response.output_item.added",
+                    "output_index": output_index,
+                    "item": initial_item,
+                },
+            )
+            content = item.get("content")
+            if not isinstance(content, list) or not content:
+                yield event(
+                    "response.output_item.done",
+                    {
+                        "type": "response.output_item.done",
+                        "output_index": output_index,
+                        "item": item,
+                    },
+                )
+                continue
+            part = content[0]
+            initial_part = {**part, "text": ""}
+            yield event(
+                "response.content_part.added",
+                {
+                    "type": "response.content_part.added",
+                    "item_id": item["id"],
+                    "output_index": output_index,
+                    "content_index": 0,
+                    "part": initial_part,
+                },
+            )
+            text = part.get("text") or ""
+            if text:
+                yield event(
+                    "response.output_text.delta",
+                    {
+                        "type": "response.output_text.delta",
+                        "item_id": item["id"],
+                        "output_index": output_index,
+                        "content_index": 0,
+                        "delta": text,
+                        "logprobs": [],
+                    },
+                )
+            yield event(
+                "response.output_text.done",
+                {
+                    "type": "response.output_text.done",
+                    "item_id": item["id"],
+                    "output_index": output_index,
+                    "content_index": 0,
+                    "text": text,
+                    "logprobs": [],
+                },
+            )
+            yield event(
+                "response.content_part.done",
+                {
+                    "type": "response.content_part.done",
+                    "item_id": item["id"],
+                    "output_index": output_index,
+                    "content_index": 0,
+                    "part": part,
+                },
+            )
+            yield event(
+                "response.output_item.done",
+                {
+                    "type": "response.output_item.done",
+                    "output_index": output_index,
+                    "item": item,
+                },
+            )
+            continue
+        if item.get("type") != "function_call":
+            continue
+        initial_item = {**item, "arguments": "", "status": "in_progress"}
+        yield event(
+            "response.output_item.added",
+            {
+                "type": "response.output_item.added",
+                "output_index": output_index,
+                "item": initial_item,
+            },
+        )
+        yield event(
+            "response.function_call_arguments.done",
+            {
+                "type": "response.function_call_arguments.done",
+                "item_id": item["id"],
+                "name": item["name"],
+                "output_index": output_index,
+                "arguments": item["arguments"],
+            },
+        )
+        yield event(
+            "response.output_item.done",
+            {
+                "type": "response.output_item.done",
+                "output_index": output_index,
+                "item": item,
+            },
+        )
     yield event("response.completed", {"type": "response.completed", "response": obj})
 
 

--- a/src/freellmpool/router.py
+++ b/src/freellmpool/router.py
@@ -13,6 +13,7 @@ import threading
 import time
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
+from typing import Any
 
 from . import client as _client
 from .cache import Cache
@@ -35,6 +36,7 @@ from .config import (
     load_transcribers,
     settings,
 )
+from .conformance import ConformanceStore, default_conformance_path, required_features
 from .context import context_limit_from_error, estimate_input_tokens
 from .errors import (
     AllProvidersExhausted,
@@ -181,6 +183,7 @@ class Pool:
         on_event: EventHook | None = None,
         stats_store: StatsStore | None = None,
         route_health: RouteHealthStore | None = None,
+        conformance: ConformanceStore | None = None,
     ):
         self.providers = providers
         targets: list[Target] = []
@@ -217,6 +220,7 @@ class Pool:
         self._clock = clock or time.monotonic
         self.metrics = metrics or Metrics()
         self.route_health = route_health
+        self.conformance = conformance
         # "fair"   — least-used provider first, then least-used model in provider.
         # "fast"   — lowest measured provider latency / failure penalty first.
         # "quality"— match prompt difficulty to model capability (benchmark-scored),
@@ -291,6 +295,14 @@ class Pool:
         """Persistent per-model circuit reset times for readiness surfaces."""
         return self.route_health.route_cooldowns() if self.route_health is not None else {}
 
+    def conformance_snapshot(self) -> dict:
+        """Sanitized per-model protocol evidence for status/model surfaces."""
+
+        return self.conformance.snapshot() if self.conformance is not None else {
+            "version": 1,
+            "targets": {},
+        }
+
     def _acquire_route(self, target: Target) -> HealthLease | None:
         if self.route_health is None:
             return HealthLease(started_at=time.time(), generations={})
@@ -364,7 +376,7 @@ class Pool:
 
     def rank_targets(
         self,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         *,
         routing: str | None = None,
         model: str | None = None,
@@ -483,6 +495,7 @@ class Pool:
                 path=default_route_health_path(env),
                 base_cooldown=cooldown,
             ),
+            conformance=ConformanceStore(default_conformance_path(env)),
         )
 
     def embed(
@@ -645,6 +658,20 @@ class Pool:
         if include_set is None:
             return list(source)
         return [target for target in source if target.provider.id in include_set]
+
+    def _feature_targets(
+        self,
+        targets: list[Target],
+        features: Iterable[str],
+        *,
+        exact_pin: bool,
+    ) -> list[Target]:
+        """Restrict feature requests to verified targets while preserving exact pins."""
+
+        wanted = frozenset(features)
+        if not wanted or exact_pin or self.conformance is None:
+            return targets
+        return self.conformance.verified_targets(targets, wanted)
 
     def _order(
         self, targets: list[Target], difficulty: float | None = None, routing: str | None = None
@@ -897,7 +924,7 @@ class Pool:
 
     def chat(
         self,
-        messages: list[dict[str, str]],
+        messages: list[dict[str, Any]],
         *,
         model: str | None = None,
         providers: Iterable[str] | None = None,
@@ -906,6 +933,8 @@ class Pool:
         timeout: float = 90.0,
         tools: list | None = None,
         tool_choice=None,
+        response_format=None,
+        protocol: str | None = None,
         routing: str | None = None,
     ) -> Reply:
         """Like :meth:`ask` but takes raw OpenAI-style ``messages``.
@@ -918,6 +947,20 @@ class Pool:
             )
 
         provider_list = list(providers) if providers else None
+        features = required_features(
+            messages,
+            tools=tools,
+            response_format=response_format,
+            protocol=protocol,
+        )
+        exact_pin = (
+            model is not None and provider_list is not None and len(provider_list) == 1
+        )
+        candidates = self._feature_targets(
+            self._all_targets(include=provider_list, model=model),
+            features,
+            exact_pin=exact_pin,
+        )
         # Resolve the effective routing mode *before* the cache key so that a
         # per-request override (fast/quality/fair/…) keys its own cache bucket and
         # never serves a reply produced under a different mode's intent.
@@ -925,10 +968,32 @@ class Pool:
         cache_key = None
         if self._cache is not None:
             cache_key = self._cache.make_key(
-                messages, model, provider_list, max_tokens, temperature, tools, tool_choice, eff
+                messages,
+                model,
+                provider_list,
+                max_tokens,
+                temperature,
+                tools,
+                tool_choice,
+                eff,
+                response_format=response_format,
+                protocol=protocol,
             )
             hit = self._cache.get(cache_key)
-            if hit is not None:
+            feature_cache_eligible = (
+                hit is not None
+                and (
+                    not features
+                    or exact_pin
+                    or self.conformance is None
+                    or any(
+                        target.provider.id == hit.get("provider_id")
+                        and target.model == hit.get("model")
+                        for target in candidates
+                    )
+                )
+            )
+            if hit is not None and feature_cache_eligible:
                 emit(self._on_event, "cache_hit", key=cache_key)
                 self._bump_stats(cache_hits=1)
                 return Reply(
@@ -945,7 +1010,7 @@ class Pool:
 
         difficulty = prompt_difficulty(messages, max_tokens, tools) if eff == "quality" else None
         targets = self._order(
-            self._all_targets(include=provider_list, model=model),
+            candidates,
             difficulty=difficulty,
             routing=eff,
         )
@@ -1020,6 +1085,7 @@ class Pool:
                     timeout=remaining,
                     tools=tools,
                     tool_choice=tool_choice,
+                    response_format=response_format,
                     post=self._post,
                 )
             except ProviderHTTPError as exc:
@@ -1138,8 +1204,15 @@ class Pool:
             raise NoProvidersConfigured("no provider has an API key set")
         eff = normalize_routing_mode(routing, self.routing)
         difficulty = prompt_difficulty(messages, max_tokens) if eff == "quality" else None
+        provider_list = list(providers) if providers else None
+        candidates = self._all_targets(include=provider_list, model=model)
+        candidates = self._feature_targets(
+            candidates,
+            required_features(messages, stream=True),
+            exact_pin=model is not None and provider_list is not None and len(provider_list) == 1,
+        )
         targets = self._order(
-            self._all_targets(include=providers, model=model),
+            candidates,
             difficulty=difficulty,
             routing=eff,
         )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 import threading
 
+import pytest
 from helpers import make_post, make_stream_post
 
 from freellmpool.cache import Cache
@@ -82,6 +84,20 @@ def test_make_key_includes_routing():
     assert Cache.make_key(*args, routing="fair") == Cache.make_key(*args, routing="fair")
 
 
+def test_make_key_includes_response_format_and_protocol():
+    args = ([{"role": "user", "content": "hi"}], None, None, 1024, 0.0, None, None)
+    plain = Cache.make_key(*args, routing="fair")
+    structured = Cache.make_key(
+        *args,
+        routing="fair",
+        response_format={"type": "json_object"},
+    )
+    responses = Cache.make_key(*args, routing="fair", protocol="responses")
+    messages = Cache.make_key(*args, routing="fair", protocol="anthropic_messages")
+
+    assert len({plain, structured, responses, messages}) == 4
+
+
 def test_pool_uses_cache(providers, env, quota, tmp_path):
     cache = Cache(ttl=999.0, path=tmp_path / "c.db")
     post = make_post({})  # returns "ok", counts calls
@@ -96,6 +112,119 @@ def test_pool_uses_cache(providers, env, quota, tmp_path):
     assert r2.provider_id == r1.provider_id  # cached reply preserves the original provider
     assert len(post.calls) == n_after_first  # no extra network call
     assert pool.stats["cache_hits"] == 1
+
+
+def test_feature_cache_hit_is_rejected_after_conformance_regression(
+    providers, env, quota, tmp_path
+):
+    from freellmpool.conformance import (
+        FEATURE_TOOLS,
+        STATUS_PASS,
+        STATUS_UNSUPPORTED,
+        ConformanceStore,
+    )
+    alpha, beta = providers[:2]
+    alpha_model = next(model for model in alpha.models if model.enabled)
+    beta_model = next(model for model in beta.models if model.enabled)
+    store = ConformanceStore(tmp_path / "conformance.json")
+    for provider, model in ((alpha, alpha_model), (beta, beta_model)):
+        store.record(
+            provider,
+            model.name,
+            FEATURE_TOOLS,
+            status=STATUS_PASS,
+            classification="verified",
+        )
+    cache = Cache(ttl=999.0, path=tmp_path / "c.db")
+    post = make_post({})
+    pool = Pool(
+        [alpha, beta],
+        quota=quota,
+        env=env,
+        post=post,
+        cache=cache,
+        conformance=store,
+    )
+    tools = [{"type": "function", "function": {"name": "answer", "parameters": {}}}]
+
+    assert pool.chat([{"role": "user", "content": "answer"}], tools=tools).cached is False
+    assert post.calls[0]["url"].startswith("https://alpha.test/")
+    assert len(post.calls) == 1
+    store.record(
+        alpha,
+        alpha_model.name,
+        FEATURE_TOOLS,
+        status=STATUS_UNSUPPORTED,
+        classification="unsupported",
+    )
+
+    reply = pool.chat([{"role": "user", "content": "answer"}], tools=tools)
+    assert reply.cached is False
+    assert reply.provider_id == "beta"
+    assert len(post.calls) == 2
+
+
+def test_async_feature_cache_hit_is_rejected_after_conformance_regression(
+    providers, env, quota, tmp_path
+):
+    from freellmpool.aio import AsyncPool
+    from freellmpool.client import HTTPResult
+    from freellmpool.conformance import (
+        FEATURE_TOOLS,
+        STATUS_PASS,
+        STATUS_UNSUPPORTED,
+        ConformanceStore,
+    )
+    from freellmpool.errors import NoProvidersConfigured
+
+    provider = providers[0]
+    model = next(model for model in provider.models if model.enabled)
+    store = ConformanceStore(tmp_path / "conformance.json")
+    store.record(
+        provider,
+        model.name,
+        FEATURE_TOOLS,
+        status=STATUS_PASS,
+        classification="verified",
+    )
+    cache = Cache(ttl=999.0, path=tmp_path / "c.db")
+    calls = []
+
+    async def apost(url, headers, body, timeout):
+        calls.append(url)
+        return HTTPResult(
+            200,
+            {"choices": [{"message": {"role": "assistant", "content": "ok"}}]},
+            "",
+        )
+
+    pool = AsyncPool(
+        Pool(
+            [provider],
+            quota=quota,
+            env=env,
+            cache=cache,
+            conformance=store,
+        ),
+        apost=apost,
+    )
+    tools = [{"type": "function", "function": {"name": "answer", "parameters": {}}}]
+
+    first = asyncio.run(
+        pool.achat([{"role": "user", "content": "answer"}], tools=tools)
+    )
+    assert first.cached is False
+    store.record(
+        provider,
+        model.name,
+        FEATURE_TOOLS,
+        status=STATUS_UNSUPPORTED,
+        classification="unsupported",
+    )
+
+    with pytest.raises(NoProvidersConfigured):
+        asyncio.run(pool.achat([{"role": "user", "content": "answer"}], tools=tools))
+    assert len(calls) == 1
 
 
 def test_cache_preserves_tool_calls(providers, env, quota, tmp_path):

--- a/tests/test_catalog_sentinel.py
+++ b/tests/test_catalog_sentinel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import socketserver
 import sys
 import threading
@@ -706,9 +707,43 @@ def test_workflow_is_advisory_least_privilege_and_fork_safe():
     assert "--body-file" in workflow
     assert "scripts/catalog_sentinel.py discover" in workflow
     assert "scripts/catalog_sentinel.py probe" in workflow
+    assert "freellmpool conformance run" in workflow
+    assert "FREELLMPOOL_CONFORMANCE_KEYS_JSON" in workflow
+    assert ".sentinel-state/conformance.json" in workflow
+    assert ".sentinel-artifacts/conformance.json" in workflow
     assert "--previous" in workflow
     assert "FREELLMPOOL_SENTINEL_KEYS_JSON" in workflow
     assert "Never mutates providers.toml" in workflow
+
+
+def test_authenticated_workflow_timeout_covers_declared_probe_budget():
+    workflow = (ROOT / ".github" / "workflows" / "catalog-sentinel.yml").read_text(
+        encoding="utf-8"
+    )
+    protected = workflow.split("  authenticated-probes:", 1)[1]
+    timeout_minutes = int(re.search(r"timeout-minutes:\s*(\d+)", protected).group(1))
+
+    probe = protected.split("python scripts/catalog_sentinel.py probe", 1)[1].split(
+        "cp .sentinel-artifacts/probe.json", 1
+    )[0]
+    probe_timeout = int(re.search(r"--timeout\s+(\d+)", probe).group(1))
+    max_providers = int(re.search(r"--max-providers\s+(\d+)", probe).group(1))
+    max_models = int(
+        re.search(r"--max-models-per-provider\s+(\d+)", probe).group(1)
+    )
+
+    canaries = protected.split("freellmpool conformance run", 1)[1].split(
+        "cp .sentinel-state/conformance.json", 1
+    )[0]
+    conformance_timeout = int(re.search(r"--timeout\s+(\d+)", canaries).group(1))
+    max_targets = int(re.search(r"--max-targets\s+(\d+)", canaries).group(1))
+    features = re.search(r"--features\s+([a-z_,]+)", canaries).group(1).split(",")
+
+    network_budget_seconds = (
+        probe_timeout * max_providers * max_models
+        + conformance_timeout * max_targets * len(features)
+    )
+    assert timeout_minutes * 60 >= network_budget_seconds + 600
 
 
 def test_catalog_sentinel_operator_contract_is_documented():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,8 +13,9 @@ def test_strip_plain_json():
     assert _strip_fences('{"a": 1}') == '{"a": 1}'
 
 
-def test_cli_models_json_is_machine_readable(monkeypatch, capsys):
+def test_cli_models_json_is_machine_readable(monkeypatch, capsys, tmp_path):
     from freellmpool.cli import main
+    from freellmpool.conformance import FEATURE_TOOLS, STATUS_PASS, ConformanceStore
 
     catalog = [
         Provider(
@@ -39,14 +40,283 @@ def test_cli_models_json_is_machine_readable(monkeypatch, capsys):
         "freellmpool.cli.configured_providers",
         lambda providers: [provider for provider in providers if provider.id == "ready"],
     )
+    store = ConformanceStore(tmp_path / "conformance.json")
+    store.record(
+        catalog[0],
+        "on",
+        FEATURE_TOOLS,
+        status=STATUS_PASS,
+        classification="verified",
+    )
+    monkeypatch.setattr("freellmpool.cli.ConformanceStore", lambda: store)
 
     assert main(["models", "--json", "--all"]) == 0
 
     assert json.loads(capsys.readouterr().out) == [
-        {"provider": "ready", "model": "on", "enabled": True, "configured": True},
-        {"provider": "ready", "model": "off", "enabled": False, "configured": True},
-        {"provider": "missing", "model": "other", "enabled": True, "configured": False},
+        {
+            "provider": "ready",
+            "model": "on",
+            "enabled": True,
+            "configured": True,
+            "capabilities": {
+                "tools": {
+                    "status": "pass",
+                    "classification": "verified",
+                    "verified_at": json.loads(store.path.read_text())["updated_at"],
+                    "verification_count": 1,
+                }
+            },
+            "verified_features": ["tools"],
+        },
+        {
+            "provider": "ready",
+            "model": "off",
+            "enabled": False,
+            "configured": True,
+            "capabilities": {},
+            "verified_features": [],
+        },
+        {
+            "provider": "missing",
+            "model": "other",
+            "enabled": True,
+            "configured": False,
+            "capabilities": {},
+            "verified_features": [],
+        },
     ]
+
+
+def test_cli_models_and_conformance_include_plugin_providers(
+    monkeypatch, capsys, tmp_path
+):
+    from freellmpool import plugins
+    from freellmpool.cli import main
+    from freellmpool.conformance import ConformanceStore
+
+    builtin = Provider(
+        id="builtin",
+        label="Built in",
+        adapter="openai",
+        base_url="https://builtin.test/v1",
+        auth="none",
+        models=(Model("builtin-model"),),
+    )
+    plugin = Provider(
+        id="plugin",
+        label="Plugin",
+        adapter="plugin-adapter",
+        base_url="https://plugin.test/v1",
+        auth="none",
+        models=(Model("plugin-model"),),
+    )
+    store = ConformanceStore(tmp_path / "conformance.json")
+    captured = []
+
+    def fake_run(provider, model, **kwargs):
+        captured.append((provider.id, provider.adapter, model))
+        return {"chat": {"status": "pass", "classification": "verified"}}
+
+    monkeypatch.setattr("freellmpool.cli.load_catalog", lambda: [builtin])
+    monkeypatch.setattr(plugins, "registered_providers", lambda: [plugin])
+    monkeypatch.setattr(
+        "freellmpool.cli.configured_providers",
+        lambda providers, env=None: providers,
+    )
+    monkeypatch.setattr("freellmpool.cli.ConformanceStore", lambda: store)
+    monkeypatch.setattr("freellmpool.cli.run_target_canaries", fake_run)
+
+    assert main(["models", "--providers", "plugin", "--json"]) == 0
+    assert json.loads(capsys.readouterr().out) == [
+        {
+            "provider": "plugin",
+            "model": "plugin-model",
+            "enabled": True,
+            "configured": True,
+            "capabilities": {},
+            "verified_features": [],
+        }
+    ]
+
+    assert (
+        main(
+            [
+                "conformance",
+                "run",
+                "--providers",
+                "plugin",
+                "--features",
+                "chat",
+                "--json",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+    assert captured == [("plugin", "plugin-adapter", "plugin-model")]
+
+
+def test_plugin_provider_overrides_builtin_id_in_cli_catalog(monkeypatch, capsys):
+    from freellmpool import plugins
+    from freellmpool.cli import main
+
+    builtin = Provider(
+        id="same",
+        label="Built in",
+        adapter="openai",
+        base_url="https://builtin.test/v1",
+        auth="none",
+        models=(Model("old"),),
+    )
+    plugin = Provider(
+        id="same",
+        label="Plugin override",
+        adapter="openai",
+        base_url="https://plugin.test/v1",
+        auth="none",
+        models=(Model("new"),),
+    )
+    monkeypatch.setattr("freellmpool.cli.load_catalog", lambda: [builtin])
+    monkeypatch.setattr(plugins, "registered_providers", lambda: [plugin])
+    monkeypatch.setattr(
+        "freellmpool.cli.configured_providers",
+        lambda providers, env=None: providers,
+    )
+
+    assert main(["models", "--json"]) == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert [(row["provider"], row["model"]) for row in rows] == [("same", "new")]
+
+
+def test_cli_conformance_run_is_bounded_machine_readable(monkeypatch, capsys, tmp_path):
+    from freellmpool.cli import main
+    from freellmpool.conformance import ConformanceStore
+
+    provider = Provider(
+        id="ready",
+        label="Ready",
+        adapter="openai",
+        base_url="https://ready.test/v1",
+        auth="none",
+        models=(Model("first"), Model("second")),
+    )
+    store = ConformanceStore(tmp_path / "conformance.json")
+    captured = []
+
+    def fake_run(provider, model, **kwargs):
+        captured.append((provider.id, model, kwargs["features"], kwargs["timeout"]))
+        return {
+            "chat": {"status": "pass", "classification": "verified"},
+            "tools": {"status": "unsupported", "classification": "unsupported"},
+        }
+
+    monkeypatch.setattr("freellmpool.cli.load_catalog", lambda: [provider])
+    monkeypatch.setattr("freellmpool.cli.configured_providers", lambda catalog, env=None: catalog)
+    monkeypatch.setattr("freellmpool.cli.ConformanceStore", lambda: store)
+    monkeypatch.setattr("freellmpool.cli.run_target_canaries", fake_run)
+
+    assert (
+        main(
+            [
+                "conformance",
+                "run",
+                "--providers",
+                "ready",
+                "--features",
+                "chat,tools",
+                "--max-targets",
+                "1",
+                "--timeout",
+                "7",
+                "--json",
+            ]
+        )
+        == 0
+    )
+
+    output = json.loads(capsys.readouterr().out)
+    assert captured == [("ready", "first", ("chat", "tools"), 7.0)]
+    assert output == [
+        {
+            "provider": "ready",
+            "model": "first",
+            "features": {
+                "chat": {"status": "pass", "classification": "verified"},
+                "tools": {"status": "unsupported", "classification": "unsupported"},
+            },
+        }
+    ]
+    evidence = store.evidence(provider, "first")
+    assert evidence["chat"]["status"] == "pass"
+    assert evidence["tools"]["status"] == "unsupported"
+
+
+def test_cli_conformance_run_uses_only_catalog_allowlisted_secret_keys(
+    monkeypatch, capsys, tmp_path
+):
+    from freellmpool.cli import main
+    from freellmpool.conformance import ConformanceStore
+
+    secret = "provider-secret-value"
+    provider = Provider(
+        id="ready",
+        label="Ready",
+        adapter="openai",
+        base_url="https://ready.test/v1",
+        key_env="READY_KEY",
+        models=(Model("first"),),
+    )
+    store = ConformanceStore(tmp_path / "conformance.json")
+    captured = {}
+
+    def fake_run(provider, model, **kwargs):
+        captured.update(kwargs["env"])
+        return {"chat": {"status": "pass", "classification": "verified"}}
+
+    monkeypatch.delenv("READY_KEY", raising=False)
+    monkeypatch.setenv(
+        "FREELLMPOOL_CONFORMANCE_KEYS_JSON",
+        json.dumps({"READY_KEY": secret, "NOT_IN_CATALOG": "must-not-be-imported"}),
+    )
+    monkeypatch.setattr("freellmpool.cli.load_catalog", lambda: [provider])
+    monkeypatch.setattr("freellmpool.cli.ConformanceStore", lambda: store)
+    monkeypatch.setattr("freellmpool.cli.run_target_canaries", fake_run)
+
+    assert main(["conformance", "run", "--features", "chat", "--json"]) == 0
+    output = capsys.readouterr()
+    assert captured["READY_KEY"] == secret
+    assert "NOT_IN_CATALOG" not in captured
+    assert "FREELLMPOOL_CONFORMANCE_KEYS_JSON" not in captured
+    assert secret not in output.out
+    assert secret not in output.err
+
+
+def test_cli_conformance_status_json_reads_sanitized_store(monkeypatch, capsys, tmp_path):
+    from freellmpool.cli import main
+    from freellmpool.conformance import FEATURE_CHAT, STATUS_PASS, ConformanceStore
+
+    provider = Provider(
+        id="ready",
+        label="Ready",
+        adapter="openai",
+        base_url="https://ready.test/v1",
+        auth="none",
+        models=(Model("first"),),
+    )
+    store = ConformanceStore(tmp_path / "conformance.json")
+    store.record(
+        provider,
+        "first",
+        FEATURE_CHAT,
+        status=STATUS_PASS,
+        classification="verified",
+    )
+    monkeypatch.setattr("freellmpool.cli.ConformanceStore", lambda: store)
+
+    assert main(["conformance", "status", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["version"] == 1
+    assert payload["targets"]["ready/first"]["features"]["chat"]["status"] == "pass"
 
 
 def test_cli_tokenmax_smoke(providers, env, quota, monkeypatch, capsys):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -180,6 +180,29 @@ def test_tools_forwarded_and_tool_calls_preserved():
     assert reply.text == ""
 
 
+def test_response_format_is_forwarded_without_relaxing_token_bound():
+    seen = {}
+
+    def post(url, headers, body, timeout):
+        seen.update(body)
+        return C.HTTPResult(200, openai_body('{"ok":true}'), "")
+
+    reply = C.call(
+        P,
+        "plain-model",
+        [{"role": "user", "content": "json"}],
+        api_key="k",
+        env={},
+        max_tokens=16,
+        response_format={"type": "json_object"},
+        post=post,
+    )
+
+    assert reply.text == '{"ok":true}'
+    assert seen["max_tokens"] == 16
+    assert seen["response_format"] == {"type": "json_object"}
+
+
 def test_think_tags_stripped():
     post = make_post({"x.test": (200, openai_body("<think>secret reasoning</think>final answer"))})
     reply = C.call(

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,0 +1,903 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import json
+import struct
+import threading
+import urllib.request
+import zlib
+from pathlib import Path
+
+import pytest
+from helpers import make_post
+
+import freellmpool.conformance as conformance_module
+from freellmpool.aio import AsyncPool
+from freellmpool.client import HTTPResult
+from freellmpool.conformance import (
+    _RED_PIXEL,
+    FEATURE_CHAT,
+    FEATURE_JSON,
+    FEATURE_JSON_SCHEMA,
+    FEATURE_RESPONSES,
+    FEATURE_STREAMING,
+    FEATURE_TOOLS,
+    FEATURE_VISION,
+    STATUS_PASS,
+    STATUS_UNSUPPORTED,
+    ConformanceStore,
+    classify_canary_exception,
+    required_features,
+    run_target_canaries,
+    validate_canary_result,
+)
+from freellmpool.errors import NoProvidersConfigured, ProviderHTTPError
+from freellmpool.models import Model, Provider, Reply
+from freellmpool.proxy import (
+    _anthropic_models_payload,
+    _openai_models_payload,
+    _responses_input_to_messages,
+    _status_payload,
+    serve,
+)
+from freellmpool.quota import QuotaStore
+from freellmpool.router import Pool
+
+
+def _provider(provider_id: str, adapter: str = "openai") -> Provider:
+    return Provider(
+        id=provider_id,
+        label=provider_id,
+        adapter=adapter,
+        base_url=f"https://{provider_id}.test/v1",
+        auth="none",
+        models=(Model("model-1"),),
+    )
+
+
+def test_store_persists_only_bounded_machine_readable_evidence(tmp_path):
+    path = tmp_path / "conformance.json"
+    provider = _provider("alpha")
+    store = ConformanceStore(path)
+
+    store.record(
+        provider,
+        "model-1",
+        FEATURE_TOOLS,
+        status=STATUS_PASS,
+        classification="verified",
+        verified_at="2026-07-29T12:00:00Z",
+    )
+
+    loaded = ConformanceStore(path)
+    evidence = loaded.evidence(provider, "model-1")
+    assert evidence[FEATURE_TOOLS]["status"] == STATUS_PASS
+    assert evidence[FEATURE_TOOLS]["verification_count"] == 1
+    serialized = path.read_text(encoding="utf-8")
+    assert "response" not in serialized
+    assert "prompt" not in serialized
+    assert "secret" not in serialized
+    assert len(serialized) < 16_384
+
+
+def test_store_invalidates_evidence_after_adapter_or_model_identity_change(tmp_path):
+    path = tmp_path / "conformance.json"
+    original = _provider("alpha", "openai")
+    store = ConformanceStore(path)
+    store.record(
+        original,
+        "model-1",
+        FEATURE_STREAMING,
+        status=STATUS_PASS,
+        classification="verified",
+    )
+
+    changed_adapter = _provider("alpha", "gemini")
+    assert store.evidence(changed_adapter, "model-1") == {}
+    assert store.evidence(original, "renamed-model") == {}
+
+
+def test_store_rejects_oversized_or_malformed_state_without_mutating_it(tmp_path):
+    path = tmp_path / "conformance.json"
+    path.write_text("{" + ("x" * 2_100_000), encoding="utf-8")
+
+    store = ConformanceStore(path)
+
+    assert store.snapshot() == {"version": 1, "targets": {}}
+    assert path.stat().st_size > 2_000_000
+
+
+def test_store_fails_closed_on_deeply_nested_json(tmp_path):
+    path = tmp_path / "conformance.json"
+    original = ("[" * 10_000) + "0" + ("]" * 10_000)
+    path.write_text(original, encoding="utf-8")
+
+    assert ConformanceStore(path).snapshot() == {"version": 1, "targets": {}}
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_store_evicts_oldest_target_at_bounded_capacity(tmp_path, monkeypatch):
+    monkeypatch.setattr(conformance_module, "_MAX_TARGETS", 2)
+    store = ConformanceStore(tmp_path / "conformance.json")
+    alpha = _provider("alpha")
+    beta = _provider("beta")
+    gamma = _provider("gamma")
+    for provider, stamp in (
+        (alpha, "2026-07-29T10:00:00Z"),
+        (beta, "2026-07-29T11:00:00Z"),
+        (gamma, "2026-07-29T12:00:00Z"),
+    ):
+        store.record(
+            provider,
+            "model-1",
+            FEATURE_CHAT,
+            status=STATUS_PASS,
+            classification="verified",
+            verified_at=stamp,
+        )
+
+    snapshot = store.snapshot()
+    assert sorted(snapshot["targets"]) == ["beta/model-1", "gamma/model-1"]
+    assert store.evidence(alpha, "model-1") == {}
+    assert store.evidence(beta, "model-1")[FEATURE_CHAT]["status"] == STATUS_PASS
+    assert store.evidence(gamma, "model-1")[FEATURE_CHAT]["status"] == STATUS_PASS
+
+
+def test_store_uses_windows_cross_process_lock_when_fcntl_is_unavailable(
+    tmp_path, monkeypatch
+):
+    calls = []
+
+    class FakeMsvcrt:
+        LK_LOCK = 1
+        LK_UNLCK = 2
+
+        @staticmethod
+        def locking(fd, mode, size):
+            calls.append((mode, size))
+
+    monkeypatch.setattr(conformance_module, "fcntl", None)
+    monkeypatch.setattr(conformance_module, "msvcrt", FakeMsvcrt, raising=False)
+    store = ConformanceStore(tmp_path / "conformance.json")
+
+    with store._file_lock():
+        assert calls == [(FakeMsvcrt.LK_LOCK, 1)]
+
+    assert calls == [
+        (FakeMsvcrt.LK_LOCK, 1),
+        (FakeMsvcrt.LK_UNLCK, 1),
+    ]
+
+
+def test_store_fails_closed_without_cross_process_lock(tmp_path, monkeypatch):
+    monkeypatch.setattr(conformance_module, "fcntl", None)
+    monkeypatch.setattr(conformance_module, "msvcrt", None, raising=False)
+    store = ConformanceStore(tmp_path / "conformance.json")
+
+    with pytest.raises(RuntimeError, match="cross-process"):
+        store.record(
+            _provider("alpha"),
+            "model-1",
+            FEATURE_CHAT,
+            status=STATUS_PASS,
+            classification="verified",
+        )
+
+
+def test_required_features_detects_tools_json_stream_and_vision():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "What is shown?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+            ],
+        }
+    ]
+    features = required_features(
+        messages,
+        tools=[{"type": "function", "function": {"name": "answer"}}],
+        response_format={"type": "json_object"},
+        stream=True,
+    )
+
+    assert features == frozenset({"vision", FEATURE_TOOLS, FEATURE_JSON, FEATURE_STREAMING})
+
+
+def test_plain_text_response_format_does_not_require_json_conformance(tmp_path):
+    provider = _provider("alpha")
+    store = ConformanceStore(tmp_path / "conformance.json")
+    seen = []
+
+    def post(url, headers, body, timeout):
+        seen.append(body)
+        return HTTPResult(
+            status=200,
+            body={"choices": [{"message": {"role": "assistant", "content": "ok"}}]},
+            text="",
+        )
+
+    assert (
+        required_features(
+            [{"role": "user", "content": "plain"}],
+            response_format={"type": "text"},
+        )
+        == frozenset()
+    )
+    assert required_features(
+        [{"role": "user", "content": "use a tool"}],
+        tools=[{"type": "function", "function": {"name": "answer"}}],
+        protocol=FEATURE_RESPONSES,
+    ) == frozenset({FEATURE_RESPONSES, FEATURE_TOOLS})
+    pool = Pool([provider], env={}, post=post, conformance=store)
+    reply = pool.chat(
+        [{"role": "user", "content": "plain"}],
+        response_format={"type": "text"},
+    )
+
+    assert reply.provider_id == "alpha"
+    assert seen[0]["response_format"] == {"type": "text"}
+
+
+def test_json_schema_requires_distinct_verified_evidence(tmp_path):
+    provider = _provider("alpha")
+    store = ConformanceStore(tmp_path / "conformance.json")
+    store.record(
+        provider,
+        "model-1",
+        FEATURE_JSON,
+        status=STATUS_PASS,
+        classification="verified",
+    )
+    post = make_post({})
+    pool = Pool([provider], env={}, post=post, conformance=store)
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "answer",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {"ok": {"type": "boolean"}},
+                "required": ["ok"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+    with pytest.raises(NoProvidersConfigured):
+        pool.chat(
+            [{"role": "user", "content": "json"}],
+            response_format=response_format,
+        )
+    assert post.calls == []
+
+    store.record(
+        provider,
+        "model-1",
+        FEATURE_JSON_SCHEMA,
+        status=STATUS_PASS,
+        classification="verified",
+    )
+    assert (
+        pool.chat(
+            [{"role": "user", "content": "json"}],
+            response_format=response_format,
+        ).provider_id
+        == "alpha"
+    )
+
+
+def test_async_plain_text_response_format_does_not_require_json_conformance(tmp_path):
+    provider = _provider("alpha")
+    store = ConformanceStore(tmp_path / "conformance.json")
+    seen = []
+
+    async def apost(url, headers, body, timeout):
+        seen.append(body)
+        return HTTPResult(
+            status=200,
+            body={"choices": [{"message": {"role": "assistant", "content": "ok"}}]},
+            text="",
+        )
+
+    pool = AsyncPool(
+        Pool(
+            [provider],
+            env={},
+            quota=QuotaStore(path=tmp_path / "quota.json"),
+            post=make_post({}),
+            conformance=store,
+        ),
+        apost=apost,
+    )
+    reply = asyncio.run(
+        pool.achat(
+            [{"role": "user", "content": "plain"}],
+            response_format={"type": "text"},
+        )
+    )
+
+    assert reply.provider_id == "alpha"
+    assert seen[0]["response_format"] == {"type": "text"}
+
+
+def test_proxy_plain_text_response_format_does_not_require_json_conformance(tmp_path):
+    provider = _provider("alpha")
+    store = ConformanceStore(tmp_path / "conformance.json")
+    seen = []
+
+    def post(url, headers, body, timeout):
+        seen.append(body)
+        return HTTPResult(
+            status=200,
+            body={"choices": [{"message": {"role": "assistant", "content": "ok"}}]},
+            text="",
+        )
+
+    pool = Pool([provider], env={}, post=post, conformance=store)
+    httpd = serve(pool, host="127.0.0.1", port=0)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    request = urllib.request.Request(
+        base + "/v1/chat/completions",
+        data=json.dumps(
+            {
+                "model": "auto",
+                "messages": [{"role": "user", "content": "plain"}],
+                "response_format": {"type": "text"},
+            }
+        ).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request) as response:  # noqa: S310 - local fixture
+            assert response.status == 200
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    assert seen[0]["response_format"] == {"type": "text"}
+
+
+def test_responses_input_image_is_preserved_and_requires_vision():
+    image_url = "data:image/png;base64,AA=="
+    messages = _responses_input_to_messages(
+        {
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "Describe it."},
+                        {"type": "input_image", "image_url": image_url},
+                    ],
+                }
+            ]
+        }
+    )
+
+    assert messages == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe it."},
+                {"type": "image_url", "image_url": {"url": image_url}},
+            ],
+        }
+    ]
+    assert required_features(messages, protocol=FEATURE_RESPONSES) == frozenset(
+        {FEATURE_RESPONSES, FEATURE_VISION}
+    )
+
+
+def test_fixed_vision_canary_is_a_valid_red_rgba_png():
+    encoded = _RED_PIXEL.removeprefix("data:image/png;base64,")
+    raw = base64.b64decode(encoded, validate=True)
+    assert raw.startswith(b"\x89PNG\r\n\x1a\n")
+    offset = 8
+    chunks = {}
+    while offset < len(raw):
+        length = struct.unpack(">I", raw[offset : offset + 4])[0]
+        kind = raw[offset + 4 : offset + 8]
+        data = raw[offset + 8 : offset + 8 + length]
+        crc = struct.unpack(">I", raw[offset + 8 + length : offset + 12 + length])[0]
+        assert binascii.crc32(kind + data) & 0xFFFFFFFF == crc
+        chunks.setdefault(kind, b"")
+        chunks[kind] += data
+        offset += 12 + length
+
+    width, height, depth, color_type, compression, filter_method, interlace = struct.unpack(
+        ">IIBBBBB", chunks[b"IHDR"]
+    )
+    assert (width, height, depth, color_type, compression, filter_method, interlace) == (
+        1,
+        1,
+        8,
+        6,
+        0,
+        0,
+        0,
+    )
+    assert zlib.decompress(chunks[b"IDAT"]) == b"\x00\xff\x00\x00\xff"
+
+
+def test_router_prefers_only_verified_feature_targets_once_evidence_exists(tmp_path):
+    alpha = _provider("alpha")
+    beta = _provider("beta")
+    store = ConformanceStore(tmp_path / "conformance.json")
+    store.record(
+        alpha,
+        "model-1",
+        FEATURE_TOOLS,
+        status=STATUS_UNSUPPORTED,
+        classification="unsupported",
+    )
+    store.record(
+        beta,
+        "model-1",
+        FEATURE_TOOLS,
+        status=STATUS_PASS,
+        classification="verified",
+    )
+    post = make_post({})
+    pool = Pool([alpha, beta], env={}, post=post, conformance=store)
+
+    reply = pool.chat(
+        [{"role": "user", "content": "call answer"}],
+        tools=[{"type": "function", "function": {"name": "answer", "parameters": {}}}],
+    )
+
+    assert reply.provider_id == "beta"
+    assert "beta.test" in post.calls[0]["url"]
+
+
+def test_router_preserves_exact_user_pin_even_when_feature_is_unverified(tmp_path):
+    alpha = _provider("alpha")
+    beta = _provider("beta")
+    store = ConformanceStore(tmp_path / "conformance.json")
+    store.record(
+        beta,
+        "model-1",
+        FEATURE_TOOLS,
+        status=STATUS_PASS,
+        classification="verified",
+    )
+    post = make_post({})
+    pool = Pool([alpha, beta], env={}, post=post, conformance=store)
+
+    reply = pool.chat(
+        [{"role": "user", "content": "call answer"}],
+        model="model-1",
+        providers=["alpha"],
+        tools=[{"type": "function", "function": {"name": "answer", "parameters": {}}}],
+    )
+
+    assert reply.provider_id == "alpha"
+
+
+def test_async_router_uses_only_verified_tool_targets(tmp_path):
+    alpha = _provider("alpha")
+    beta = _provider("beta")
+    store = ConformanceStore(tmp_path / "conformance.json")
+    store.record(
+        beta,
+        "model-1",
+        FEATURE_TOOLS,
+        status=STATUS_PASS,
+        classification="verified",
+    )
+    calls = []
+
+    async def apost(url, headers, body, timeout):
+        calls.append(url)
+        return HTTPResult(
+            status=200,
+            body={"choices": [{"message": {"role": "assistant", "content": "ok"}}]},
+            text="",
+        )
+
+    pool = AsyncPool(
+        Pool(
+            [alpha, beta],
+            env={},
+            quota=QuotaStore(path=tmp_path / "quota.json"),
+            post=make_post({}),
+            conformance=store,
+        ),
+        apost=apost,
+    )
+
+    reply = asyncio.run(
+        pool.achat(
+            [{"role": "user", "content": "call answer"}],
+            tools=[{"type": "function", "function": {"name": "answer", "parameters": {}}}],
+        )
+    )
+
+    assert reply.provider_id == "beta"
+    assert calls == ["https://beta.test/v1/chat/completions"]
+
+
+def test_async_router_forwards_and_gates_structured_protocol_requests(tmp_path):
+    alpha = _provider("alpha")
+    beta = _provider("beta")
+    store = ConformanceStore(tmp_path / "conformance.json")
+    for feature in (FEATURE_JSON, FEATURE_RESPONSES):
+        store.record(
+            beta,
+            "model-1",
+            feature,
+            status=STATUS_PASS,
+            classification="verified",
+        )
+    bodies = []
+
+    async def apost(url, headers, body, timeout):
+        bodies.append(body)
+        return HTTPResult(
+            status=200,
+            body={"choices": [{"message": {"role": "assistant", "content": '{"ok":true}'}}]},
+            text="",
+        )
+
+    pool = AsyncPool(
+        Pool(
+            [alpha, beta],
+            env={},
+            quota=QuotaStore(path=tmp_path / "quota.json"),
+            post=make_post({}),
+            conformance=store,
+        ),
+        apost=apost,
+    )
+
+    reply = asyncio.run(
+        pool.achat(
+            [{"role": "user", "content": "json"}],
+            response_format={"type": "json_object"},
+            protocol=FEATURE_RESPONSES,
+        )
+    )
+
+    assert reply.provider_id == "beta"
+    assert bodies[0]["response_format"] == {"type": "json_object"}
+
+
+def test_router_rejects_unverified_feature_requests_without_an_exact_pin(tmp_path):
+    alpha = _provider("alpha")
+    store = ConformanceStore(tmp_path / "conformance.json")
+    post = make_post({})
+    pool = Pool([alpha], env={}, post=post, conformance=store)
+
+    with pytest.raises(NoProvidersConfigured):
+        pool.chat(
+            [{"role": "user", "content": "call answer"}],
+            tools=[{"type": "function", "function": {"name": "answer", "parameters": {}}}],
+        )
+    assert post.calls == []
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (ProviderHTTPError(400, "tools unsupported", retryable=True), "unsupported"),
+        (ProviderHTTPError(429, "rate limited", retryable=True), "rate_limit"),
+        (ProviderHTTPError(503, "down", retryable=True), "availability"),
+        (TimeoutError("contains-sensitive-upstream-text"), "timeout"),
+    ],
+)
+def test_canary_failure_classification_is_privacy_safe(exc, expected):
+    assert classify_canary_exception(exc) == expected
+    assert "sensitive" not in classify_canary_exception(exc)
+
+
+def test_tool_canary_rejects_semantically_wrong_arguments():
+    reply = Reply(
+        text="",
+        provider_id="alpha",
+        model="model-1",
+        raw={},
+        message={
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "record_number", "arguments": '{"number": 8}'},
+                }
+            ]
+        },
+    )
+
+    assert validate_canary_result(FEATURE_TOOLS, reply) == "semantic_mismatch"
+
+
+def test_json_canary_rejects_valid_json_with_wrong_semantics():
+    reply = Reply(
+        text='{"ok": false}',
+        provider_id="alpha",
+        model="model-1",
+        raw={},
+    )
+
+    assert validate_canary_result(FEATURE_JSON, reply) == "semantic_mismatch"
+
+
+def test_chat_canary_accepts_normalized_exact_result():
+    reply = Reply(text="  OK. \n", provider_id="alpha", model="model-1", raw={})
+
+    assert validate_canary_result(FEATURE_CHAT, reply) == "verified"
+
+
+def test_vision_canary_requires_the_exact_expected_color_word():
+    reply = Reply(
+        text="The image is not red",
+        provider_id="alpha",
+        model="model-1",
+        raw={},
+    )
+
+    assert validate_canary_result(FEATURE_VISION, reply) == "semantic_mismatch"
+    reply.text = "red"
+    assert validate_canary_result(FEATURE_VISION, reply) == "verified"
+
+
+def test_state_json_never_contains_provider_response_or_exception_text(tmp_path):
+    provider = _provider("alpha")
+    path = tmp_path / "conformance.json"
+    store = ConformanceStore(path)
+    store.record(
+        provider,
+        "model-1",
+        FEATURE_JSON,
+        status="fail",
+        classification="semantic_mismatch",
+    )
+
+    parsed = json.loads(path.read_text(encoding="utf-8"))
+    feature = parsed["targets"]["alpha/model-1"]["features"][FEATURE_JSON]
+    assert set(feature) == {
+        "status",
+        "classification",
+        "verified_at",
+        "verification_count",
+    }
+
+
+def test_protocol_conformance_operator_contract_is_documented():
+    root = Path(__file__).resolve().parents[1]
+    doc = (root / "docs" / "PROTOCOL_CONFORMANCE.md").read_text(encoding="utf-8")
+    readme = (root / "README.md").read_text(encoding="utf-8")
+    contributing = (root / "CONTRIBUTING.md").read_text(encoding="utf-8")
+
+    for phrase in (
+        "freellmpool conformance run",
+        "freellmpool conformance status",
+        "explicitly pinned",
+        "FREELLMPOOL_CONFORMANCE_FILE",
+        "FREELLMPOOL_CONFORMANCE_KEYS_JSON",
+        "16",
+        "never",
+    ):
+        assert phrase in doc
+    assert "docs/PROTOCOL_CONFORMANCE.md" in readme
+    assert "docs/PROTOCOL_CONFORMANCE.md" in contributing
+
+
+def test_default_pool_honors_programmatic_conformance_path(tmp_path, monkeypatch):
+    path = tmp_path / "custom-conformance.json"
+    monkeypatch.delenv("FREELLMPOOL_CONFORMANCE_FILE", raising=False)
+
+    pool = Pool.from_default_config(
+        env={"FREELLMPOOL_CONFORMANCE_FILE": str(path)}
+    )
+
+    assert pool.conformance is not None
+    assert pool.conformance.path == path
+
+
+def test_status_and_model_payloads_expose_feature_evidence(tmp_path):
+    provider = _provider("alpha")
+    store = ConformanceStore(tmp_path / "conformance.json")
+    store.record(
+        provider,
+        "model-1",
+        FEATURE_STREAMING,
+        status=STATUS_PASS,
+        classification="verified",
+    )
+    pool = Pool([provider], env={}, post=make_post({}), conformance=store)
+
+    status = _status_payload(pool, [])
+    model_status = status["providers"][0]["models"][0]
+    assert model_status["capabilities"][FEATURE_STREAMING]["status"] == STATUS_PASS
+    assert model_status["verified_features"] == [FEATURE_STREAMING]
+
+    models = _openai_models_payload(pool)
+    target = next(row for row in models["data"] if row["id"] == "alpha/model-1")
+    assert target["capabilities"][FEATURE_STREAMING]["status"] == STATUS_PASS
+    assert target["verified_features"] == [FEATURE_STREAMING]
+
+    anthropic = _anthropic_models_payload(pool)
+    anthropic_target = next(
+        row for row in anthropic["data"] if row["id"] == "alpha/model-1"
+    )
+    assert anthropic_target["capabilities"][FEATURE_STREAMING]["status"] == STATUS_PASS
+    assert anthropic_target["verified_features"] == [FEATURE_STREAMING]
+
+
+def test_verified_target_filter_reads_one_snapshot(tmp_path, monkeypatch):
+    providers = [_provider("alpha"), _provider("beta")]
+    store = ConformanceStore(tmp_path / "conformance.json")
+    for provider in providers:
+        store.record(
+            provider,
+            "model-1",
+            FEATURE_TOOLS,
+            status=STATUS_PASS,
+            classification="verified",
+        )
+    pool = Pool(providers, env={}, post=make_post({}), conformance=store)
+    original_snapshot = store.snapshot
+    calls = 0
+
+    def counted_snapshot():
+        nonlocal calls
+        calls += 1
+        return original_snapshot()
+
+    monkeypatch.setattr(store, "snapshot", counted_snapshot)
+
+    assert len(store.verified_targets(pool._all_targets(), [FEATURE_TOOLS])) == 2
+    assert calls == 1
+
+
+def test_proxy_forwards_response_format_and_preserves_serving_provenance(tmp_path):
+    provider = _provider("alpha")
+    store = ConformanceStore(tmp_path / "conformance.json")
+    store.record(
+        provider,
+        "model-1",
+        FEATURE_JSON,
+        status=STATUS_PASS,
+        classification="verified",
+    )
+    seen = {}
+
+    def post(url, headers, body, timeout):
+        seen.update(body)
+        return HTTPResult(
+            status=200,
+            body={
+                "choices": [{"message": {"role": "assistant", "content": '{"ok":true}'}}],
+                "usage": {},
+            },
+            text="",
+        )
+
+    pool = Pool([provider], env={}, post=post, conformance=store)
+    httpd = serve(pool, host="127.0.0.1", port=0)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    payload = {
+        "model": "auto",
+        "messages": [{"role": "user", "content": "json"}],
+        "response_format": {"type": "json_object"},
+        "max_tokens": 16,
+    }
+    request = urllib.request.Request(
+        base + "/v1/chat/completions",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(request) as response:  # noqa: S310 - local fixture
+            body = json.load(response)
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    assert seen["response_format"] == {"type": "json_object"}
+    assert body["model"] == "alpha/model-1"
+
+
+def test_canary_runner_uses_only_fixed_bounded_synthetic_requests():
+    provider = _provider("alpha")
+    calls = []
+
+    def call_fn(provider, model, messages, **kwargs):
+        calls.append({"messages": messages, **kwargs})
+        if kwargs.get("tools"):
+            return Reply(
+                text="",
+                provider_id=provider.id,
+                model=model,
+                raw={},
+                message={
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "type": "function",
+                            "function": {
+                                "name": "record_number",
+                                "arguments": '{"number":7}',
+                            },
+                        }
+                    ]
+                },
+            )
+        if kwargs.get("response_format"):
+            return Reply(text='{"ok":true}', provider_id=provider.id, model=model, raw={})
+        return Reply(text="OK", provider_id=provider.id, model=model, raw={})
+
+    def stream_fn(provider, model, messages, **kwargs):
+        calls.append({"messages": messages, "stream": True, **kwargs})
+        yield "O"
+        yield "K"
+
+    results = run_target_canaries(
+        provider,
+        "model-1",
+        env={},
+        features=(
+            "chat",
+            "streaming",
+            "tools",
+            "json",
+            "responses",
+            "anthropic_messages",
+        ),
+        timeout=12,
+        call_fn=call_fn,
+        stream_fn=stream_fn,
+    )
+
+    assert all(row == {"status": STATUS_PASS, "classification": "verified"} for row in results.values())
+    assert len(calls) == 6
+    assert all(call["max_tokens"] <= 16 for call in calls)
+    assert all(call["enforce_thinking_floor"] is False for call in calls if "stream" not in call)
+    serialized = json.dumps(calls)
+    assert "AUDIT_REPORT" not in serialized
+    assert "repository" not in serialized.casefold()
+    assert "user content" not in serialized.casefold()
+
+
+def test_canary_runner_classifies_unsupported_without_serializing_error_text():
+    provider = _provider("alpha")
+
+    def call_fn(*args, **kwargs):
+        raise ProviderHTTPError(
+            400,
+            "tools unsupported SECRET_SHOULD_NOT_LEAK",
+            retryable=True,
+        )
+
+    results = run_target_canaries(
+        provider,
+        "model-1",
+        env={},
+        features=(FEATURE_TOOLS,),
+        call_fn=call_fn,
+    )
+
+    assert results == {
+        FEATURE_TOOLS: {
+            "status": STATUS_UNSUPPORTED,
+            "classification": "unsupported",
+        }
+    }
+    assert "SECRET_SHOULD_NOT_LEAK" not in json.dumps(results)
+
+
+def test_canary_runner_rejects_unknown_or_excessive_feature_matrix():
+    provider = _provider("alpha")
+    with pytest.raises(ValueError, match="unknown"):
+        run_target_canaries(provider, "model-1", env={}, features=("bogus",))
+    with pytest.raises(ValueError, match="at most"):
+        run_target_canaries(
+            provider,
+            "model-1",
+            env={},
+            features=("chat",) * 20,
+        )

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -903,6 +903,46 @@ def test_responses_shim_input_items(server):
     assert body["output_text"] == "ok"
 
 
+def _responses_stream_events(raw):
+    return [
+        json.loads(line.removeprefix("data: "))
+        for line in raw.splitlines()
+        if line.startswith("data: ")
+    ]
+
+
+def _assert_responses_stream_accumulates(raw):
+    """Replay the SDK's output accumulation invariants over a Responses stream."""
+
+    events = _responses_stream_events(raw)
+    assert [event["sequence_number"] for event in events] == list(range(len(events)))
+    current = json.loads(json.dumps(events[0]["response"]))
+    assert current["output"] == []
+    for event in events[1:]:
+        kind = event["type"]
+        if kind == "response.output_item.added":
+            current["output"].append(event["item"])
+        elif kind == "response.content_part.added":
+            current["output"][event["output_index"]]["content"].append(event["part"])
+        elif kind == "response.output_text.delta":
+            current["output"][event["output_index"]]["content"][event["content_index"]][
+                "text"
+            ] += event["delta"]
+        elif kind == "response.output_text.done":
+            current["output"][event["output_index"]]["content"][event["content_index"]][
+                "text"
+            ] = event["text"]
+        elif kind == "response.content_part.done":
+            current["output"][event["output_index"]]["content"][event["content_index"]] = (
+                event["part"]
+            )
+        elif kind == "response.output_item.done":
+            current["output"][event["output_index"]] = event["item"]
+        elif kind == "response.completed":
+            assert current["output"] == event["response"]["output"]
+    return events
+
+
 def test_responses_shim_streaming(server):
     req = urllib.request.Request(
         server + "/v1/responses",
@@ -914,6 +954,190 @@ def test_responses_shim_streaming(server):
     assert "event: response.created" in raw
     assert "event: response.output_text.delta" in raw
     assert "event: response.completed" in raw
+    _assert_responses_stream_accumulates(raw)
+
+
+def test_responses_tools_are_forwarded_and_return_function_call_output(providers, env, quota):
+    tool_calls = [
+        {
+            "id": "call_weather",
+            "type": "function",
+            "function": {"name": "weather", "arguments": '{"city":"Dublin"}'},
+        }
+    ]
+    post = make_post(
+        {
+            "alpha.test": (
+                200,
+                {"choices": [{"message": {"content": None, "tool_calls": tool_calls}}]},
+            )
+        }
+    )
+    pool = Pool(providers[:1], quota=quota, env=env, post=post)
+    httpd, base = _serve(pool)
+    try:
+        status, body = _post_json(
+            base + "/v1/responses",
+            {
+                "model": "auto",
+                "input": "What is the weather?",
+                "tools": [
+                    {
+                        "type": "function",
+                        "name": "weather",
+                        "description": "Look up weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                        "strict": True,
+                    }
+                ],
+                "tool_choice": {"type": "function", "name": "weather"},
+            },
+        )
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    assert status == 200
+    upstream = post.calls[0]["body"]
+    assert upstream["tools"] == [
+        {
+            "type": "function",
+            "function": {
+                "name": "weather",
+                "description": "Look up weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+                "strict": True,
+            },
+        }
+    ]
+    assert upstream["tool_choice"] == {
+        "type": "function",
+        "function": {"name": "weather"},
+    }
+    assert body["output_text"] == ""
+    assert body["output"] == [
+        {
+            "type": "function_call",
+            "id": "fc-call_weather",
+            "call_id": "call_weather",
+            "name": "weather",
+            "arguments": '{"city":"Dublin"}',
+            "status": "completed",
+        }
+    ]
+
+
+def test_responses_stream_includes_function_call_events(providers, env, quota):
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "lookup", "arguments": '{"q":"answer"}'},
+        }
+    ]
+    post = make_post(
+        {
+            "alpha.test": (
+                200,
+                {"choices": [{"message": {"content": None, "tool_calls": tool_calls}}]},
+            )
+        }
+    )
+    pool = Pool(providers[:1], quota=quota, env=env, post=post)
+    httpd, base = _serve(pool)
+    try:
+        req = urllib.request.Request(
+            base + "/v1/responses",
+            data=json.dumps(
+                {
+                    "model": "auto",
+                    "stream": True,
+                    "input": "Use the lookup tool",
+                    "tools": [
+                        {
+                            "type": "function",
+                            "name": "lookup",
+                            "parameters": {"type": "object"},
+                        }
+                    ],
+                }
+            ).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req) as resp:  # noqa: S310
+            raw = resp.read().decode()
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+    events = _assert_responses_stream_accumulates(raw)
+    arguments_done = next(
+        event
+        for event in events
+        if event["type"] == "response.function_call_arguments.done"
+    )
+    assert arguments_done["name"] == "lookup"
+    assert isinstance(arguments_done["sequence_number"], int)
+    completed = next(event for event in events if event["type"] == "response.completed")
+    assert completed["response"]["output"][0]["type"] == "function_call"
+    assert completed["response"]["output"][0]["call_id"] == "call_1"
+
+
+def test_responses_function_call_history_translates_to_chat_messages():
+    from freellmpool.proxy import _responses_input_to_messages
+
+    assert _responses_input_to_messages(
+        {
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "lookup",
+                    "arguments": '{"q":"answer"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "42",
+                },
+            ]
+        }
+    ) == [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": '{"q":"answer"}'},
+                }
+            ],
+        },
+        {"role": "tool", "content": "42", "tool_call_id": "call_1"},
+    ]
+
+
+def test_responses_rejects_non_function_tools_instead_of_silently_dropping(server):
+    with pytest.raises(urllib.error.HTTPError) as exc_info:
+        _post_json(
+            server + "/v1/responses",
+            {
+                "model": "auto",
+                "input": "search",
+                "tools": [{"type": "web_search_preview"}],
+            },
+        )
+    assert exc_info.value.code == 400
+    assert json.load(exc_info.value)["error"]["type"] == "invalid_request_error"
 
 
 def test_responses_missing_input_400(server):
@@ -1152,6 +1376,19 @@ def test_null_assistant_content_not_stringified():
     out = _normalize_messages([{"role": "assistant", "content": None, "tool_calls": [{"id": "x"}]}])
     assert out[0]["content"] == ""
     assert out[0]["tool_calls"] == [{"id": "x"}]
+
+
+def test_multimodal_content_is_preserved_for_vision_routing():
+    from freellmpool.proxy import _normalize_messages
+
+    content = [
+        {"type": "text", "text": "What color is this?"},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA=="}},
+    ]
+
+    assert _normalize_messages([{"role": "user", "content": content}]) == [
+        {"role": "user", "content": content}
+    ]
 
 
 # ---- JSON /status endpoint + per-request routing control ----


### PR DESCRIPTION
## Summary

- add bounded, deterministic per-model canaries for chat, streaming, tools, JSON object, JSON schema, vision, Responses, and Anthropic Messages
- gate feature-specific automatic routing on current provider/model evidence while preserving exact-pin overrides and safe cache provenance
- expose machine-readable capabilities in CLI/proxy model and status surfaces, including plugin providers
- add protected catalog-sentinel automation, cross-platform atomic evidence storage, and SDK-compatible Responses tool streaming

## Verification

- `pytest --cov=freellmpool --cov-branch --cov-report=json:.coverage.json`
- line coverage 86.47%; branch coverage 74.51%
- `ruff check .`
- focused strict `mypy`
- catalog/count/release/proxy-stress gates
- Bandit, pip-audit, and zizmor
- OpenAI Python SDK 2.48.0 consumed both text and function-call Responses streams
- Codex Sol 5.6 xhigh approved exact tree `56099172d493138210b62a88c160136ebdf75a9c`

Fixes #71

## Summary by Sourcery

Introduce per-model protocol conformance canaries and wire their evidence into routing, proxy/CLI surfaces, and CI workflows.

New Features:
- Add protocol conformance store and deterministic feature canaries for chat, streaming, tools, JSON object/schema, vision, Responses, and Anthropic Messages.
- Expose per-model capabilities and verified_features in CLI models JSON output and proxy /status and /models responses, including plugin providers.
- Add CLI conformance subcommands to run bounded feature probes and inspect sanitized evidence state JSON.

Enhancements:
- Update routing, async routing, and cache keying to be feature-aware, restricting automatic routing and cache hits to verified targets while preserving exact provider/model pins.
- Extend Responses and Anthropic Messages shims to support tools, function-call history, structured streaming events, and protocol-aware provenance.
- Forward OpenAI response_format through client, async pool, and proxy while keeping token bounds and adapter compatibility.

CI:
- Expand catalog-sentinel GitHub workflow with longer authenticated timeout and a bounded protocol conformance canaries step whose artifacts and state are cached and uploaded.

Documentation:
- Document protocol conformance canaries, routing contract, protected automation, and operator privacy guarantees in PROTOCOL_CONFORMANCE.md and reference it from README and CONTRIBUTING.

Tests:
- Add comprehensive conformance store, feature inference, routing, proxy, client, cache, CLI, and workflow tests to validate bounded behavior, evidence sanitization, and protocol streaming invariants.