### PR TITLE
fix: release 0.12.2 without premature latest promotion

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -170,6 +170,8 @@ jobs:
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-## [0.12.1] — 2026-08-29
+## [0.12.2] — 2026-08-29
+
+This release includes the maintenance changes below. Version 0.12.1 was tagged
+but not published: the container no-clobber guard correctly stopped when Docker
+metadata implicitly added the mutable `latest` tag. The exposed tag was left
+unchanged and superseded rather than moved or reused.
 
 ### Added
 - A dated, source-backed model-activity audit covering every packaged chat,
@@ -59,6 +64,11 @@ All notable changes to this project are documented here. The format is based on
   interactive terminal, while non-interactive use requires an explicit key.
 - The bundled `llm-freellmpool` examples now pin an enabled Groq route and its
   package metadata points to the maintained monorepo source.
+
+## [0.12.1] — 2026-08-29
+
+This version was tagged but was not published to PyPI or GitHub Releases. It was
+superseded by 0.12.2 without moving or reusing the exposed tag.
 
 ## [0.12.0] — 2026-08-23
 

--- a/README.es.md
+++ b/README.es.md
@@ -25,8 +25,8 @@ comparaciones.
 
 ## Estado de versión y distribución
 
-- **Última versión: 0.12.1.** La versión de GitHub y el paquete de PyPI son
-  0.12.1; incluyen el catálogo auditado, el endurecimiento de streaming y del
+- **Última versión: 0.12.2.** La versión de GitHub y el paquete de PyPI son
+  0.12.2; incluyen el catálogo auditado, el endurecimiento de streaming y del
   sentinel, el perfil de Hermes, las APIs operativas `/livez`, `/readyz`,
   `/v1/providers` y `/v1/models?ready=true`, y el enrutamiento `spread`.
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ enabled keyless route is available.
 
 ## Release and distribution status
 
-- **Latest release: 0.12.1.** The GitHub release and PyPI package are both
-  0.12.1; `pip install freellmpool` and `uvx freellmpool` install the audited
+- **Latest release: 0.12.2.** The GitHub release and PyPI package are both
+  0.12.2; `pip install freellmpool` and `uvx freellmpool` install the audited
   provider catalog, bounded streaming and sentinel hardening, Hermes profile,
   proxy readiness/provider APIs, `spread` routing, and OpenCode
   registry-readiness hardening.
@@ -204,7 +204,7 @@ docker volume create freellmpool-data
 docker run --rm -p 127.0.0.1:8080:8080 \
   --volume freellmpool-data:/home/freellmpool/.config/freellmpool \
   --env GROQ_API_KEY \
-  ghcr.io/0xzr/freellmpool:0.12.1
+  ghcr.io/0xzr/freellmpool:0.12.2
 ```
 
 Omit `--env GROQ_API_KEY` if you want a credential-free start; the proxy can

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -7,7 +7,7 @@ rate-limits you mid-run (exactly when long agent loops tend to die).
 
 ## Release status
 
-- **Latest release: 0.12.1.** GitHub and PyPI both provide 0.12.1, including
+- **Latest release: 0.12.2.** GitHub and PyPI both provide 0.12.2, including
   the Hermes profile, `freellmpool/spread` routing, public `/livez` and
   `/readyz`, authenticated `/v1/providers`, `/v1/models?ready=true`, refreshed
   providers, Vercel AI Gateway support, and OpenCode registry-readiness hardening.

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -17,7 +17,7 @@ model setting untouched — just set the base URL and any API key.
 
 ## Release status
 
-Latest release: 0.12.1. GitHub and PyPI both provide the Hermes profile, the
+Latest release: 0.12.2. GitHub and PyPI both provide the Hermes profile, the
 readiness/provider operations APIs, refreshed providers, Vercel AI Gateway
 support, `spread` routing, and registry-readiness hardening for the existing
 repository-local OpenCode plugins. Install it with

--- a/docs/MCP_LISTINGS.md
+++ b/docs/MCP_LISTINGS.md
@@ -1,6 +1,6 @@
 # MCP Registry Listing Status
 
-Updated on 2026-08-29 for the local `freellmpool 0.12.1` manifest. The official
+Updated on 2026-08-29 for the local `freellmpool 0.12.2` manifest. The official
 MCP Registry has an active published entry and the MCP.so submission is complete;
 the live active/latest endpoint below is authoritative for the version whose
 publication has finished. Smithery, Glama, and PulseMCP still need account/web
@@ -12,7 +12,7 @@ UI actions.
 
 - Schema: `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
 - Name: `io.github.0xzr/freellmpool`
