### PR TITLE
release: freellmpool 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-08-23
+
 ### Added
 - A bounded Vercel AI Gateway acceptance verifier that checks every automatic
   route's aggregate and endpoint pricing before credential use, performs

--- a/README.es.md
+++ b/README.es.md
@@ -23,17 +23,11 @@ comparaciones.
 
 ## Estado de versión y distribución
 
-- **Última versión: 0.11.4.** La versión de GitHub y el paquete de PyPI son
-  0.11.4; incluyen el enrutamiento `spread`.
-- **main contiene cambios aún no publicados**, entre ellos el perfil de
-  Hermes, las APIs operativas `/livez`, `/readyz`, `/v1/providers` y
-  `/v1/models?ready=true`, el catálogo actualizado y la preparación para
-  publicar los plugins de OpenCode que ya existen en 0.11.4. Para probar esos
-  cambios antes de la próxima versión, reemplaza el paquete en tu entorno:
-
-  ```bash
-  python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'
-  ```
+- **Última versión: 0.12.0.** La versión de GitHub y el paquete de PyPI son
+  0.12.0; incluyen el perfil de Hermes, las APIs operativas `/livez`,
+  `/readyz`, `/v1/providers` y `/v1/models?ready=true`, el catálogo actualizado,
+  Vercel AI Gateway, el enrutamiento `spread` y la preparación de los plugins
+  de OpenCode para el registro.
 
 - **Estado de publicación en npm: pendiente.** `opencode-freellmpool` y
   `opencode-freellmpool-tui` están probados, pero no publicados en npm al

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Existing OpenAI-compatible apps work the same way: set
 Anthropic-compatible tools can use the experimental bridge with
 `ANTHROPIC_BASE_URL=http://localhost:8080`.
 
