### PR TITLE
fix: satisfy current MCP registry description limit

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.0xzr/freellmpool",
   "title": "freellmpool",
-  "description": "Pool 24 LLM providers through MCP: ask, panel, second-opinion, battle, recipe, roles, tailnet, quota-wise, tokenmax, route, models, quota, and stats.",
+  "description": "OpenAI-compatible MCP gateway pooling 24 LLM providers with routing, failover, quota, and tools.",
   "websiteUrl": "https://0xzr.github.io/freellmpool/",
   "repository": {
     "url": "https://github.com/0xzr/freellmpool",

--- a/tests/test_mcp_listings.py
+++ b/tests/test_mcp_listings.py
@@ -43,20 +43,10 @@ def test_server_json_is_registry_ready_for_stdio_package():
         "url": "https://github.com/0xzr/freellmpool",
         "source": "github",
     }
+    assert len(server["description"]) <= 100
     assert "24 LLM providers" in server["description"]
-    assert "tokenmax" in server["description"]
-    # WU-011: registry description surfaces the new UX tools too.
-    for new_tool in (
-        "second-opinion",
-        "battle",
-        "recipe",
-        "roles",
-        "tailnet",
-        "quota-wise",
-    ):
-        assert new_tool in server["description"].lower(), (
-            f"server.json description should mention {new_tool}"
-        )
+    assert "OpenAI-compatible" in server["description"]
+    assert "MCP" in server["description"]
     assert package["registryType"] == "pypi"
     assert package["identifier"] == "freellmpool"
     assert package["version"] == __version__


### PR DESCRIPTION
## Summary

- shorten the MCP Registry description to its current 100-character limit
- preserve the provider count, MCP, and OpenAI-compatible positioning
- replace impossible full tool enumeration in the description test with current schema constraints

## Validation

- official mcp-publisher 1.8.1 online validation passed
- focused MCP/release suites passed
- release readiness and catalog counts passed
- one xhigh review: GREEN

## Summary by Sourcery

Bring the MCP Registry listing and its validation in line with the current description schema constraints.

Bug Fixes:
- Shorten the MCP Registry server description to comply with the current 100-character limit while retaining its provider count and positioning.

Enhancements:
- Update listing validation to enforce the registry length limit and verify the key description markers instead of requiring exhaustive tool-name enumeration.