-- Version: `0.12.1`
+- Version: `0.12.2`
 - Repository: `https://github.com/0xzr/freellmpool`
 - Package: PyPI `freellmpool`, runtime hint `uvx`
 - Transport: stdio

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,7 +67,7 @@ freellmpool ask "Explain the CAP theorem in one sentence."   # keyless when rout
 MIT license
 </p>
 
-<div class="note"><strong>Release status.</strong> Latest release: 0.12.1, available from both
+<div class="note"><strong>Release status.</strong> Latest release: 0.12.2, available from both
 GitHub and PyPI. It includes the audited provider catalog, bounded streaming and sentinel hardening,
 the Hermes profile, readiness/provider operations APIs, <code>spread</code> routing, and registry-readiness hardening for
 the existing repository-local OpenCode plugins.
@@ -184,7 +184,7 @@ for provider routing, ToS, and privacy notes.</p>
 
 </div>
 
-<p class="meta">Free and open source (MIT). Latest release: 0.12.1. Page updated 2026-08-29.
+<p class="meta">Free and open source (MIT). Latest release: 0.12.2. Page updated 2026-08-29.
 Project: <a href="https://github.com/0xzr/freellmpool">github.com/0xzr/freellmpool</a></p>
 
 </div>
@@ -199,7 +199,7 @@ Project: <a href="https://github.com/0xzr/freellmpool">github.com/0xzr/freellmpo
   "description": "Free, open-source OpenAI-compatible gateway with cataloged free-tier routes across 22 LLM providers behind one endpoint, automatic failover, CLI, Python library, local proxy, and MCP server. Keyless start when routes are available.",
   "url": "https://0xzr.github.io/freellmpool/",
   "downloadUrl": "https://pypi.org/project/freellmpool/",
-  "softwareVersion": "0.12.1",
+  "softwareVersion": "0.12.2",
   "license": "https://opensource.org/licenses/MIT",
   "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
   "author": {"@type": "Person", "name": "0xzr"}

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,7 +10,7 @@
 > free tiers are usable right now and help configure more.
 
 ## Release status
-- Latest release: 0.12.1. GitHub and PyPI include the audited provider catalog,
+- Latest release: 0.12.2. GitHub and PyPI include the audited provider catalog,
   bounded streaming and sentinel hardening, the Hermes profile, `spread` routing,
   `/livez`, `/readyz`, `/v1/providers`, `/v1/models?ready=true`, and OpenCode
   registry-readiness hardening.

--- a/docs/promotion/README.md
+++ b/docs/promotion/README.md
@@ -5,12 +5,12 @@ registry polish. Use this pack when posting externally.
 
 ## Current launch facts
 
-These facts describe the 0.12.1 GitHub and PyPI release.
+These facts describe the 0.12.2 GitHub and PyPI release.
 
 - Repository: <https://github.com/0xzr/freellmpool>
 - Docs: <https://0xzr.github.io/freellmpool/>
 - PyPI: <https://pypi.org/project/freellmpool/>
-- Version: `0.12.1`
+- Version: `0.12.2`
 - First-run hook: installs with `pip install freellmpool` and can answer with no
   provider credentials while an enabled keyless/key-optional route is available.
 - Interfaces: CLI, Python library, OpenAI-compatible proxy, experimental

--- a/docs/run-coding-agents-on-free-models.html
+++ b/docs/run-coding-agents-on-free-models.html
@@ -45,7 +45,7 @@ free LLM tiers by pointing them at a local proxy that speaks the OpenAI API and 
     disabled candidates (177 enabled chat routes), and automatically fails over only across enabled routes you
     can access. You can start without provider credentials when an enabled keyless route is available.</strong></p>
 
-<div class="note"><strong>Release status:</strong> Latest release: 0.12.1. GitHub and PyPI both
+<div class="note"><strong>Release status:</strong> Latest release: 0.12.2. GitHub and PyPI both
 provide the Hermes profile, operational endpoints, refreshed providers, Vercel AI Gateway support,
 <code>spread</code> routing, and OpenCode registry-readiness hardening.</div>
 

--- a/docs/run-opencode-on-free-models.html
+++ b/docs/run-opencode-on-free-models.html
@@ -47,7 +47,7 @@ free LLM tiers — no API bill — by pointing it at a local proxy that speaks t
     ships an OpenCode plugin with a <strong>live dashboard, quality
 routing, and usage tools</strong> built in.</strong></p>
 