-**OpenCode** gets a deeper integration on current `main`: a live in-editor **dashboard** (routing mode,
+**OpenCode** gets a deeper integration in 0.12.0: a live in-editor **dashboard** (routing mode,
 estimated savings, tokens served free, provider race, latency), per-request
 **agent routing** via the model picker (`freellmpool/agent|spread|auto|fast|quality|fair`), and `freellmpool_status`
 / `freellmpool_models` tools — see [integrations/opencode-tui](integrations/opencode-tui)
@@ -286,7 +286,7 @@ freellmpool profile show opencode
 freellmpool profile doctor opencode --dry-run
 ```
 
-Current `main` proxy surfaces (the readiness/provider additions are unreleased):
+Release 0.12.0 proxy surfaces:
 
 - `/v1/chat/completions` — OpenAI-compatible chat, token streaming, tool calling.
 - `/v1/responses` — minimal Responses API shim for Codex-style agents.

--- a/README.md
+++ b/README.md
@@ -19,18 +19,10 @@ proxy. Can start without API keys when a keyless provider is up.
 
 ## Release and distribution status
 
-- **Latest release: 0.11.4.** The GitHub release and PyPI package are both
-  0.11.4; `pip install freellmpool` and `uvx freellmpool` install that released
-  artifact. It includes `spread` routing.
-- **Current main includes unreleased changes**, including the Hermes profile,
-  proxy readiness/provider APIs, refreshed provider catalog, and
-  registry-readiness hardening for the existing repository-local OpenCode
-  plugins. To exercise those before the next release, replace the released
-  package in your environment with current `main`:
-
-  ```bash
-  python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'
-  ```
+- **Latest release: 0.12.0.** The GitHub release and PyPI package are both
+  0.12.0; `pip install freellmpool` and `uvx freellmpool` install the Hermes
+  profile, proxy readiness/provider APIs, refreshed provider catalog, Vercel
+  AI Gateway support, `spread` routing, and OpenCode registry-readiness hardening.
 
 - **Registry publication status: pending.** `opencode-freellmpool` and
   `opencode-freellmpool-tui` are tested but not published on npm as of
@@ -137,7 +129,7 @@ freellmpool proxy                       # starts http://localhost:8080
 freellmpool code claude                 # prints the one-line setup for Claude Code
 freellmpool profile list                # richer installable profiles
 freellmpool profile show metaswarm      # Tailnet-aware Metaswarm profile
-freellmpool profile install hermes       # Hermes config (current main; unreleased)
+freellmpool profile install hermes       # Hermes custom-endpoint config
 # (also: codex, aider, cline, continue, cursor, hermes, opencode, metaswarm)
 ```
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -7,17 +7,11 @@ rate-limits you mid-run (exactly when long agent loops tend to die).
 
 ## Release status
 
-- **Latest release: 0.11.4.** GitHub and PyPI both provide 0.11.4, including
-  `freellmpool/spread` routing.
-- **Current main includes unreleased changes**: the Hermes profile, public
-  `/livez` and `/readyz`, authenticated `/v1/providers`,
-  `/v1/models?ready=true`, and registry-readiness hardening for the existing
-  repository-local OpenCode plugins. Replace the released package in your agent
-  environment to test that source:
-
-  ```bash
-  python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'
-  ```
+- **Latest release: 0.12.0.** GitHub and PyPI both provide 0.12.0, including
+  the Hermes profile, `freellmpool/spread` routing, public `/livez` and
+  `/readyz`, authenticated `/v1/providers`, `/v1/models?ready=true`, refreshed
+  providers, Vercel AI Gateway support, and OpenCode registry-readiness hardening.
+  Install it with `python -m pip install freellmpool`.
 
 - **Registry publication status: pending.** `opencode-freellmpool` and
   `opencode-freellmpool-tui` were not published on npm as of 2026-07-19; use
@@ -33,7 +27,7 @@ export OPENAI_API_KEY=anything   # ignored by freellmpool
 
 Then wire up your tool of choice.
 
-On current `main`, orchestrators can use `/livez` for liveness, `/readyz` for an
+Orchestrators can use `/livez` for liveness, `/readyz` for an
 advisory local quota/cooldown snapshot, authenticated `/v1/providers` for
 secret-free provider readiness, and `/v1/models?ready=true` for ready targets.
 These endpoints do not probe upstream providers.
@@ -100,7 +94,7 @@ codex --config model_provider=openai   # or set base URL in ~/.codex/config.toml
 > running Codex/agents on free inference for everyday coding; tool-calling and
 > richer Responses features are a work in progress.
 
-## Hermes Agent (current main; unreleased)
+## Hermes Agent (released in 0.12.0)
 
 Hermes supports an OpenAI-compatible custom endpoint. The first-class profile
 prints the supported config and never edits `~/.hermes/config.yaml`:

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -17,17 +17,11 @@ model setting untouched — just set the base URL and any API key.
 
 ## Release status
 
-The latest GitHub and PyPI release is 0.11.4. Current `main` includes unreleased
-changes documented below: the Hermes profile, the readiness/provider operations
-APIs, and registry-readiness hardening for the existing repository-local
-OpenCode plugins. To test those additions before the next release, replace the
-released package in your integration environment with `main`:
-
-```bash
-python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'
-```
-
-Released 0.11.4 already includes `spread` routing.
+Latest release: 0.12.0. GitHub and PyPI both provide the Hermes profile, the
+readiness/provider operations APIs, refreshed providers, Vercel AI Gateway
+support, `spread` routing, and registry-readiness hardening for the existing
+repository-local OpenCode plugins. Install it with
+`python -m pip install freellmpool`.
 
 ---
 
@@ -172,8 +166,8 @@ escalation/final-review tools.
 
 ### Hermes Agent
 
-The Hermes profile is on current `main` and is not part of released 0.11.4.
-Hermes supports OpenAI-compatible custom endpoints. Start the proxy, then either
+The Hermes profile is included in release 0.12.0. Hermes supports
+OpenAI-compatible custom endpoints. Start the proxy, then either
 run `hermes model` and choose **Custom endpoint**, or inspect the print-only
 profile:
 

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -71,7 +71,7 @@ Anthropic bridge, `/v1/models` for concrete `provider/model` ids, `/dashboard`
 for operations, `/playground` for browser-side battle runs, and
 `/freellmpool/battle` for JSON/Markdown comparison results.
 
-On current `main`, automation can use `/healthz` and `/livez` as public liveness aliases;
+In release 0.12.0, automation can use `/healthz` and `/livez` as public liveness aliases;
 `/readyz` is a public advisory local-capacity probe (200 or 503), and
 `/v1/providers` is the authenticated secret-free inventory. Use
 `/v1/models?ready=true` to keep the normal OpenAI/Anthropic model-list shape

--- a/docs/MCP_LISTINGS.md
+++ b/docs/MCP_LISTINGS.md
@@ -1,6 +1,6 @@
 # MCP Registry Listing Status
 
-Updated on 2026-06-19 after the `freellmpool 0.11.4` release docs pass. The official MCP
+Updated on 2026-08-23 for the `freellmpool 0.12.0` release. The official MCP
 Registry entry and MCP.so submission are complete; Smithery, Glama, and PulseMCP
 still need account/web UI actions.
 
@@ -10,7 +10,7 @@ still need account/web UI actions.
 
 - Schema: `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
 - Name: `io.github.0xzr/freellmpool`
-- Version: `0.11.4`
+- Version: `0.12.0`
 - Repository: `https://github.com/0xzr/freellmpool`
 - Package: PyPI `freellmpool`, runtime hint `uvx`
 - Transport: stdio

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,12 +67,10 @@ freellmpool ask "Explain the CAP theorem in one sentence."   # keyless when rout
 MIT license
 </p>
 
-<div class="note"><strong>Release status.</strong> Latest release: 0.11.4, available from both
-GitHub and PyPI. <strong>Current main includes unreleased changes</strong>, including the Hermes profile,
-the readiness/provider operations APIs, refreshed catalog data, and registry-readiness hardening for
+<div class="note"><strong>Release status.</strong> Latest release: 0.12.0, available from both
+GitHub and PyPI. It includes the Hermes profile, readiness/provider operations APIs, refreshed
+providers, Vercel AI Gateway support, <code>spread</code> routing, and registry-readiness hardening for
 the existing repository-local OpenCode plugins.
-Released 0.11.4 already includes <code>spread</code> routing. To test the main-only additions explicitly:
-<pre><code>python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'</code></pre>
 <strong>Registry publication status: pending.</strong> <code>opencode-freellmpool</code> and
 <code>opencode-freellmpool-tui</code> are CI-tested but were not published on npm as of 2026-07-19;
 use their repository-local installation paths.</div>
@@ -92,8 +90,8 @@ tiers — not a server you deploy and not a paid aggregator.</p>
 <ul>
 <li><strong>Use free LLMs from the command line:</strong> <code>freellmpool ask "..."</code>, pipe stdin, pin a provider/model.</li>
 <li><strong>OpenAI-compatible proxy:</strong> point <code>OPENAI_BASE_URL</code> at <code>freellmpool proxy</code> for most text, embedding, and transcription calls.</li>
-<li><strong>Run coding agents for free:</strong> <code>freellmpool code claude</code> (also codex, aider, cline, continue, cursor, Hermes, and OpenCode) routes them to pooled free models — see the <a href="run-coding-agents-on-free-models.html">step-by-step guide</a>. The Hermes profile is currently main-only.</li>
-<li><strong>Automate proxy operations:</strong> current <code>main</code> adds public <code>/livez</code> and <code>/readyz</code> probes, authenticated <code>/v1/providers</code>, and <code>/v1/models?ready=true</code> for locally ready targets.</li>
+<li><strong>Run coding agents for free:</strong> <code>freellmpool code claude</code> (also codex, aider, cline, continue, cursor, Hermes, and OpenCode) routes them to pooled free models — see the <a href="run-coding-agents-on-free-models.html">step-by-step guide</a>. The Hermes profile is included in 0.12.0.</li>
+<li><strong>Automate proxy operations:</strong> release 0.12.0 includes public <code>/livez</code> and <code>/readyz</code> probes, authenticated <code>/v1/providers</code>, and <code>/v1/models?ready=true</code> for locally ready targets.</li>
 <li><strong>Use OpenCode deeply:</strong> choose <code>freellmpool/agent</code> for strongest-tier, quota-aware agent loops and add the repository-local dashboard/tools plugins while npm publication is pending.</li>
 <li><strong>Add model-pool review to metaswarm:</strong> use the experimental <a href="https://github.com/0xzr/freellmpool/tree/main/integrations/metaswarm">metaswarm adapter</a> as a review-only external tool.</li>
 <li><strong>Async + library:</strong> <code>from freellmpool import Pool, AsyncPool</code>.</li>
@@ -185,7 +183,7 @@ for provider routing, ToS, and privacy notes.</p>
 
 </div>
 
-<p class="meta">Free and open source (MIT). Latest release: 0.11.4. Page updated 2026-08-23.
+<p class="meta">Free and open source (MIT). Latest release: 0.12.0. Page updated 2026-08-23.
 Project: <a href="https://github.com/0xzr/freellmpool">github.com/0xzr/freellmpool</a></p>
 
 </div>
@@ -200,7 +198,7 @@ Project: <a href="https://github.com/0xzr/freellmpool">github.com/0xzr/freellmpo
   "description": "Free, open-source OpenAI-compatible gateway that pools the free tiers of 24 cataloged LLM providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Cloudflare, Morph, Vercel and more) behind one endpoint, with automatic failover. CLI, Python library, local proxy, and MCP server. Keyless start when routes are available.",
   "url": "https://0xzr.github.io/freellmpool/",
   "downloadUrl": "https://pypi.org/project/freellmpool/",
-  "softwareVersion": "0.11.4",
+  "softwareVersion": "0.12.0",
   "license": "https://opensource.org/licenses/MIT",
   "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
   "author": {"@type": "Person", "name": "0xzr"}

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,10 +10,9 @@
 > free tiers are usable right now and help configure more.
 
 ## Release status
-- Latest GitHub and PyPI release: 0.11.4. Released 0.11.4 includes `spread` routing.
-- Current main includes unreleased changes: the Hermes profile, `/livez`, `/readyz`,
-  `/v1/providers`, `/v1/models?ready=true`, refreshed catalog data, and registry-readiness hardening for the existing repository-local OpenCode plugins. Persistent source install:
-  `python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'`.
+- Latest release: 0.12.0. GitHub and PyPI include the Hermes profile, `spread`
+  routing, `/livez`, `/readyz`, `/v1/providers`, `/v1/models?ready=true`,
+  refreshed providers, Vercel AI Gateway support, and OpenCode registry-readiness hardening.
 - OpenCode npm registry publication is pending; `opencode-freellmpool` and
   `opencode-freellmpool-tui` were not published as of 2026-07-19.
 

--- a/docs/promotion/README.md
+++ b/docs/promotion/README.md
@@ -5,22 +5,19 @@ registry polish. Use this pack when posting externally.
 
 ## Current launch facts
 
-Release facts and unreleased repository facts are separated below. Do not pair
-the current-main catalog counts with the published PyPI package until a release
-containing those counts is available.
+These facts describe the 0.12.0 GitHub and PyPI release.
 
 - Repository: <https://github.com/0xzr/freellmpool>
 - Docs: <https://0xzr.github.io/freellmpool/>
 - PyPI: <https://pypi.org/project/freellmpool/>
-- Version: `0.11.4`
+- Version: `0.12.0`
 - First-run hook: installs with `pip install freellmpool` and can answer with no
   API keys through default keyless/key-optional routes.
 - Interfaces: CLI, Python library, OpenAI-compatible proxy, experimental
   Anthropic-compatible proxy path, and MCP server.
 - Audio: OpenAI-compatible speech-to-text through the transcription endpoint.
-- Current checkout / target catalog (unreleased): 24 cataloged providers, 226
-  enabled chat routes, 410 cataloged chat models. Relabel this as current main
-  only after the catalog change merges.
+- Released catalog: 24 cataloged providers, 226 enabled chat routes, 410
+  cataloged chat models.
 - Strongest visual assets:
   - `assets/social-preview.png`
   - `assets/demo.png`

--- a/docs/run-coding-agents-on-free-models.html
+++ b/docs/run-coding-agents-on-free-models.html
@@ -45,18 +45,12 @@ the free tiers of 24 providers (Groq, Cerebras, NVIDIA, Gemini, OpenRouter, Clou
 and more) behind one endpoint, with automatic failover. Several providers need no API key, so you can
 start for free in under a minute and change no code in the agent.</strong></p>
 
-<div class="note"><strong>Release status:</strong> GitHub and PyPI both provide 0.11.4.
-Released 0.11.4 includes <code>spread</code> routing. The Hermes profile and the operational endpoints
-below are newer, unreleased additions on current <code>main</code>. Replace the released package in
-your agent environment to use them:
-<pre><code>python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'</code></pre></div>
+<div class="note"><strong>Release status:</strong> Latest release: 0.12.0. GitHub and PyPI both
+provide the Hermes profile, operational endpoints, refreshed providers, Vercel AI Gateway support,
+<code>spread</code> routing, and OpenCode registry-readiness hardening.</div>
 
-<h2>1. Choose a release or current-main install, then start the proxy</h2>
-<pre><code># Released 0.11.4:
-python -m pip install freellmpool
-# Or replace it with current main for Hermes and the operational endpoints:
-python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'
-
+<h2>1. Install the release, then start the proxy</h2>
+<pre><code>python -m pip install freellmpool
 freellmpool proxy            # serves http://localhost:8080</code></pre>
 <p>That's all the setup. The proxy now accepts both OpenAI (<code>/v1/chat/completions</code>) and
 Anthropic (<code>/v1/messages</code>) requests and routes each to a free provider, failing over when one
@@ -81,7 +75,7 @@ codex</code></pre>
 export OPENAI_API_KEY=anything
 aider --model gpt-4o-mini      # alias resolves to a free model</code></pre>
 
-<h3>Hermes Agent (current main; unreleased)</h3>
+<h3>Hermes Agent (released in 0.12.0)</h3>
 <p>Hermes supports a custom OpenAI-compatible endpoint. The print-only profile
 shows the supported config without editing <code>~/.hermes/config.yaml</code>:</p>
 <pre><code>freellmpool profile install hermes
@@ -95,8 +89,8 @@ Run <code>freellmpool code &lt;agent&gt;</code> for the exact per-agent setup.</
 refactors, tests, commit messages, and everyday edits — not a substitute for a frontier model on the
 hardest reasoning. Limits reset at UTC midnight.</div>
 
-<h2>3. Operational checks for agents and orchestrators (current main)</h2>
-<p>The current-main proxy exposes public <code>/livez</code> liveness and advisory
+<h2>3. Operational checks for agents and orchestrators</h2>
+<p>The proxy exposes public <code>/livez</code> liveness and advisory
 <code>/readyz</code> readiness. Authenticated automation can inspect the secret-free
 <code>/v1/providers</code> inventory or request only locally ready models with
 <code>/v1/models?ready=true</code>. Readiness is a local quota/cooldown snapshot; it does not
@@ -119,11 +113,11 @@ those tools officially support for custom base URLs and local models. You're usi
 own free tiers; don't abuse them.</p>
 <h3>Which coding agents are supported?</h3>
 <p>Any tool that lets you set an OpenAI or Anthropic base URL: Claude Code, OpenAI Codex CLI, Hermes,
-Aider, Cline, Continue, Cursor, OpenCode, and more. Hermes' first-class profile is currently on
-<code>main</code> rather than in released 0.11.4.</p>
+Aider, Cline, Continue, Cursor, OpenCode, and more. Hermes' first-class profile is
+included in release 0.12.0.</p>
 
 <p class="meta">Part of <a href="https://github.com/0xzr/freellmpool">freellmpool</a> (MIT, free, open
-source). Updated 2026-07-19.</p>
+source). Updated 2026-08-23.</p>
 
 </div>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "freellmpool", "item": "https://0xzr.github.io/freellmpool/"}, {"@type": "ListItem", "position": 2, "name": "How to run Claude Code, Codex, Hermes, or Aider on free LLM models", "item": "https://0xzr.github.io/freellmpool/run-coding-agents-on-free-models.html"}]}</script>

