### PR TITLE
fix: align Vercel evidence and release 0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
-## [0.12.2] — 2026-08-29
+## [0.12.3] — 2026-08-29
 
-This release includes the maintenance changes below. Version 0.12.1 was tagged
-but not published: the container no-clobber guard correctly stopped when Docker
-metadata implicitly added the mutable `latest` tag. The exposed tag was left
-unchanged and superseded rather than moved or reused.
+This release includes the maintenance changes below. Versions 0.12.1 and 0.12.2
+were tagged but not published to PyPI or GitHub Releases. The 0.12.1 container
+no-clobber guard correctly stopped an implicit mutable `latest` tag; 0.12.2 then
+published only its scanned immutable versioned container before a final evidence
+audit caught contradictory Vercel completion wording. Every exposed tag and
+container remains unchanged and is superseded rather than moved or reused.
 
 ### Added
 - A dated, source-backed model-activity audit covering every packaged chat,
@@ -40,9 +42,11 @@ unchanged and superseded rather than moved or reused.
 - Removed the retired GitHub Models chat/embedder integrations and the obsolete
   LongCat provider; refreshed Groq, Kilo, NVIDIA, Gemini, Cloudflare, Vercel,
   Cerebras, Mistral, OpenRouter, and the remaining packaged catalogs.
-- Restricted Vercel automatic routing to the completion-verified zero-price
-  Poolside route. Current zero-price candidates remain disabled until their
-  provenance, cost, and credentialed completion acceptance evidence is complete.
+- Restricted Vercel automatic routing to the sole Poolside route with verified
+  public aggregate and endpoint zero pricing. Its credentialed completion,
+  serving-provider provenance, and response-cost acceptance remain blocked by
+  Vercel customer verification; other zero-price candidates remain disabled
+  pending equivalent evidence.
 - Upgraded the digest-pinned Python container base and installed Alpine security
   updates while removing build-only packaging tools from the runtime image.
 - Bumped CodeQL actions to the current pinned v4 release and made Python and
@@ -65,10 +69,17 @@ unchanged and superseded rather than moved or reused.
 - The bundled `llm-freellmpool` examples now pin an enabled Groq route and its
   package metadata points to the maintained monorepo source.
 
+## [0.12.2] — 2026-08-29
+
+This version was tagged and its scanned immutable versioned container was
+published to GHCR, but it was not published to PyPI or GitHub Releases. A final
+evidence audit found contradictory Vercel completion wording, so the exposed tag
+and container were preserved and superseded by 0.12.3.
+
 ## [0.12.1] — 2026-08-29
 
 This version was tagged but was not published to PyPI or GitHub Releases. It was
-superseded by 0.12.2 without moving or reusing the exposed tag.
+superseded without moving or reusing the exposed tag.
 
 ## [0.12.0] — 2026-08-23
 

--- a/README.es.md
+++ b/README.es.md
@@ -25,8 +25,8 @@ comparaciones.
 
 ## Estado de versión y distribución
 
-- **Última versión: 0.12.2.** La versión de GitHub y el paquete de PyPI son
-  0.12.2; incluyen el catálogo auditado, el endurecimiento de streaming y del
+- **Última versión: 0.12.3.** La versión de GitHub y el paquete de PyPI son
+  0.12.3; incluyen el catálogo auditado, el endurecimiento de streaming y del
   sentinel, el perfil de Hermes, las APIs operativas `/livez`, `/readyz`,
   `/v1/providers` y `/v1/models?ready=true`, y el enrutamiento `spread`.
 
@@ -308,7 +308,7 @@ tarjeta, prueba finita o precio están en [docs/ACCOUNTS.md](docs/ACCOUNTS.md).
 | Aion Labs | `AION_API_KEY` | 20K tokens gratis/día, sin tarjeta |
 | ModelScope API Inference | `MODELSCOPE_API_KEY` | 2.000 llamadas gratis/día |
 | Morph | `MORPH_API_KEY` | alias con precio retenidos deshabilitados para verificación futura |