-<div class="note"><strong>Release status:</strong> Latest release: 0.12.1. GitHub and PyPI include
+<div class="note"><strong>Release status:</strong> Latest release: 0.12.2. GitHub and PyPI include
 <code>spread</code> routing and the operations APIs described below. Repository-local OpenCode plugin sources are included in 0.12.0 with registry-readiness hardening and corrected defaults.</div>
 
 <h2>1. Install the release, then start the proxy</h2>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "freellmpool"
-version = "0.12.1"
+version = "0.12.2"
 description = "Free LLM gateway: 22 LLM providers, 177 enabled chat routes, 431 cataloged chat models; keyless start when available."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/0xzr/freellmpool",
     "source": "github"
   },
-  "version": "0.12.1",
+  "version": "0.12.2",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "freellmpool",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/freellmpool/_version.py
+++ b/src/freellmpool/_version.py
@@ -1,3 +1,3 @@
 """Single source for the installed package version."""
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -69,7 +69,7 @@ def test_all_agent_keys_appear_in_integrations_guide():
 def test_agents_guide_tracks_current_release_surfaces():
     guide = (ROOT / "docs" / "AGENTS.md").read_text(encoding="utf-8")
 
-    assert "Latest release: 0.12.1" in guide
+    assert "Latest release: 0.12.2" in guide
     assert "Current main includes unreleased changes" not in guide
     assert "0.11.4" not in guide
     assert "Registry publication status: pending" in guide

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -19,7 +19,7 @@ def test_release_metadata_versions_match_package() -> None:
     demo = (ROOT / "assets" / "demo.svg").read_text()
     readme = (ROOT / "README.md").read_text()
 
-    assert version == "0.12.1"
+    assert version == "0.12.2"
     assert __version__ == version
     assert server["version"] == version
     assert server["packages"][0]["version"] == version

--- a/tests/test_spanish_readme.py
+++ b/tests/test_spanish_readme.py
@@ -29,7 +29,7 @@ def test_spanish_readme_tracks_current_launch_surface():
     assert "22 proveedores" in spanish
     assert "177 rutas de chat" in spanish
     assert "431 modelos de chat" in spanish
-    assert "Última versión: 0.12.1" in spanish
+    assert "Última versión: 0.12.2" in spanish
     assert "main contiene cambios aún no publicados" not in spanish
     assert "0.11.4" not in spanish
     assert "Estado de publicación en npm: pendiente" in spanish

--- a/tests/test_supply_chain.py
+++ b/tests/test_supply_chain.py
@@ -306,6 +306,7 @@ def test_release_artifacts_and_images_have_sboms_and_provenance():
     assert "--prefer-index=false" in images
     assert "type=raw,value=latest" not in images
     assert "*:latest" not in images
+    assert "flavor: |\n            latest=false" in images
     assert "Preflight immutable version tags" in images
     assert "manifest unknown|not found" in images
     assert "Refusing to overwrite immutable version tag" in images


### PR DESCRIPTION
## Summary

- explicitly disable docker/metadata-action automatic latest emission during immutable version publication
- supersede the tagged-but-unpublished v0.12.1 with 0.12.2 without moving or reusing the exposed tag
- align root package, MCP manifest, docs, Pages metadata, and release notes on 0.12.2

## Failure evidence

Release evidence run 33256203399 stopped safely at the immutable-tag preflight because metadata-action emitted both 0.12.1 and latest. No root PyPI artifact, GitHub Release, versioned GHCR tag, image attestation, MCP record, or plugin artifact was published. Existing latest remained unchanged.

## Validation

- full pytest suite
- focused release/supply-chain/docs/plugin suites
- full build, twine check, and fresh 0.12.2 wheel install
- actionlint and release-checklist ShellCheck
- ruff, focused mypy, docs/assets/counts/readiness, and diff checks
- independent pinned-source verification that latest=false produces only the exact semver tag

## Summary by Sourcery

Publish 0.12.2 safely without prematurely promoting or reusing the mutable `latest` container tag.

Bug Fixes:
- Prevent Docker image publication from implicitly promoting the mutable `latest` tag during immutable version releases.

Enhancements:
- Supersede the unpublished 0.12.1 release with 0.12.2 while preserving the existing exposed tag.
- Synchronize the package, MCP manifest, documentation, release notes, and metadata with version 0.12.2.

Documentation:
- Update release status, installation examples, and distribution metadata across project documentation for 0.12.2.

Tests:
- Extend release and supply-chain checks to verify that Docker metadata emits only the immutable semantic-version tag.