--- a/docs/run-opencode-on-free-models.html
+++ b/docs/run-opencode-on-free-models.html
@@ -46,18 +46,11 @@ and more) behind one endpoint, with automatic failover. Several providers need n
 start for free in under a minute. It also ships an OpenCode plugin with a <strong>live dashboard, quality
 routing, and usage tools</strong> built in.</strong></p>
 
-<div class="note"><strong>Release status:</strong> GitHub and PyPI both provide 0.11.4,
-including <code>spread</code> routing. Repository-local OpenCode plugin sources are included in 0.11.4;
-current <code>main</code> adds registry-readiness hardening, corrected defaults, and the operations APIs
-described below. Replace the released package to test that source explicitly:
-<pre><code>python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'</code></pre></div>
+<div class="note"><strong>Release status:</strong> Latest release: 0.12.0. GitHub and PyPI include
+<code>spread</code> routing and the operations APIs described below. Repository-local OpenCode plugin sources are included in 0.12.0 with registry-readiness hardening and corrected defaults.</div>
 
-<h2>1. Choose a release or current-main install, then start the proxy</h2>
-<pre><code># Released 0.11.4:
-python -m pip install freellmpool
-# Or replace it with current main for the latest plugin support and operations APIs:
-python -m pip install --force-reinstall 'git+https://github.com/0xzr/freellmpool.git@main'
-
+<h2>1. Install the release, then start the proxy</h2>
+<pre><code>python -m pip install freellmpool
 freellmpool proxy            # serves http://localhost:8080</code></pre>
 <p>The proxy now routes OpenAI-style requests to a free provider and fails over when one is
 rate-limited.</p>