-| Vercel AI Gateway | `AI_GATEWAY_API_KEY` | automático solo para Poolside a precio cero verificado; define un presupuesto en el gateway |
+| Vercel AI Gateway | `AI_GATEWAY_API_KEY` | automático solo para Poolside con precio público verificado en cero; define un presupuesto en el gateway |
 | SiliconFlow | `SILICONFLOW_API_KEY` | modelos gratis; requiere verificación de identidad |
 | Mistral, Cohere, SambaNova, Z.ai, Ollama Cloud | ver `.env.example` | |
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ enabled keyless route is available.
 
 ## Release and distribution status
 
-- **Latest release: 0.12.2.** The GitHub release and PyPI package are both
-  0.12.2; `pip install freellmpool` and `uvx freellmpool` install the audited
+- **Latest release: 0.12.3.** The GitHub release and PyPI package are both
+  0.12.3; `pip install freellmpool` and `uvx freellmpool` install the audited
   provider catalog, bounded streaming and sentinel hardening, Hermes profile,
   proxy readiness/provider APIs, `spread` routing, and OpenCode
   registry-readiness hardening.
@@ -204,7 +204,7 @@ docker volume create freellmpool-data
 docker run --rm -p 127.0.0.1:8080:8080 \
   --volume freellmpool-data:/home/freellmpool/.config/freellmpool \
   --env GROQ_API_KEY \
-  ghcr.io/0xzr/freellmpool:0.12.2
+  ghcr.io/0xzr/freellmpool:0.12.3
 ```
 
 Omit `--env GROQ_API_KEY` if you want a credential-free start; the proxy can
@@ -529,7 +529,7 @@ payment-method caveats, are in
 | Aion Labs | `AION_API_KEY` | 20K free tokens/day, no card |
 | ModelScope API Inference | `MODELSCOPE_API_KEY` | 2,000 free calls/day |
 | Morph | `MORPH_API_KEY` | current priced aliases are retained disabled for explicit future verification |
-| Vercel AI Gateway | `AI_GATEWAY_API_KEY` | automatic routing is limited to the verified zero-price Poolside route; other routes are pin-only or disabled; set a gateway-side budget |
+| Vercel AI Gateway | `AI_GATEWAY_API_KEY` | automatic routing is limited to the publicly price-verified zero-price Poolside route; other routes are pin-only or disabled; set a gateway-side budget |
 | SiliconFlow | `SILICONFLOW_API_KEY` | free models; identity verification required |
 | Mistral, Cohere, SambaNova, Z.ai, Ollama Cloud | see `.env.example` | |
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -7,7 +7,7 @@ rate-limits you mid-run (exactly when long agent loops tend to die).
 
 ## Release status
 
-- **Latest release: 0.12.2.** GitHub and PyPI both provide 0.12.2, including
+- **Latest release: 0.12.3.** GitHub and PyPI both provide 0.12.3, including
   the Hermes profile, `freellmpool/spread` routing, public `/livez` and
   `/readyz`, authenticated `/v1/providers`, `/v1/models?ready=true`, refreshed
   providers, Vercel AI Gateway support, and OpenCode registry-readiness hardening.

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -17,7 +17,7 @@ model setting untouched — just set the base URL and any API key.
 
 ## Release status
 
-Latest release: 0.12.2. GitHub and PyPI both provide the Hermes profile, the
+Latest release: 0.12.3. GitHub and PyPI both provide the Hermes profile, the
 readiness/provider operations APIs, refreshed providers, Vercel AI Gateway
 support, `spread` routing, and registry-readiness hardening for the existing
 repository-local OpenCode plugins. Install it with

--- a/docs/MCP_LISTINGS.md
+++ b/docs/MCP_LISTINGS.md
@@ -1,6 +1,6 @@
 # MCP Registry Listing Status
 
-Updated on 2026-08-29 for the local `freellmpool 0.12.2` manifest. The official
+Updated on 2026-08-29 for the local `freellmpool 0.12.3` manifest. The official
 MCP Registry has an active published entry and the MCP.so submission is complete;
 the live active/latest endpoint below is authoritative for the version whose
 publication has finished. Smithery, Glama, and PulseMCP still need account/web
@@ -12,7 +12,7 @@ UI actions.
 
 - Schema: `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`
 - Name: `io.github.0xzr/freellmpool`
-- Version: `0.12.2`
+- Version: `0.12.3`
 - Repository: `https://github.com/0xzr/freellmpool`
 - Package: PyPI `freellmpool`, runtime hint `uvx`
 - Transport: stdio

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,7 +67,7 @@ freellmpool ask "Explain the CAP theorem in one sentence."   # keyless when rout
 MIT license
 </p>
 
-<div class="note"><strong>Release status.</strong> Latest release: 0.12.2, available from both
+<div class="note"><strong>Release status.</strong> Latest release: 0.12.3, available from both
 GitHub and PyPI. It includes the audited provider catalog, bounded streaming and sentinel hardening,
 the Hermes profile, readiness/provider operations APIs, <code>spread</code> routing, and registry-readiness hardening for
 the existing repository-local OpenCode plugins.
@@ -184,7 +184,7 @@ for provider routing, ToS, and privacy notes.</p>
 
 </div>
 
-<p class="meta">Free and open source (MIT). Latest release: 0.12.2. Page updated 2026-08-29.
+<p class="meta">Free and open source (MIT). Latest release: 0.12.3. Page updated 2026-08-29.
 Project: <a href="https://github.com/0xzr/freellmpool">github.com/0xzr/freellmpool</a></p>
 
 </div>
@@ -199,7 +199,7 @@ Project: <a href="https://github.com/0xzr/freellmpool">github.com/0xzr/freellmpo
   "description": "Free, open-source OpenAI-compatible gateway with cataloged free-tier routes across 22 LLM providers behind one endpoint, automatic failover, CLI, Python library, local proxy, and MCP server. Keyless start when routes are available.",
   "url": "https://0xzr.github.io/freellmpool/",
   "downloadUrl": "https://pypi.org/project/freellmpool/",
-  "softwareVersion": "0.12.2",
+  "softwareVersion": "0.12.3",
   "license": "https://opensource.org/licenses/MIT",
   "offers": {"@type": "Offer", "price": "0", "priceCurrency": "USD"},
   "author": {"@type": "Person", "name": "0xzr"}

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -10,7 +10,7 @@
 > free tiers are usable right now and help configure more.
 
 ## Release status
-- Latest release: 0.12.2. GitHub and PyPI include the audited provider catalog,
+- Latest release: 0.12.3. GitHub and PyPI include the audited provider catalog,
   bounded streaming and sentinel hardening, the Hermes profile, `spread` routing,
   `/livez`, `/readyz`, `/v1/providers`, `/v1/models?ready=true`, and OpenCode
   registry-readiness hardening.

--- a/docs/promotion/README.md
+++ b/docs/promotion/README.md
@@ -5,12 +5,12 @@ registry polish. Use this pack when posting externally.
 
 ## Current launch facts
 
-These facts describe the 0.12.2 GitHub and PyPI release.
+These facts describe the 0.12.3 GitHub and PyPI release.
 
 - Repository: <https://github.com/0xzr/freellmpool>
 - Docs: <https://0xzr.github.io/freellmpool/>
 - PyPI: <https://pypi.org/project/freellmpool/>
-- Version: `0.12.2`
+- Version: `0.12.3`
 - First-run hook: installs with `pip install freellmpool` and can answer with no
   provider credentials while an enabled keyless/key-optional route is available.
 - Interfaces: CLI, Python library, OpenAI-compatible proxy, experimental

--- a/docs/run-coding-agents-on-free-models.html
+++ b/docs/run-coding-agents-on-free-models.html
@@ -45,7 +45,7 @@ free LLM tiers by pointing them at a local proxy that speaks the OpenAI API and 
     disabled candidates (177 enabled chat routes), and automatically fails over only across enabled routes you
     can access. You can start without provider credentials when an enabled keyless route is available.</strong></p>
 
-<div class="note"><strong>Release status:</strong> Latest release: 0.12.2. GitHub and PyPI both
+<div class="note"><strong>Release status:</strong> Latest release: 0.12.3. GitHub and PyPI both
 provide the Hermes profile, operational endpoints, refreshed providers, Vercel AI Gateway support,
 <code>spread</code> routing, and OpenCode registry-readiness hardening.</div>
 