@@ -113,12 +106,12 @@ The planned packages are <code>opencode-freellmpool</code> and
 but neither package was published on npm as of 2026-07-19. Use the linked
 local-file setup until both registry versions are verified.</p>
 
-<h2>5. Operational checks (current main)</h2>
+<h2>5. Operational checks</h2>
 <p>Before a long OpenCode run, automation can call public <code>/livez</code> for process
 liveness and <code>/readyz</code> for advisory local capacity. With proxy authentication,
 <code>/v1/providers</code> returns secret-free readiness details and
 <code>/v1/models?ready=true</code> returns only locally ready targets. These endpoints are
-current-main additions and readiness does not probe upstream providers.</p>
+released operations, and readiness does not probe upstream providers.</p>
 
 <div class="note">Free-tier models are smaller than frontier models. They're great for scaffolding,
 refactors, tests, commit messages, and everyday edits — not a substitute for a frontier model on the
@@ -148,7 +141,7 @@ for local and custom models. You're using the LLM providers' own free tiers; don
 <code>freellmpool_status</code> tool, or curl the proxy's <code>/status</code> endpoint.</p>
 
 <p class="meta">Part of <a href="https://github.com/0xzr/freellmpool">freellmpool</a> (MIT, free, open
-source). Updated 2026-07-19.</p>
+source). Updated 2026-08-23.</p>
 
 </div>
 <script type="application/ld+json">{"@context": "https://schema.org", "@type": "BreadcrumbList", "itemListElement": [{"@type": "ListItem", "position": 1, "name": "freellmpool", "item": "https://0xzr.github.io/freellmpool/"}, {"@type": "ListItem", "position": 2, "name": "How to run OpenCode on free LLM models", "item": "https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html"}]}</script>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -8,8 +8,8 @@
   <url><loc>https://0xzr.github.io/freellmpool/free-claude-api.html</loc><lastmod>2026-07-16</lastmod><priority>0.9</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/free-alternative-to-openrouter.html</loc><lastmod>2026-07-16</lastmod><priority>0.8</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/use-multiple-free-llm-apis.html</loc><lastmod>2026-07-16</lastmod><priority>0.8</priority></url>