--- a/docs/run-opencode-on-free-models.html
+++ b/docs/run-opencode-on-free-models.html
@@ -47,7 +47,7 @@ free LLM tiers — no API bill — by pointing it at a local proxy that speaks t
     ships an OpenCode plugin with a <strong>live dashboard, quality
 routing, and usage tools</strong> built in.</strong></p>
 
-<div class="note"><strong>Release status:</strong> Latest release: 0.12.2. GitHub and PyPI include
+<div class="note"><strong>Release status:</strong> Latest release: 0.12.3. GitHub and PyPI include
 <code>spread</code> routing and the operations APIs described below. Repository-local OpenCode plugin sources are included in 0.12.0 with registry-readiness hardening and corrected defaults.</div>
 
 <h2>1. Install the release, then start the proxy</h2>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "freellmpool"
-version = "0.12.2"
+version = "0.12.3"
 description = "Free LLM gateway: 22 LLM providers, 177 enabled chat routes, 431 cataloged chat models; keyless start when available."
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -8,13 +8,13 @@
     "url": "https://github.com/0xzr/freellmpool",
     "source": "github"
   },
-  "version": "0.12.2",
+  "version": "0.12.3",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "freellmpool",
-      "version": "0.12.2",
+      "version": "0.12.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/freellmpool/_version.py
+++ b/src/freellmpool/_version.py
@@ -1,3 +1,3 @@
 """Single source for the installed package version."""
 
-__version__ = "0.12.2"
+__version__ = "0.12.3"

--- a/src/freellmpool/providers.toml
+++ b/src/freellmpool/providers.toml
@@ -246,11 +246,13 @@ models = [
 ]
 
 # Vercel AI Gateway: the Hobby team receives $5/month of recurring gateway
-# credit. Automatic routing is restricted to the one zero-price route with
-# credentialed completion/provenance evidence. Other routes are pinnable or
-# disabled pending equivalent canaries. RPD is only a request-count
-# hint, never a monetary ceiling; use a Vercel-side key budget. Model IDs and
-# public aggregate/endpoint pricing checked 2026-08-29.
+# credit. Automatic routing is restricted by maintainer policy to the one route
+# whose public aggregate and endpoint prices are verified as zero. Credentialed
+# completion, serving-provider provenance, and response-cost acceptance remain
+# blocked by Vercel customer verification. Other routes are pinnable or disabled
+# pending equivalent evidence. RPD is only a request-count hint, never a monetary
+# ceiling; use a Vercel-side key budget. Model IDs and public aggregate/endpoint
+# pricing checked 2026-08-29.
 [[provider]]
 id = "vercel"
 label = "Vercel AI Gateway"

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -69,7 +69,7 @@ def test_all_agent_keys_appear_in_integrations_guide():
 def test_agents_guide_tracks_current_release_surfaces():
     guide = (ROOT / "docs" / "AGENTS.md").read_text(encoding="utf-8")
 
-    assert "Latest release: 0.12.2" in guide
+    assert "Latest release: 0.12.3" in guide
     assert "Current main includes unreleased changes" not in guide
     assert "0.11.4" not in guide
     assert "Registry publication status: pending" in guide

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -19,7 +19,7 @@ def test_release_metadata_versions_match_package() -> None:
     demo = (ROOT / "assets" / "demo.svg").read_text()
     readme = (ROOT / "README.md").read_text()
 
-    assert version == "0.12.2"
+    assert version == "0.12.3"
     assert __version__ == version
     assert server["version"] == version
     assert server["packages"][0]["version"] == version
@@ -141,6 +141,31 @@ def test_public_docs_describe_the_current_release() -> None:
         ),
     ):
         assert "registry-readiness hardening" in text