-  <url><loc>https://0xzr.github.io/freellmpool/run-coding-agents-on-free-models.html</loc><lastmod>2026-07-19</lastmod><priority>0.8</priority></url>
-  <url><loc>https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html</loc><lastmod>2026-07-28</lastmod><priority>0.8</priority></url>
+  <url><loc>https://0xzr.github.io/freellmpool/run-coding-agents-on-free-models.html</loc><lastmod>2026-08-23</lastmod><priority>0.8</priority></url>
+  <url><loc>https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html</loc><lastmod>2026-08-23</lastmod><priority>0.8</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/capacity-management.html</loc><lastmod>2026-07-16</lastmod><priority>0.8</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/free-groq-api.html</loc><lastmod>2026-06-03</lastmod><priority>0.7</priority></url>
   <url><loc>https://0xzr.github.io/freellmpool/free-gemini-api.html</loc><lastmod>2026-06-03</lastmod><priority>0.7</priority></url>

--- a/integrations/opencode-tui/README.md
+++ b/integrations/opencode-tui/README.md
@@ -49,7 +49,7 @@ your editor and lives alongside OpenCode's own Context / MCP / LSP panels.
 > **Registry publication status: pending.** `opencode-freellmpool-tui` and the
 > companion `opencode-freellmpool` server plugin are pack/install/load-tested
 > in CI, but neither package was published on npm as of 2026-07-19.
-> Repository-local plugin sources are included in 0.11.4; current `main` adds registry-readiness hardening and corrected defaults. Use the local-file command
+> Repository-local plugin sources are included in 0.12.0 with registry-readiness hardening and corrected defaults. Use the local-file command
 > below until verified registry versions exist.
 
 OpenCode TUI plugins are installed with the built-in installer (which wires the OpenTUI

--- a/integrations/opencode/README.md
+++ b/integrations/opencode/README.md
@@ -47,7 +47,7 @@ aggregate quota matters more than keeping every turn in the strongest tier.
 > **Registry publication status: pending.** `opencode-freellmpool` and its
 > companion `opencode-freellmpool-tui` are pack/install/load-tested in CI, but
 > neither package was published on npm as of 2026-07-19.
-> Repository-local plugin sources are included in 0.11.4; current `main` adds registry-readiness hardening
+> Repository-local plugin sources are included in 0.12.0 with registry-readiness hardening
 > and corrected defaults. Use the local-file path below until verified registry
 > versions exist.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "freellmpool"
-version = "0.11.4"
+version = "0.12.0"
 description = "Free LLM API pool: 24 LLM providers cataloged, 226 routes, 410 cataloged chat models, keyless start when available."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/0xzr/freellmpool",
     "source": "github"
   },