+
+
+def test_vercel_acceptance_claims_match_the_recorded_evidence() -> None:
+    catalog_source = (ROOT / "src/freellmpool/providers.toml").read_text(
+        encoding="utf-8"
+    )
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    spanish = (ROOT / "README.es.md").read_text(encoding="utf-8")
+    acceptance = (ROOT / "docs/VERCEL_ACCEPTANCE_2026-08-23.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "customer_verification_required" in acceptance
+    assert "No completion was returned" in acceptance
+    for contradicted_claim in (
+        "completion-verified zero-price",
+        "credentialed completion/provenance evidence",
+    ):
+        assert contradicted_claim not in catalog_source
+        assert contradicted_claim not in changelog
+    assert "blocked by Vercel customer verification" in catalog_source
+    assert "blocked by\n  Vercel customer verification" in changelog
+    assert "publicly price-verified zero-price Poolside route" in readme
+    assert "Poolside con precio público verificado en cero" in spanish
 
 
 def test_pages_describe_current_main_agent_and_operations_surfaces() -> None:

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -144,6 +144,13 @@ def test_public_docs_describe_the_current_release() -> None:
 
 
 def test_vercel_acceptance_claims_match_the_recorded_evidence() -> None:
+    def section(text: str, start: str, end: str) -> str:
+        start_at = text.index(start)
+        return text[start_at : text.index(end, start_at + len(start))]
+
+    def compact(text: str) -> str:
+        return " ".join(text.replace("`", "").replace("#", " ").split())
+
     catalog_source = (ROOT / "src/freellmpool/providers.toml").read_text(
         encoding="utf-8"
     )
@@ -153,19 +160,111 @@ def test_vercel_acceptance_claims_match_the_recorded_evidence() -> None:
     acceptance = (ROOT / "docs/VERCEL_ACCEPTANCE_2026-08-23.md").read_text(
         encoding="utf-8"
     )
+    activity = (ROOT / "docs/MODEL_ACTIVITY_AUDIT_2026-08-29.md").read_text(
+        encoding="utf-8"
+    )
+    accounts = (ROOT / "docs/ACCOUNTS.md").read_text(encoding="utf-8")
+    env_example = (ROOT / ".env.example").read_text(encoding="utf-8")
+    provider_page = (ROOT / "docs/free-llm-api-providers-list.html").read_text(
+        encoding="utf-8"
+    )
 
-    assert "customer_verification_required" in acceptance
-    assert "No completion was returned" in acceptance
-    for contradicted_claim in (
-        "completion-verified zero-price",
-        "credentialed completion/provenance evidence",
-    ):
-        assert contradicted_claim not in catalog_source
-        assert contradicted_claim not in changelog
-    assert "blocked by Vercel customer verification" in catalog_source
-    assert "blocked by\n  Vercel customer verification" in changelog
-    assert "publicly price-verified zero-price Poolside route" in readme
-    assert "Poolside con precio público verificado en cero" in spanish
+    catalog_policy = section(catalog_source, "# Vercel AI Gateway:", "[[provider]]")
+    release_notes = section(changelog, "## [0.12.3]", "## [0.12.2]")
+    credentialed_evidence = section(
+        acceptance, "## Credentialed evidence", "## Terms and privacy"
+    )
+    activity_record = section(
+        activity, "### Vercel AI Gateway (`vercel`)", "### SiliconFlow"
+    )
+    account_guidance = section(
+        accounts, "### Vercel AI Gateway", "### SiliconFlow"
+    )
+    readme_row = next(line for line in readme.splitlines() if "| Vercel AI Gateway |" in line)
+    spanish_row = next(
+        line for line in spanish.splitlines() if "| Vercel AI Gateway |" in line
+    )
+    provider_row = next(
+        line for line in provider_page.splitlines() if 'data-provider="vercel"' in line
+    )
+    compact_credentialed_evidence = compact(credentialed_evidence)
+
+    assert acceptance.startswith(
+        "# Vercel AI Gateway acceptance audit — 2026-08-23\n"
+    )
+    assert "Updated through 2026-08-29" in acceptance
+    assert "## Credentialed evidence" in acceptance
+    assert "All three failed with HTTP 403" in compact_credentialed_evidence
+    assert "customer_verification_required" in compact_credentialed_evidence
+    assert (
+        "No completion was returned and this is not acceptance evidence"
+        in compact_credentialed_evidence
+    )
+
+    assert (
+        "public aggregate and endpoint prices are verified as zero"
+        in compact(catalog_policy)
+    )
+    assert (
+        "Credentialed completion, serving-provider provenance, and response-cost "
+        "acceptance remain blocked by Vercel customer verification"
+        in compact(catalog_policy)
+    )
+    assert (
+        "sole Poolside route with verified public aggregate and endpoint zero pricing"
+        in compact(release_notes)
+    )
+    assert (
+        "credentialed completion, serving-provider provenance, and response-cost "
+        "acceptance remain blocked by Vercel customer verification"
+        in compact(release_notes)
+    )
+    assert "publicly price-verified zero-price Poolside route" in readme_row
+    assert "Poolside con precio público verificado en cero" in spanish_row
+    assert "customer verification" in account_guidance.casefold()
+    assert "After Vercel has cleared" in account_guidance
+    assert "Customer verification/card may be required" in env_example
+    assert "disabled candidates await canaries" in provider_row
+    assert (
+        "no completion, provenance, or response-cost acceptance was proven"
+        in compact(activity_record)
+    )
+    assert (
+        "catalog policy disposition, not a successful current credentialed canary"
+        in compact(activity_record)
+    )
+
+    vercel_surfaces = (
+        catalog_policy,
+        release_notes,
+        readme_row,
+        spanish_row,
+        credentialed_evidence,
+        activity_record,
+        account_guidance,
+        env_example,
+        provider_row,
+    )
+    unsupported_claims = (
+        r"\bcompletion[- ]verified\b",
+        r"\bcredentialed completion/provenance evidence\b",
+        r"\bcredentialed (?:completion|canary) "
+        r"(?:succeeded|passed|was successful)\b",
+    )
+    semantic_claims = (
+        r"\b(?:completion|provenance|response-cost) acceptance "
+        r"(?:was|is|has been) (?:proven|verified|complete|accepted)\b",
+        r"\bsuccessful current credentialed canary\b",
+    )
+    negative_qualifiers = ("no ", "not ", "blocked", "failed", "pending")
+    for surface in vercel_surfaces:
+        normalized = compact(surface).casefold()
+        for unsupported in unsupported_claims:
+            assert re.search(unsupported, normalized) is None
+        for claim in semantic_claims:
+            for match in re.finditer(claim, normalized):
+                context = normalized[max(0, match.start() - 80) : match.end() + 80]
+                assert any(qualifier in context for qualifier in negative_qualifiers)
 
 
 def test_pages_describe_current_main_agent_and_operations_surfaces() -> None:

--- a/tests/test_spanish_readme.py
+++ b/tests/test_spanish_readme.py
@@ -29,7 +29,7 @@ def test_spanish_readme_tracks_current_launch_surface():
     assert "22 proveedores" in spanish
     assert "177 rutas de chat" in spanish
     assert "431 modelos de chat" in spanish
-    assert "Última versión: 0.12.2" in spanish
+    assert "Última versión: 0.12.3" in spanish
     assert "main contiene cambios aún no publicados" not in spanish
     assert "0.11.4" not in spanish
     assert "Estado de publicación en npm: pendiente" in spanish


### PR DESCRIPTION
## Summary
- correct the contradictory Vercel Poolside evidence wording: public zero-price evidence is verified, while credentialed completion, serving-provider provenance, and response-cost acceptance remain blocked by customer verification
- add a regression test tying release/catalog claims to the dated acceptance record
- preserve exposed v0.12.2 and its immutable versioned container, and supersede it with 0.12.3 across package, MCP, docs, Spanish, Docker, and Pages surfaces

## Verification
- 1,189 tests passed with line and branch coverage gates
- release build, Twine 7 validation, and fresh-wheel smoke passed
- Ruff, mypy, catalog, counts, docs, assets, supply-chain, and focused release checks passed

Issue #68 intentionally remains open pending three successful live Vercel completions with provenance and zero returned cost.

## Summary by Sourcery

Align Vercel evidence wording with the recorded acceptance results and supersede the preserved 0.12.2 artifacts with release 0.12.3.

Bug Fixes:
- Correct Vercel Poolside evidence claims so public zero pricing is distinguished from unverified credentialed completion, provider provenance, and response-cost acceptance.

Enhancements:
- Preserve the exposed 0.12.2 tag and immutable container while superseding them with release 0.12.3 across package, MCP, documentation, container, and Pages metadata.

Documentation:
- Update English and Spanish release and Vercel provider guidance to describe version 0.12.3 and the verified evidence boundaries.

Tests:
- Add regression coverage ensuring Vercel acceptance claims across catalog, release, documentation, and provider surfaces remain consistent with the dated evidence record.