-  "version": "0.11.4",
+  "version": "0.12.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "freellmpool",
-      "version": "0.11.4",
+      "version": "0.12.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/freellmpool/_version.py
+++ b/src/freellmpool/_version.py
@@ -1,3 +1,3 @@
 """Single source for the installed package version."""
 
-__version__ = "0.11.4"
+__version__ = "0.12.0"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -66,12 +66,12 @@ def test_all_agent_keys_appear_in_integrations_guide():
         assert name.casefold() in coding_agents_section
 
 
-def test_agents_guide_tracks_current_release_and_main_surfaces():
+def test_agents_guide_tracks_current_release_surfaces():
     guide = (ROOT / "docs" / "AGENTS.md").read_text(encoding="utf-8")
 
-    assert "Latest release: 0.11.4" in guide
-    assert "Current main includes unreleased changes" in guide
-    assert "git+https://github.com/0xzr/freellmpool.git@main" in guide
+    assert "Latest release: 0.12.0" in guide
+    assert "Current main includes unreleased changes" not in guide
+    assert "0.11.4" not in guide
     assert "Registry publication status: pending" in guide
     for marker in (
         "Hermes",

--- a/tests/test_opencode_packages.py
+++ b/tests/test_opencode_packages.py
@@ -175,7 +175,7 @@ def test_unpublished_registry_install_is_labelled_pending_everywhere() -> None:
         assert "opencode-freellmpool-tui" in text
 
 
-def test_opencode_docs_distinguish_released_sources_from_registry_hardening() -> None:
+def test_opencode_docs_include_current_release_and_registry_hardening() -> None:
     paths = [
         ROOT / "docs" / "run-opencode-on-free-models.html",
         ROOT / "integrations" / "opencode" / "README.md",
@@ -183,9 +183,9 @@ def test_opencode_docs_distinguish_released_sources_from_registry_hardening() ->
     ]
     for path in paths:
         text = path.read_text(encoding="utf-8")
-        assert "plugin sources are included in 0.11.4" in text
+        assert "plugin sources are included in 0.12.0" in text
         assert "registry-readiness hardening" in text
-        assert "unreleased repository additions" not in text
+        assert "0.11.4" not in text
 
 
 def test_opencode_config_examples_forward_protected_proxy_auth() -> None:

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -18,6 +18,7 @@ def test_release_metadata_versions_match_package() -> None:
     demo = (ROOT / "assets" / "demo.svg").read_text()
     readme = (ROOT / "README.md").read_text()
 
+    assert version == "0.12.0"
     assert __version__ == version
     assert server["version"] == version
     assert server["packages"][0]["version"] == version
@@ -92,7 +93,7 @@ def test_readme_has_current_adoption_paths_and_pinned_comparison_sources() -> No
         assert "/v1/models?ready=true" in text
 
 
-def test_public_docs_separate_release_from_current_main() -> None:
+def test_public_docs_describe_the_current_release() -> None:
     pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
     version = pyproject["project"]["version"]
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
@@ -113,17 +114,14 @@ def test_public_docs_separate_release_from_current_main() -> None:
         ),
     )
 
+    for text in source_docs:
+        assert version in text
+        assert "pip install" in text
+        assert "Current main includes unreleased changes" not in text
+        assert "0.11.4" not in text
+
     for text in (readme, index):
         assert f"Latest release: {version}" in text
-        assert "Current main includes unreleased changes" in text
-
-    for text in source_docs:
-        assert "python -m pip install" in text
-        assert "git+https://github.com/0xzr/freellmpool.git@main" in text
-        assert (
-            "uvx --from git+https://github.com/0xzr/freellmpool.git@main "
-            "freellmpool --version"
-        ) not in text
 
     assert f'"softwareVersion": "{version}"' in index
 
@@ -167,14 +165,26 @@ def test_pages_describe_current_main_agent_and_operations_surfaces() -> None:
 def test_pages_dates_match_current_documentation_pass() -> None:
     sitemap = (ROOT / "docs" / "sitemap.xml").read_text(encoding="utf-8")
     index = (ROOT / "docs" / "index.html").read_text(encoding="utf-8")
+    agent_guide = (ROOT / "docs" / "run-coding-agents-on-free-models.html").read_text(
+        encoding="utf-8"
+    )
+    opencode_guide = (ROOT / "docs" / "run-opencode-on-free-models.html").read_text(
+        encoding="utf-8"
+    )
     assert "Page updated 2026-08-23" in index
+    assert "Updated 2026-08-23" in agent_guide
+    assert "Updated 2026-08-23" in opencode_guide
     assert (
         "<loc>https://0xzr.github.io/freellmpool/</loc>"
         "<lastmod>2026-08-23</lastmod>"
     ) in sitemap
     assert (
+        "<loc>https://0xzr.github.io/freellmpool/run-coding-agents-on-free-models.html</loc>"
+        "<lastmod>2026-08-23</lastmod>"
+    ) in sitemap
+    assert (
         "<loc>https://0xzr.github.io/freellmpool/run-opencode-on-free-models.html</loc>"
-        "<lastmod>2026-07-28</lastmod>"
+        "<lastmod>2026-08-23</lastmod>"
     ) in sitemap
     assert (
         "<loc>https://0xzr.github.io/freellmpool/free-llm-api-providers-list.html</loc>"
@@ -206,7 +216,7 @@ def test_pypi_metadata_has_launch_surfaces() -> None:
 
     assert len(project["description"]) <= 120
     assert f"> {project['description']}" in discovery
-    assert "Current checkout / target catalog (unreleased)" in promotion
+    assert "Released catalog: 24 cataloged providers, 226 enabled chat routes" in promotion
 
     urls = project["urls"]
     for name in ("Docs", "Changelog", "Issues", "Repository"):

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -115,9 +115,11 @@ def test_public_docs_describe_the_current_release() -> None:
     )
 
     for text in source_docs:
+        normalized = text.casefold().replace("`", "")
         assert version in text
         assert "pip install" in text
-        assert "Current main includes unreleased changes" not in text
+        assert "unreleased" not in normalized
+        assert re.search(r"\bcurrent[- ]+main\b", normalized) is None
         assert "0.11.4" not in text
 
     for text in (readme, index):

--- a/tests/test_spanish_readme.py
+++ b/tests/test_spanish_readme.py
@@ -29,9 +29,9 @@ def test_spanish_readme_tracks_current_launch_surface():
     assert "24 proveedores" in spanish
     assert "226 rutas de chat" in spanish
     assert "410 modelos de chat" in spanish
-    assert "Última versión: 0.11.4" in spanish
-    assert "main contiene cambios aún no publicados" in spanish
-    assert "git+https://github.com/0xzr/freellmpool.git@main" in spanish
+    assert "Última versión: 0.12.0" in spanish
+    assert "main contiene cambios aún no publicados" not in spanish
+    assert "0.11.4" not in spanish
     assert "Estado de publicación en npm: pendiente" in spanish
     assert "opencode-freellmpool" in spanish
     assert "opencode-freellmpool-tui" in spanish


### PR DESCRIPTION
## Summary

- bump freellmpool from 0.11.4 to 0.12.0
- move accumulated unreleased changes into the 2026-08-23 release entry
- synchronize README, Pages, integration, agent, MCP, promotion, sitemap, and package metadata
- add regression guards against stale 0.11.4 and unreleased-main claims

## Validation

- 1,071 tests passed
- coverage: 86.66% lines, 74.83% branches
- Ruff and CI-scoped mypy passed
- catalog/count/release metadata passed
- wheel + sdist build, Twine check, and clean wheel smoke passed
- Bandit, pip-audit, Zizmor, and secret-pattern checks passed
- one final xhigh review: GREEN

## Summary by Sourcery

Release freellmpool 0.12.0 and align all package metadata, public documentation, distribution listings, and regression checks with the published release.

Enhancements:
- Finalize the freellmpool 0.12.0 release by promoting accumulated functionality and catalog updates from unreleased status to the published release.
- Synchronize package, server, MCP, documentation, promotion, and Pages metadata with version 0.12.0 and the 2026-08-23 release date.

Documentation:
- Update English and Spanish release guidance to describe 0.12.0 as the current GitHub and PyPI release, including Hermes, operational APIs, Vercel AI Gateway, refreshed providers, and OpenCode integration.
- Refresh release-related guides, registry listings, sitemap dates, and promotion materials to reflect the released catalog and current distribution status.

Tests:
- Add regression checks ensuring public documentation and release metadata do not retain stale 0.11.4 or unreleased-main claims.